### PR TITLE
fix: match python autopush's crypto_key format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
     \
     apt-get -qq update && \
-    apt-get -qq install -y libssl-dev && \
+    apt-get -qq install -y libssl-dev ca-certificates && \
     rm -rf /var/lib/apt/lists
 
 COPY --from=builder /app/bin /app/bin

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -113,7 +113,7 @@ def setup_module():
         statsd_host="",
         router_tablename=ROUTER_TABLE,
         message_tablename=MESSAGE_TABLE,
-        crypto_key=CRYPTO_KEY,
+        crypto_key="[{}]".format(CRYPTO_KEY),
         auto_ping_interval=60.0,
         auto_ping_timeout=10.0,
         close_handshake_timeout=5,


### PR DESCRIPTION
and ensure ca-certificates is installed to hopefully avoid the error
"The OpenSSL library reported an error"

Closes #11