### PR TITLE
fix: fix notification fetch spinning

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -207,7 +207,7 @@ impl DynamoDbNotification {
         Ok(Notification {
             channel_id: key.channel_id,
             version,
-            ttl: self.ttl.ok_or("No TTL found")?,
+            ttl: self.ttl.unwrap_or(0),
             timestamp: self.timestamp.ok_or("No timestamp found")?,
             topic: key.topic,
             data: self.data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! WIP: Implementation of Web Push ("autopush" as well) in Rust
-//! 
+//!
 //! This crate currently provides the connection node functionality for a Web
-//! Push server, and is a replacement for the 
+//! Push server, and is a replacement for the
 //! [`autopush`](https://github.com/mozilla-services/autopush) server. The older
 //! python handler still manages the HTTP endpoint calls, since those require
-//! less overhead to process. Eventually, those functions will be moved to 
+//! less overhead to process. Eventually, those functions will be moved to
 //! rust as well.
 //!
 //! # High level overview
@@ -18,7 +18,7 @@
 //! webpush protocol (see `states.dot` at the root of this repository). Note
 //! that not all states are implemented yet, this is a work in progress! All I/O
 //! is managed by Rust and various state transitions are managed by Rust as
-//! well. 
+//! well.
 //!
 //! # Module index
 //!

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -547,6 +547,23 @@ class TestRustWebPush(unittest.TestCase):
         yield self.shut_down(client)
 
     @inlineCallbacks
+    def test_topic_expired(self):
+        data = str(uuid.uuid4())
+        client = yield self.quick_register()
+        yield client.disconnect()
+        assert client.channels
+        yield client.send_notification(data=data, ttl=1, topic="test")
+        yield client.sleep(2)
+        yield client.connect()
+        yield client.hello()
+        result = yield client.get_notification(timeout=0.5)
+        assert result is None
+        result = yield client.send_notification(data=data, topic="test")
+        assert result != {}
+        assert result["data"] == base64url_encode(data)
+        yield self.shut_down(client)
+
+    @inlineCallbacks
     def test_multiple_delivery_with_single_ack(self):
         data = str(uuid.uuid4())
         data2 = str(uuid.uuid4())


### PR DESCRIPTION
Co-authored by: Phil Jenvey <pjenvey@underboss.org>

Expired notifications without a sortkey_timestamp need to be deleted
by the server as they aren't sent to the client for it to Ack.