### PR TITLE
fix: limit valid message tables to the last 3

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -86,7 +86,10 @@ impl DynamoStorage {
 
         let mut message_table_names = list_message_tables(&ddb, &opts._message_table_name)
             .map_err(|_| "Failed to locate message tables")?;
-        message_table_names.sort_unstable();
+        // Valid message months are the current and last 2 months
+        message_table_names.sort_unstable_by(|a, b| b.cmp(a));
+        message_table_names.truncate(3);
+        message_table_names.reverse();
         let current_message_month = message_table_names
             .last()
             .ok_or("No last message month found")?

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -124,13 +124,13 @@ pub struct DynamoDbNotification {
     pub chids: Option<HashSet<String>>,
     // Time in seconds from epoch
     #[serde(skip_serializing_if = "Option::is_none")]
-    timestamp: Option<u32>,
+    timestamp: Option<u64>,
     // DynamoDB expiration timestamp per
     //    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
-    expiry: u32,
+    expiry: u64,
     // TTL value provided by application server for the message
     #[serde(skip_serializing_if = "Option::is_none")]
-    ttl: Option<u32>,
+    ttl: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -221,7 +221,7 @@ impl DynamoDbNotification {
             uaid: *uaid,
             chidmessageid: val.sort_key(),
             timestamp: Some(val.timestamp),
-            expiry: sec_since_epoch() as u32 + min(val.ttl, MAX_EXPIRY as u32),
+            expiry: sec_since_epoch() + min(val.ttl, MAX_EXPIRY),
             ttl: Some(val.ttl),
             data: val.data,
             headers: val.headers.map(|h| h.into()),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -109,10 +109,10 @@ pub struct Notification {
     pub channel_id: Uuid,
     pub version: String,
     #[serde(default = "default_ttl", skip_serializing)]
-    pub ttl: u32,
+    pub ttl: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic: Option<String>,
-    pub timestamp: u32,
+    pub timestamp: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
     #[serde(skip_serializing)]
@@ -157,6 +157,6 @@ impl Notification {
     }
 }
 
-fn default_ttl() -> u32 {
+fn default_ttl() -> u64 {
     0
 }


### PR DESCRIPTION
and use u64 for all time fields