### PR TITLE
feat: fix sentry test and add release data to sentry errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ click==6.7
 configargparse==0.13.0
 constantly==15.1.0        # via twisted
 contextlib2==0.5.5        # via raven
-cryptography==2.2.2
+cryptography==2.3.1
 cyclone==1.1
 datadog==0.20.0
 decorator==4.2.1          # via datadog
@@ -39,11 +39,11 @@ objgraph==3.4.0
 pyasn1-modules==0.2.1     # via service-identity
 pyasn1==0.4.2
 pycparser==2.18           # via cffi
-pycryptodome==3.5.1       # via python-jose
+pycryptodome==3.6.6       # via python-jose
 pyfcm==1.4.5
 pyopenssl==17.5.0
 python-dateutil==2.6.1    # via botocore
-python-jose==2.0.2
+python-jose==3.0.1
 raven==6.6.0
 requests-toolbelt==0.8.0  # via pyfcm
 requests==2.18.4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ extern crate reqwest;
 extern crate rusoto_core;
 extern crate rusoto_credential;
 extern crate rusoto_dynamodb;
+#[macro_use]
 extern crate sentry;
 extern crate serde;
 #[macro_use]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -265,7 +265,13 @@ impl Server {
     /// Setup Sentry logging if a SENTRY_DSN exists
     fn start_sentry() -> Option<sentry::internals::ClientInitGuard> {
         if let Ok(dsn) = env::var("SENTRY_DSN") {
-            let guard = sentry::init(dsn);
+            let guard = sentry::init((
+                dsn,
+                sentry::ClientOptions {
+                    release: sentry_crate_release!(),
+                    ..Default::default()
+                }
+            ));
             register_panic_handler();
             Some(guard)
         } else {


### PR DESCRIPTION
Refactored the mock test server to use bottle for easier mocking. Added
full release name/version to sentry errors and refactored sentry error
handling in client.rs to easily add event tags as desired before the
event is submitted.

Closes #66