### PR TITLE
chore: update test_integration dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,60 +1,61 @@
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 apns==2.0.1
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0
-autobahn[twisted]==18.3.1
-automat==0.6.0            # via twisted
-boto3==1.7.0
-botocore==1.10.0          # via boto3, s3transfer
-certifi==2018.1.18        # via requests
+attrs==18.1.0
+autobahn[twisted]==18.6.1
+automat==0.7.0            # via twisted
+boto3==1.7.57
+botocore==1.10.57         # via boto3, s3transfer
+certifi==2018.4.16        # via requests
 cffi==1.11.5
 chardet==3.0.4            # via requests
 click==6.7
 configargparse==0.13.0
 constantly==15.1.0        # via twisted
 contextlib2==0.5.5        # via raven
-cryptography==2.2.2
+cryptography==2.3
 cyclone==1.1
-datadog==0.20.0
-decorator==4.2.1          # via datadog
+datadog==0.22.0
+decorator==4.3.0          # via datadog
 docutils==0.14            # via botocore
 ecdsa==0.13               # via python-jose
 enum34==1.1.6             # via cryptography, h2
 future==0.16.0            # via python-jose
 futures==3.2.0            # via s3transfer
 gcm-client==0.1.4
-graphviz==0.8.2           # via objgraph
+graphviz==0.8.4           # via objgraph
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 hyper==0.7.0
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==18.0.0         # via twisted
-idna==2.6                 # via cryptography, hyperlink, requests
+idna==2.7                 # via cryptography, hyperlink, requests
 incremental==17.5.0       # via twisted
-ipaddress==1.0.19         # via cryptography
+ipaddress==1.0.22         # via cryptography
 jmespath==0.9.3           # via boto3, botocore
 marshmallow-polyfield==3.2
-marshmallow==2.15.0
+marshmallow==2.15.3
 objgraph==3.4.0
-pyasn1-modules==0.2.1     # via service-identity
-pyasn1==0.4.2
+pyasn1-modules==0.2.2     # via service-identity
+pyasn1==0.4.3
 pycparser==2.18           # via cffi
-pycryptodome==3.5.1       # via python-jose
 pyfcm==1.4.5
-pyopenssl==17.5.0
-python-dateutil==2.6.1    # via botocore
-python-jose==2.0.2
-raven==6.6.0
+pyhamcrest==1.9.0         # via twisted
+pyopenssl==18.0.0
+python-dateutil==2.7.3    # via botocore
+python-jose==3.0.0
+raven==6.9.0
 requests-toolbelt==0.8.0  # via pyfcm
-requests==2.18.4
+requests==2.19.1
+rsa==3.4.2                # via python-jose
 s3transfer==0.1.13        # via boto3
 service-identity==17.0.0
-simplejson==3.13.2
-six==1.11.0               # via autobahn, automat, cryptography, pyopenssl, python-dateutil, python-jose, txaio
-twisted==17.9.0
-txaio==2.9.0              # via autobahn
+simplejson==3.16.0
+six==1.11.0               # via autobahn, automat, cryptography, pyhamcrest, pyopenssl, python-dateutil, python-jose, txaio
+twisted==18.7.0
+txaio==2.10.0             # via autobahn
 typing==3.6.4
-ua-parser==0.7.3
-urllib3==1.22             # via requests
+ua-parser==0.8.0
+urllib3==1.23             # via requests
 wsaccel==0.6.2 ; platform_python_implementation == "CPython"
-zope.interface==4.4.3
+zope.interface==4.5.0


### PR DESCRIPTION
to quiet security warnings on the older cryptography/pycryptodome