### PR TITLE
fix: capture additional errors that shouldn't be reported to Sentry

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -74,6 +74,19 @@ error_chain! {
             description("invalid state transition")
             display("invalid state transition, from: {}, to: {}", from, to)
         }
+
+        InvalidClientMessage(text: String) {
+            description("invalid json text")
+            display("invalid json: {}", text)
+        }
+
+        MessageFetch {
+            description("server error fetching messages")
+        }
+
+        SendError {
+            description("unable to send to client")
+        }
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -889,11 +889,15 @@ where
             match msg {
                 Message::Text(ref s) => {
                     trace!("text message {}", s);
-                    let msg = s.parse().chain_err(|| "invalid json text")?;
+                    let msg = s
+                        .parse()
+                        .chain_err(|| ErrorKind::InvalidClientMessage(s.to_owned()))?;
                     return Ok(Some(msg).into());
                 }
 
-                Message::Binary(_) => return Err("binary messages not accepted".into()),
+                Message::Binary(_) => {
+                    return Err(ErrorKind::InvalidClientMessage("binary content".to_string()).into())
+                }
 
                 // sending a pong is already managed by lower layers, just go to
                 // the next message


### PR DESCRIPTION
Avoids capturing errors for the following:
- Unable to send to a client
- Invalid json text sent to server
- DynamoDB Internal Server Error that should be retried

Closes #87