### PR TITLE
chore: use cargo's lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     cargo --version && \
     rustc --version && \
     mkdir -m 755 bin && \
-    cargo install --path autopush --root /app
+    cargo install --path autopush --locked --root /app
 
 
 FROM debian:buster-slim

--- a/PR_TEMPLATE.md
+++ b/PR_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Description
+
+Describe these changes.
+
+## Testing
+
+How should reviewers test?
+
+## Issue(s)
+
+Closes [link](link).


### PR DESCRIPTION
## Description

Forcing cargo install to use cargo's lockfile after we discovered [this issue](https://github.com/mozilla-services/syncstorage-rs/issues/378) over in syncstorage-rs.

Also, adding PR template.

## Testing

Make sure you can build the docker image (`docker build .`).

When I did this, I _did_ see the following warning: ```warning: package `block-buffer v0.7.0` in Cargo.lock is yanked in registry `crates.io`, consider running without --locked```. However, after 
some light googling, it appears we should be fine here; [yanked crates still let you install from the lockfile](https://github.com/rust-lang/crates-io-cargo-teams/issues/9). Calling this out specifically here just in case other reviewers have issues with this.

## Issue(s)

Closes [#127](https://github.com/mozilla-services/autopush-rs/issues/127).
