### PR TITLE
feat: only register new users on new subscription requests

### DIFF
--- a/autopush-common/src/db/models.rs
+++ b/autopush-common/src/db/models.rs
@@ -93,8 +93,10 @@ pub struct DynamoDbUser {
 
 impl Default for DynamoDbUser {
     fn default() -> Self {
+        let uaid = Uuid::new_v4();
+        //trace!(">>> Setting default uaid: {:?}", &uaid);
         Self {
-            uaid: Uuid::new_v4(),
+            uaid,
             connected_at: ms_since_epoch(),
             router_type: "webpush".to_string(),
             last_connect: Some(generate_last_connect()),

--- a/autopush/src/http.rs
+++ b/autopush/src/http.rs
@@ -46,6 +46,7 @@ impl Service for Push {
         let clients = Arc::clone(&self.0);
         match (req.method(), method_name, uaid) {
             (&Method::PUT, "push", uaid) => {
+                trace!("## PUT /push/ {}", uaid);
                 // Due to consumption of body as a future we must return here
                 let body = req.into_body().concat2();
                 return Box::new(body.and_then(move |body| {
@@ -70,6 +71,7 @@ impl Service for Push {
                 }));
             }
             (&Method::PUT, "notif", uaid) => {
+                trace!("## PUT /notif/ {}", uaid);
                 return Box::new(clients.check_storage(uaid).then(move |result| {
                     let body = if result.is_ok() {
                         response.status(StatusCode::OK);

--- a/autopush/src/server/protocol.rs
+++ b/autopush/src/server/protocol.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use autopush_common::notification::Notification;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum BroadcastValue {
     Value(String),
@@ -34,7 +34,7 @@ impl Default for ServerNotification {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(tag = "messageType", rename_all = "snake_case")]
 pub enum ClientMessage {
     Hello {
@@ -86,14 +86,14 @@ impl FromStr for ClientMessage {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ClientAck {
     #[serde(rename = "channelID")]
     pub channel_id: Uuid,
     pub version: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(tag = "messageType", rename_all = "snake_case")]
 pub enum ServerMessage {
     Hello {


### PR DESCRIPTION
when no UAID is specified from desktop clients, defer writing them to
the router table until they subscribe to a channel

Avoids unwriting unnecessary router entries, especially important
after https://bugzilla.mozilla.org/show_bug.cgi?id=1617136

Co-authored by: jrconlin <jr+git@mozilla.com>

Closes #137