### PR TITLE
feat: Validate user subscription data in autoendpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
  "autopush_common 1.0.0",
  "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cadence 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cadence 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fernet 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -616,14 +616,6 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cadence"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -743,14 +735,6 @@ dependencies = [
  "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3765,7 +3749,6 @@ dependencies = [
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum bytestring 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fc7c05fa5172da78a62d9949d662d2ac89d4cc7355d7b49adee5163f1fb3f363"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cadence 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4cc8802110b3a8650896ab9ab0578b5b3057a112ccb0832b5c2ffebfccacc0db"
 "checksum cadence 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c57523ff87f22fc96f07f5f379af387fdd86009242a17d805a3278540cde94a"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -3780,7 +3763,6 @@ dependencies = [
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "slog-term 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -33,5 +33,6 @@ slog-stdlog = "4.0"
 slog-term = "2.5"
 thiserror = "1.0"
 url = "2.1"
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
 validator = "0.10.0"
 validator_derive = "0.10.0"

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -12,7 +12,7 @@ actix-cors = "0.2.0"
 autopush_common = { path = "../autopush-common" }
 backtrace = "0.3"
 base64 = "0.12.1"
-cadence = "0.19.1"
+cadence = "0.20"
 config = "0.10.1"
 docopt = "1.1.0"
 fernet = "0.1.3"

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -59,6 +59,9 @@ pub enum ApiErrorKind {
     #[error(transparent)]
     VapidError(#[from] VapidError),
 
+    #[error(transparent)]
+    Uuid(#[from] uuid::Error),
+
     #[error("Error while validating token")]
     TokenHashValidation(#[from] openssl::error::ErrorStack),
 
@@ -67,6 +70,9 @@ pub enum ApiErrorKind {
 
     #[error("Invalid token")]
     InvalidToken,
+
+    #[error("No such subscription")]
+    NoSubscription,
 
     /// A specific issue with the encryption headers
     #[error("{0}")]
@@ -91,7 +97,10 @@ impl ApiErrorKind {
 
             ApiErrorKind::Validation(_)
             | ApiErrorKind::InvalidEncryption(_)
-            | ApiErrorKind::TokenHashValidation(_) => StatusCode::BAD_REQUEST,
+            | ApiErrorKind::TokenHashValidation(_)
+            | ApiErrorKind::Uuid(_) => StatusCode::BAD_REQUEST,
+
+            ApiErrorKind::NoSubscription => StatusCode::GONE,
 
             ApiErrorKind::VapidError(_) => StatusCode::UNAUTHORIZED,
 

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -62,6 +62,9 @@ pub enum ApiErrorKind {
     #[error("Error while validating token")]
     TokenHashValidation(#[from] openssl::error::ErrorStack),
 
+    #[error("Database error: {0}")]
+    Database(#[source] autopush_common::errors::Error),
+
     #[error("Invalid token")]
     InvalidToken,
 
@@ -96,9 +99,10 @@ impl ApiErrorKind {
 
             ApiErrorKind::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
 
-            ApiErrorKind::Io(_) | ApiErrorKind::Metrics(_) | ApiErrorKind::Internal(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            ApiErrorKind::Io(_)
+            | ApiErrorKind::Metrics(_)
+            | ApiErrorKind::Database(_)
+            | ApiErrorKind::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/autoendpoint/src/server/extractors/mod.rs
+++ b/autoendpoint/src/server/extractors/mod.rs
@@ -5,3 +5,4 @@ pub mod notification;
 pub mod notification_headers;
 pub mod subscription;
 pub mod token_info;
+pub mod user;

--- a/autoendpoint/src/server/extractors/user.rs
+++ b/autoendpoint/src/server/extractors/user.rs
@@ -1,0 +1,85 @@
+//! User validations
+
+use crate::error::{ApiErrorKind, ApiResult};
+use crate::server::ServerState;
+use autopush_common::db::{DynamoDbUser, DynamoStorage};
+use cadence::{Counted, StatsdClient};
+use futures::compat::Future01CompatExt;
+use uuid::Uuid;
+
+/// Valid `DynamoDbUser::router_type` values
+const VALID_ROUTERS: [&str; 5] = ["webpush", "gcm", "fcm", "apns", "adm"];
+
+/// Perform some validations on the user, including:
+/// - Validate router type
+/// - (WebPush) Check that the subscription/channel exists
+/// - (WebPush) Drop user if inactive
+pub async fn validate_user(
+    user: &DynamoDbUser,
+    channel_id: &Uuid,
+    state: &ServerState,
+) -> ApiResult<()> {
+    if !VALID_ROUTERS.contains(&user.router_type.as_str()) {
+        debug!("Unknown router type, dropping user"; "user" => ?user);
+        drop_user(&user.uaid, &state.ddb, &state.metrics).await?;
+        return Err(ApiErrorKind::NoSubscription.into());
+    }
+
+    if user.router_type == "webpush" {
+        validate_webpush_user(user, channel_id, &state.ddb, &state.metrics).await?;
+    }
+
+    Ok(())
+}
+
+/// Make sure the user is not inactive and the subscription channel exists
+async fn validate_webpush_user(
+    user: &DynamoDbUser,
+    channel_id: &Uuid,
+    ddb: &DynamoStorage,
+    metrics: &StatsdClient,
+) -> ApiResult<()> {
+    // Make sure the user is active (has a valid message table)
+    let message_table = match user.current_month.as_ref() {
+        Some(table) => table,
+        None => {
+            debug!("Missing `current_month` value, dropping user"; "user" => ?user);
+            drop_user(&user.uaid, ddb, metrics).await?;
+            return Err(ApiErrorKind::NoSubscription.into());
+        }
+    };
+
+    if !ddb.message_table_names.contains(message_table) {
+        debug!("User is inactive, dropping user"; "user" => ?user);
+        drop_user(&user.uaid, ddb, metrics).await?;
+        return Err(ApiErrorKind::NoSubscription.into());
+    }
+
+    // Make sure the subscription channel exists
+    let channel_ids = ddb
+        .get_user_channels(&user.uaid, message_table)
+        .compat()
+        .await
+        .map_err(ApiErrorKind::Database)?;
+
+    if !channel_ids.contains(channel_id) {
+        return Err(ApiErrorKind::NoSubscription.into());
+    }
+
+    Ok(())
+}
+
+/// Drop a user and increment associated metric
+async fn drop_user(uaid: &Uuid, ddb: &DynamoStorage, metrics: &StatsdClient) -> ApiResult<()> {
+    metrics
+        .incr_with_tags("updates.drop_user")
+        .with_tag("errno", "102")
+        .send();
+
+    ddb.drop_uaid(uaid)
+        .compat()
+        .await
+        .map_err(ApiErrorKind::Database)?;
+
+    Ok(())
+}

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -19,6 +19,9 @@ pub struct Settings {
     #[cfg(any(test, feature = "db_test"))]
     pub database_use_test_transactions: bool,
 
+    pub router_table_name: String,
+    pub message_table_name: String,
+
     pub max_data_bytes: usize,
     pub crypto_keys: String,
     pub human_logs: bool,
@@ -38,6 +41,8 @@ impl Default for Settings {
             database_pool_max_size: None,
             #[cfg(any(test, feature = "db_test"))]
             database_use_test_transactions: false,
+            router_table_name: "router".to_string(),
+            message_table_name: "message".to_string(),
             max_data_bytes: 4096,
             crypto_keys: format!("[{}]", Fernet::generate_key()),
             human_logs: false,

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::env;
-use std::rc::Rc;
 use uuid::Uuid;
 
 use cadence::StatsdClient;
@@ -61,9 +60,10 @@ pub enum RegisterResponse {
     Error { error_msg: String, status: u32 },
 }
 
+#[derive(Clone)]
 pub struct DynamoStorage {
-    ddb: Rc<Box<dyn DynamoDb>>,
-    metrics: Rc<StatsdClient>,
+    ddb: DynamoDbClient,
+    metrics: StatsdClient,
     router_table_name: String,
     message_table_names: Vec<String>,
     pub current_message_month: String,
@@ -75,19 +75,18 @@ impl DynamoStorage {
         router_table_name: &str,
         metrics: StatsdClient,
     ) -> Result<Self> {
-        let ddb: Box<dyn DynamoDb> = if let Ok(endpoint) = env::var("AWS_LOCAL_DYNAMODB") {
-            Box::new(DynamoDbClient::new_with(
+        let ddb = if let Ok(endpoint) = env::var("AWS_LOCAL_DYNAMODB") {
+            DynamoDbClient::new_with(
                 HttpClient::new().chain_err(|| "TLS initialization error")?,
                 StaticProvider::new_minimal("BogusKey".to_string(), "BogusKey".to_string()),
                 Region::Custom {
                     name: "us-east-1".to_string(),
                     endpoint,
                 },
-            ))
+            )
         } else {
-            Box::new(DynamoDbClient::new(Region::default()))
+            DynamoDbClient::new(Region::default())
         };
-        let ddb = Rc::new(ddb);
 
         let mut message_table_names = list_message_tables(&ddb, &message_table_name)
             .map_err(|_| "Failed to locate message tables")?;
@@ -102,7 +101,7 @@ impl DynamoStorage {
 
         Ok(Self {
             ddb,
-            metrics: Rc::new(metrics),
+            metrics,
             router_table_name: router_table_name.to_owned(),
             message_table_names,
             current_message_month,
@@ -154,7 +153,7 @@ impl DynamoStorage {
         let response: MyFuture<(HelloResponse, Option<DynamoDbUser>)> = if let Some(uaid) = uaid {
             commands::lookup_user(
                 self.ddb.clone(),
-                &self.metrics,
+                self.metrics.clone(),
                 &uaid,
                 connected_at,
                 router_url,
@@ -387,7 +386,7 @@ impl DynamoStorage {
         let response: MyFuture<FetchMessageResponse> = if include_topic {
             Box::new(commands::fetch_messages(
                 self.ddb.clone(),
-                &self.metrics,
+                self.metrics.clone(),
                 table_name,
                 uaid,
                 11 as u32,
@@ -398,7 +397,7 @@ impl DynamoStorage {
         let uaid = *uaid;
         let table_name = table_name.to_string();
         let ddb = self.ddb.clone();
-        let metrics = Rc::clone(&self.metrics);
+        let metrics = self.metrics.clone();
 
         response.and_then(move |resp| -> MyFuture<_> {
             // Return now from this future if we have messages
@@ -420,7 +419,7 @@ impl DynamoStorage {
                 if resp.messages.is_empty() || resp.timestamp.is_some() {
                     Box::new(commands::fetch_timestamp_messages(
                         ddb,
-                        &metrics,
+                        metrics,
                         table_name.as_ref(),
                         &uaid,
                         timestamp,
@@ -461,11 +460,11 @@ impl DynamoStorage {
     }
 }
 
-pub fn list_message_tables(ddb: &Rc<Box<dyn DynamoDb>>, prefix: &str) -> Result<Vec<String>> {
+pub fn list_message_tables(ddb: &DynamoDbClient, prefix: &str) -> Result<Vec<String>> {
     let mut names: Vec<String> = Vec::new();
     let mut start_key = None;
     loop {
-        let result = commands::list_tables_sync(Rc::clone(ddb), start_key)?;
+        let result = commands::list_tables_sync(&ddb, start_key)?;
         start_key = result.last_evaluated_table_name;
         if let Some(table_names) = result.table_names {
             names.extend(table_names);

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -458,6 +458,20 @@ impl DynamoStorage {
         });
         Box::new(result)
     }
+
+    /// Get the set of channel IDs for a user
+    pub fn get_user_channels(
+        &self,
+        uaid: &Uuid,
+        message_table: &str,
+    ) -> impl Future<Item = HashSet<Uuid>, Error = Error> {
+        commands::all_channels(self.ddb.clone(), uaid, message_table).and_then(|channels| {
+            channels
+                .into_iter()
+                .map(|channel| channel.parse().map_err(Error::from))
+                .collect::<Result<_>>()
+        })
+    }
 }
 
 pub fn list_message_tables(ddb: &DynamoDbClient, prefix: &str) -> Result<Vec<String>> {

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -65,7 +65,7 @@ pub struct DynamoStorage {
     ddb: DynamoDbClient,
     metrics: StatsdClient,
     router_table_name: String,
-    message_table_names: Vec<String>,
+    pub message_table_names: Vec<String>,
     pub current_message_month: String,
 }
 

--- a/autopush-common/src/db/models.rs
+++ b/autopush-common/src/db/models.rs
@@ -77,9 +77,6 @@ pub struct DynamoDbUser {
     pub connected_at: u64,
     // Router type of the user
     pub router_type: String,
-    // Router-specific data
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub router_data: Option<HashMap<String, serde_json::Value>>,
     // Keyed time in a month the user last connected at with limited key range for indexing
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_connect: Option<u64>,
@@ -102,7 +99,6 @@ impl Default for DynamoDbUser {
             uaid,
             connected_at: ms_since_epoch(),
             router_type: "webpush".to_string(),
-            router_data: None,
             last_connect: Some(generate_last_connect()),
             node_id: None,
             record_version: Some(USER_RECORD_VERSION),

--- a/autopush-common/src/db/models.rs
+++ b/autopush-common/src/db/models.rs
@@ -77,6 +77,9 @@ pub struct DynamoDbUser {
     pub connected_at: u64,
     // Router type of the user
     pub router_type: String,
+    // Router-specific data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_data: Option<HashMap<String, serde_json::Value>>,
     // Keyed time in a month the user last connected at with limited key range for indexing
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_connect: Option<u64>,
@@ -99,6 +102,7 @@ impl Default for DynamoDbUser {
             uaid,
             connected_at: ms_since_epoch(),
             router_type: "webpush".to_string(),
+            router_data: None,
             last_connect: Some(generate_last_connect()),
             node_id: None,
             record_version: Some(USER_RECORD_VERSION),


### PR DESCRIPTION
User subscription data is now validated as part of the Actix extractor validations. Specifically:
- Validate router type
- (WebPush) Check that the subscription/channel exists
- (WebPush) Drop user if inactive

This is the first autoendpoint feature to use the database, so support has been added. Part of those changes simplified `DynamoStorage` and made it `Send + Sync`.

Closes #156