### PR TITLE
feat: Check database health in `/health`

### DIFF
--- a/autoendpoint/src/db/error.rs
+++ b/autoendpoint/src/db/error.rs
@@ -1,7 +1,9 @@
 use thiserror::Error;
 
 use rusoto_core::RusotoError;
-use rusoto_dynamodb::{DeleteItemError, GetItemError, PutItemError, UpdateItemError};
+use rusoto_dynamodb::{
+    DeleteItemError, DescribeTableError, GetItemError, PutItemError, UpdateItemError,
+};
 
 pub type DbResult<T> = Result<T, DbError>;
 
@@ -19,6 +21,12 @@ pub enum DbError {
     #[error("Database error while performing DeleteItem")]
     DeleteItem(#[from] RusotoError<DeleteItemError>),
 
+    #[error("Database error while performing DescribeTable")]
+    DescribeTable(#[from] RusotoError<DescribeTableError>),
+
     #[error("Error while performing (de)serialization: {0}")]
     Serialization(#[from] serde_dynamodb::Error),
+
+    #[error("Unable to determine table status")]
+    TableStatusUnknown,
 }

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -71,7 +71,7 @@ impl Server {
                 .service(web::resource("/status").route(web::get().to(status_route)))
                 .service(web::resource("/health").route(web::get().to(health_route)))
                 // Dockerflow
-                .service(web::resource("/__heartbeat__").route(web::get().to(status_route)))
+                .service(web::resource("/__heartbeat__").route(web::get().to(health_route)))
                 .service(web::resource("/__lbheartbeat__").route(web::get().to(lb_heartbeat_route)))
                 .service(web::resource("/__version__").route(web::get().to(version_route)))
         })


### PR DESCRIPTION
The `/health` and `/__heartbeat__` routes now contain health information about the router and message tables.

Closes #169 