### PR TITLE
refactor: Fix a Rust 1.45 Clippy warning

### DIFF
--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -60,7 +60,7 @@ impl Settings {
         // Merge the environment overrides
         config.merge(Environment::with_prefix(ENV_PREFIX))?;
 
-        config.try_into::<Self>().or_else(|error| match error {
+        config.try_into::<Self>().map_err(|error| match error {
             // Configuration errors are not very sysop friendly, Try to make them
             // a bit more 3AM useful.
             ConfigError::Message(error_msg) => {
@@ -71,11 +71,11 @@ impl Settings {
                     ENV_PREFIX.to_uppercase()
                 );
                 error!("Configuration error: Value undefined {:?}", &error_msg);
-                Err(ConfigError::NotFound(error_msg))
+                ConfigError::NotFound(error_msg)
             }
             _ => {
                 error!("Configuration error: Other: {:?}", &error);
-                Err(error)
+                error
             }
         })
     }


### PR DESCRIPTION
Original warning:
```
warning: using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as `map_err(|x| y)`
  --> autoendpoint/src/settings.rs:63:9
   |
63 | /         config.try_into::<Self>().or_else(|error| match error {
64 | |             // Configuration errors are not very sysop friendly, Try to make them
65 | |             // a bit more 3AM useful.
66 | |             ConfigError::Message(error_msg) => {
...  |
79 | |             }
80 | |         })
   | |__________^
   |
   = note: `#[warn(clippy::bind_instead_of_map)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map
help: try this
   |
63 |         config.try_into::<Self>().map_err(|error| match error {
64 |             // Configuration errors are not very sysop friendly, Try to make them
65 |             // a bit more 3AM useful.
66 |             ConfigError::Message(error_msg) => {
67 |                 println!("Bad configuration: {:?}", &error_msg);
68 |                 println!("Please set in config file or use environment variable.");
 ...
```