### PR TITLE
feat: New channel endpoint

### DIFF
--- a/autoendpoint/src/extractors/mod.rs
+++ b/autoendpoint/src/extractors/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod authorization_check;
 pub mod message_id;
+pub mod new_channel_data;
 pub mod notification;
 pub mod notification_headers;
 pub mod registration_path_args;

--- a/autoendpoint/src/extractors/new_channel_data.rs
+++ b/autoendpoint/src/extractors/new_channel_data.rs
@@ -1,0 +1,10 @@
+use uuid::Uuid;
+
+/// The data provided when creating a new channel for an existing user. Extract
+/// from the request via the `Json` extractor.
+#[derive(serde::Deserialize, Default)]
+pub struct NewChannelData {
+    #[serde(rename = "channelID")]
+    pub channel_id: Option<Uuid>,
+    pub key: Option<String>,
+}

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -119,7 +119,7 @@ impl FcmRouter {
                 }
             }
             FcmError::FcmUpstream { .. } | FcmError::FcmUnknown => {
-                warn!("FCM error: {error}", error = error.to_string());
+                warn!("{}", error.to_string());
                 self.incr_error_metric("server_error");
             }
             _ => {

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -136,7 +136,7 @@ pub async fn new_channel_route(
     trace!("endpoint = {}", endpoint_url);
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
-        "channelID": channel_id.to_simple().to_string(),
+        "channelID": channel_id,
         "endpoint": endpoint_url,
     })))
 }

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -1,13 +1,14 @@
 use crate::auth::sign_with_key;
 use crate::error::{ApiErrorKind, ApiResult};
 use crate::extractors::authorization_check::AuthorizationCheck;
+use crate::extractors::new_channel_data::NewChannelData;
 use crate::extractors::registration_path_args::RegistrationPathArgs;
 use crate::extractors::registration_path_args_with_uaid::RegistrationPathArgsWithUaid;
 use crate::extractors::router_data_input::RouterDataInput;
 use crate::extractors::routers::Routers;
 use crate::headers::util::get_header;
 use crate::server::ServerState;
-use actix_web::web::Data;
+use actix_web::web::{Data, Json};
 use actix_web::{HttpRequest, HttpResponse};
 use autopush_common::db::DynamoDbUser;
 use autopush_common::endpoint::make_endpoint;
@@ -106,6 +107,38 @@ pub async fn update_token_route(
 
     trace!("Finished updating token for UAID {}", user.uaid);
     Ok(HttpResponse::Ok().finish())
+}
+
+/// Handle the `POST /v1/{router_type}/{app_id}/registration/{uaid}/subscription` route
+pub async fn new_channel_route(
+    _auth: AuthorizationCheck,
+    path_args: RegistrationPathArgsWithUaid,
+    channel_data: Option<Json<NewChannelData>>,
+    state: Data<ServerState>,
+) -> ApiResult<HttpResponse> {
+    // Add the channel
+    debug!("Adding a channel to UAID {}", path_args.uaid);
+    let channel_data = channel_data.map(Json::into_inner).unwrap_or_default();
+    let channel_id = channel_data.channel_id.unwrap_or_else(Uuid::new_v4);
+    trace!("channel_id = {}", channel_id);
+    state.ddb.add_channel(path_args.uaid, channel_id).await?;
+
+    // Make the endpoint URL
+    trace!("Creating endpoint for the new channel");
+    let endpoint_url = make_endpoint(
+        &path_args.uaid,
+        &channel_id,
+        channel_data.key.as_deref(),
+        state.settings.endpoint_url.as_str(),
+        &state.fernet,
+    )
+    .map_err(ApiErrorKind::EndpointUrl)?;
+    trace!("endpoint = {}", endpoint_url);
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "channelID": channel_id.to_simple().to_string(),
+        "endpoint": endpoint_url,
+    })))
 }
 
 /// Increment a metric with data from the request

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -6,7 +6,7 @@ use crate::metrics;
 use crate::middleware::sentry::sentry_middleware;
 use crate::routers::fcm::router::FcmRouter;
 use crate::routes::health::{health_route, lb_heartbeat_route, status_route, version_route};
-use crate::routes::registration::{register_uaid_route, update_token_route};
+use crate::routes::registration::{new_channel_route, register_uaid_route, update_token_route};
 use crate::routes::webpush::{delete_notification_route, webpush_route};
 use crate::settings::Settings;
 use actix_cors::Cors;
@@ -89,6 +89,10 @@ impl Server {
                 .service(
                     web::resource("/v1/{router_type}/{app_id}/registration/{uaid}")
                         .route(web::put().to(update_token_route)),
+                )
+                .service(
+                    web::resource("/v1/{router_type}/{app_id}/registration/{uaid}/subscription")
+                        .route(web::post().to(new_channel_route)),
                 )
                 // Health checks
                 .service(web::resource("/status").route(web::get().to(status_route)))


### PR DESCRIPTION
Adds the `POST /v1/{router_type}/{app_id}/registration/{uaid}/subscription` endpoint.
Also fixed a warn log statement which produced redundant output.

Closes #178 