### PR TITLE
feat: Add the get channels route

### DIFF
--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -108,6 +108,21 @@ pub async fn update_token_route(
     Ok(HttpResponse::Ok().finish())
 }
 
+/// Handle the `GET /v1/{router_type}/{app_id}/registration/{uaid}` route
+pub async fn get_channels_route(
+    _auth: AuthorizationCheck,
+    path_args: RegistrationPathArgsWithUaid,
+    state: Data<ServerState>,
+) -> ApiResult<HttpResponse> {
+    debug!("Getting channel IDs for UAID {}", path_args.uaid);
+    let channel_ids = state.ddb.get_channels(path_args.uaid).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "uaid": path_args.uaid,
+        "channelIDs": channel_ids
+    })))
+}
+
 /// Increment a metric with data from the request
 fn incr_metric(name: &str, metrics: &StatsdClient, request: &HttpRequest) {
     metrics

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -6,7 +6,7 @@ use crate::metrics;
 use crate::middleware::sentry::sentry_middleware;
 use crate::routers::fcm::router::FcmRouter;
 use crate::routes::health::{health_route, lb_heartbeat_route, status_route, version_route};
-use crate::routes::registration::{register_uaid_route, update_token_route};
+use crate::routes::registration::{get_channels_route, register_uaid_route, update_token_route};
 use crate::routes::webpush::{delete_notification_route, webpush_route};
 use crate::settings::Settings;
 use actix_cors::Cors;
@@ -88,7 +88,8 @@ impl Server {
                 )
                 .service(
                     web::resource("/v1/{router_type}/{app_id}/registration/{uaid}")
-                        .route(web::put().to(update_token_route)),
+                        .route(web::put().to(update_token_route))
+                        .route(web::get().to(get_channels_route)),
                 )
                 // Health checks
                 .service(web::resource("/status").route(web::get().to(status_route)))


### PR DESCRIPTION
Adds the `GET /v1/{router_type}/{app_id}/registration/{uaid}` endpoint.

Closes #181 