### PR TITLE
feat: Sentry integration for autoendpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_dynamodb 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_dynamodb 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -939,11 +939,9 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2848,7 +2846,6 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2861,9 +2858,79 @@ dependencies = [
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-backtrace 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-contexts 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-failure 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-panic 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hostname 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-failure"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-backtrace 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "sentry-backtrace 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2872,10 +2939,24 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "debugid 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4271,7 +4352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9158d690bc62a3a57c3e45b85e4d50de2008b39345592c64efd79345c7e24be0"
 "checksum darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a368589465391e127e10c9e3a08efc8df66fd49b87dc8524c764bbe7f2ef82"
 "checksum darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "244e8987bd4e174385240cde20a3657f607fb0797563c28255c353b5819a07b1"
-"checksum debugid 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c49e2ce8d9607581c6b246ccd1e3ca2185991952e3ac9985291ed61ae668ea4b"
+"checksum debugid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
 "checksum derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 "checksum derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1220ad071cb8996454c20adf547a34ba3ac793759dab793d9dc04996a373ac83"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
@@ -4471,7 +4552,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
 "checksum sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b01b723fc1b0a0f9394ca1a8451daec6e20206d47f96c3dceea7fd11ec9eec0"
+"checksum sentry 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf0d1227e6b2cf0a4787c6ba7deed5156ab19fba88e00ffc009bfca8f84812b"
+"checksum sentry-backtrace 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d80067b3c23a24ea12696bb6abeb0ae1c107cbc711ccceb93b1157e4efc219e9"
+"checksum sentry-contexts 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f4367379c4799edf477172cf0964274ae0bb5760ded72779503e64f7c54103"
+"checksum sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44ecd107ce94c346da806dd5ec7afe4aa1b9ff60067b7ea63de499921c990b5d"
+"checksum sentry-failure 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fc8d591ebd58fff637fa7e8fdb308d22be3596cec02909233920c75333b8f8a"
+"checksum sentry-panic 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ee9d1cbab974ec95ba450856115108ce3726ecbdc5316e17b165b527704d1b"
 "checksum sentry-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ec406c11c060c8a7d5d67fc6f4beb2888338dcb12b9af409451995f124749d"
+"checksum sentry-types 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "127fa240592798721c87d025ff7652101a492a38462f5a126f7fec43931aeeb1"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 "checksum serde-hjson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,34 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "curl-sys 0.4.31+curl-7.70.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.31+curl-7.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "darling"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,17 +1687,6 @@ dependencies = [
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libz-sys"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -2867,15 +2828,14 @@ name = "sentry"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-backtrace 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-contexts 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-core 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-failure 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-panic 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2910,6 +2870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-types 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4347,8 +4308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-"checksum curl 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "762e34611d2d5233a506a79072be944fddd057db2f18e04c0d6fa79e3fd466fd"
-"checksum curl-sys 0.4.31+curl-7.70.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dcd62757cc4f5ab9404bc6ca9f0ae447e729a1403948ce5106bd588ceac6a3b0"
 "checksum darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9158d690bc62a3a57c3e45b85e4d50de2008b39345592c64efd79345c7e24be0"
 "checksum darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a368589465391e127e10c9e3a08efc8df66fd49b87dc8524c764bbe7f2ef82"
 "checksum darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "244e8987bd4e174385240cde20a3657f607fb0797563c28255c353b5819a07b1"
@@ -4436,7 +4395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.3"
 reqwest = "0.10.6"
 rusoto_core = "0.44.0"
 rusoto_dynamodb = "0.44.0"
-sentry = { version = "0.18", features = ["with_curl_transport"] }
+sentry = { version = "0.19", features = ["curl"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_dynamodb = "0.5.1"
 serde_json = "1.0"

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -27,7 +27,8 @@ regex = "1.3"
 reqwest = "0.10.6"
 rusoto_core = "0.44.0"
 rusoto_dynamodb = "0.44.0"
-sentry = { version = "0.19", features = ["curl"] }
+# Using debug-logs avoids https://github.com/getsentry/sentry-rust/issues/237
+sentry = { version = "0.19", features = ["debug-logs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_dynamodb = "0.5.1"
 serde_json = "1.0"

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -216,6 +216,10 @@ impl From<ApiError> for HttpResponse {
 }
 
 impl ResponseError for ApiError {
+    fn status_code(&self) -> StatusCode {
+        self.kind.status()
+    }
+
     fn error_response(&self) -> HttpResponse {
         HttpResponse::build(self.kind.status()).json(self)
     }

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -9,6 +9,7 @@ mod extractors;
 mod headers;
 mod logging;
 mod metrics;
+mod middleware;
 mod routers;
 mod routes;
 mod server;

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -16,10 +16,9 @@ mod settings;
 mod tags;
 
 use docopt::Docopt;
-use sentry::internals::ClientInitGuard;
+use sentry::ClientInitGuard;
 use serde::Deserialize;
 use std::error::Error;
-use std::sync::Arc;
 
 const USAGE: &str = "
 Usage: autoendpoint [options]
@@ -60,11 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn configure_sentry() -> ClientInitGuard {
-    let curl_transport_factory = |options: &sentry::ClientOptions| {
-        Arc::new(sentry::transports::CurlHttpTransport::new(&options)) as Arc<dyn sentry::Transport>
-    };
     let options = sentry::ClientOptions {
-        transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()
     };

--- a/autoendpoint/src/middleware/mod.rs
+++ b/autoendpoint/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+//! Actix middleware
+
+pub mod sentry;

--- a/autoendpoint/src/middleware/sentry.rs
+++ b/autoendpoint/src/middleware/sentry.rs
@@ -1,0 +1,104 @@
+use crate::error::ApiError;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse};
+use sentry::protocol::Event;
+use sentry::Hub;
+use std::future::Future;
+
+/// Sentry Actix middleware which reports errors to Sentry and includes request
+/// information in events.
+pub fn sentry_middleware(
+    request: ServiceRequest,
+    service: &mut impl Service<
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = actix_web::Error,
+    >,
+) -> impl Future<Output = Result<ServiceResponse, actix_web::Error>> {
+    // Set up the hub to add request data to events
+    let hub = Hub::new_from_top(Hub::main());
+    let _scope_guard = hub.push_scope();
+    let sentry_request = sentry_request_from_http(&request);
+    hub.configure_scope(|scope| {
+        scope.add_event_processor(Box::new(move |event| process_event(event, &sentry_request)))
+    });
+
+    let response = service.call(request);
+
+    async move {
+        // Wait for the response and check for errors
+        let response: ServiceResponse = match response.await {
+            Ok(response) => response,
+            Err(e) => {
+                debug!("Reporting error to Sentry (service error): {}", e);
+                let event_id = hub.capture_event(event_from_actix_error(&e));
+                trace!("event_id = {}", event_id);
+                return Err(e);
+            }
+        };
+
+        // Check for errors inside the response
+        if let Some(error) = response.response().error() {
+            debug!("Reporting error to Sentry (response error): {}", error);
+            let event_id = hub.capture_event(event_from_actix_error(error));
+            trace!("event_id = {}", event_id);
+        }
+
+        // Move the guard into the future and keep it from dropping until now
+        drop(_scope_guard);
+
+        Ok(response)
+    }
+}
+
+/// Build a Sentry request struct from the HTTP request
+fn sentry_request_from_http(request: &ServiceRequest) -> sentry::protocol::Request {
+    sentry::protocol::Request {
+        url: format!(
+            "{}://{}{}",
+            request.connection_info().scheme(),
+            request.connection_info().host(),
+            request.uri()
+        )
+        .parse()
+        .ok(),
+        method: Some(request.method().to_string()),
+        headers: request
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+/// Add request data to a Sentry event
+fn process_event(
+    mut event: Event<'static>,
+    request: &sentry::protocol::Request,
+) -> Option<Event<'static>> {
+    if event.request.is_none() {
+        event.request = Some(request.clone());
+    }
+
+    // TODO: Use ServiceRequest::match_pattern for the event transaction.
+    //       Coming in Actix v3.
+
+    Some(event)
+}
+
+/// Convert Actix errors into a Sentry event. ApiError is handled explicitly so
+/// the event can include a backtrace and source error information.
+fn event_from_actix_error(error: &actix_web::Error) -> sentry::protocol::Event<'static> {
+    // Actix errors don't have support source/cause, so to get more information
+    // about the error we need to downcast.
+    if let Some(error) = error.as_error::<ApiError>() {
+        // Use our error and associated backtrace for the event
+        let mut event = sentry::event_from_error(&error.kind);
+        event.exception.last_mut().unwrap().stacktrace =
+            sentry::integrations::backtrace::backtrace_to_stacktrace(&error.backtrace);
+        event
+    } else {
+        // Fallback to the Actix error
+        sentry::event_from_error(error)
+    }
+}

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -3,6 +3,7 @@
 use crate::db::client::DbClient;
 use crate::error::{ApiError, ApiResult};
 use crate::metrics;
+use crate::middleware::sentry::sentry_middleware;
 use crate::routers::fcm::router::FcmRouter;
 use crate::routes::health::{health_route, lb_heartbeat_route, status_route, version_route};
 use crate::routes::webpush::webpush_route;
@@ -61,6 +62,7 @@ impl Server {
             App::new()
                 .data(state.clone())
                 .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
+                .wrap_fn(sentry_middleware)
                 .wrap(Cors::default())
                 // Endpoints
                 .service(


### PR DESCRIPTION
Major changes:
- Errors and panics that occur in handlers are now reported to Sentry. Because `sentry-actix` does not support Actix >= 1.0, a custom sentry middleware was developed.

Minor changes:
- Changed Sentry transport from curl to the default (reqwest).

Closes #155 