### PR TITLE
chore: Trim autoendpoint dependencies/features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ name = "autoendpoint"
 version = "1.0.0"
 dependencies = [
  "actix-cors 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "again 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1302,7 +1301,6 @@ name = "futures-util"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.c
 edition = "2018"
 
 [dependencies]
-actix-http = "1.0"
 actix-web = "2.0"
 actix-rt = "1.0"
 actix-cors = "0.2.0"
@@ -18,7 +17,7 @@ cadence = "0.20"
 config = "0.10.1"
 docopt = "1.1.0"
 fernet = "0.1.3"
-futures = { version = "0.3", features = ["compat"] }
+futures = "0.3"
 hex = "0.4.2"
 jsonwebtoken = "7.1.1"
 lazy_static = "1.4.0"

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -5,7 +5,7 @@ use crate::extractors::user::validate_user;
 use crate::headers::crypto_key::CryptoKeyHeader;
 use crate::headers::vapid::{VapidError, VapidHeader, VapidHeaderWithKey, VapidVersionData};
 use crate::server::ServerState;
-use actix_http::{Payload, PayloadStream};
+use actix_web::dev::{Payload, PayloadStream};
 use actix_web::web::Data;
 use actix_web::{FromRequest, HttpRequest};
 use autopush_common::db::DynamoDbUser;

--- a/autoendpoint/src/extractors/token_info.rs
+++ b/autoendpoint/src/extractors/token_info.rs
@@ -1,6 +1,6 @@
 use crate::error::{ApiError, ApiErrorKind};
 use crate::headers::util::get_owned_header;
-use actix_http::{Payload, PayloadStream};
+use actix_web::dev::{Payload, PayloadStream};
 use actix_web::{FromRequest, HttpRequest};
 use futures::future;
 use std::str::FromStr;


### PR DESCRIPTION
1. We don't need to directly rely on `actix_http`
2. We no longer need the `compat` feature of `futures`.