### PR TITLE
fix: Drop 0 TTL WebPush notifications if they aren't delivered the first time

### DIFF
--- a/autoendpoint/src/routers/webpush.rs
+++ b/autoendpoint/src/routers/webpush.rs
@@ -73,7 +73,7 @@ impl Router for WebPushRouter {
 
         if notification.headers.ttl == 0 {
             trace!(
-                "Notification has a TTL of zero but was not successfully \
+                "Notification has a TTL of zero and was not successfully \
                  delivered, dropping it"
             );
             return Ok(self.make_delivered_response(notification));

--- a/autoendpoint/src/routers/webpush.rs
+++ b/autoendpoint/src/routers/webpush.rs
@@ -71,6 +71,14 @@ impl Router for WebPushRouter {
             }
         }
 
+        if notification.headers.ttl == 0 {
+            trace!(
+                "Notification has a TTL of zero but was not successfully \
+                 delivered, dropping it"
+            );
+            return Ok(self.make_delivered_response(notification));
+        }
+
         // Save notification, node is not present or busy
         trace!("Node is not present or busy, storing notification");
         self.store_notification(notification).await?;

--- a/tests/test_integration_all_rust.py
+++ b/tests/test_integration_all_rust.py
@@ -764,7 +764,7 @@ class TestRustWebPush(unittest.TestCase):
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
-        yield client.send_notification(data=data, ttl=0)
+        yield client.send_notification(data=data, ttl=0, status=201)
         yield client.connect()
         yield client.hello()
         result = yield client.get_notification(timeout=0.5)


### PR DESCRIPTION
This follows the logic used in Python autoendpoint:
https://github.com/mozilla-services/autopush/blob/d5d0fdf326cc7d510530201aa74e1bc14c865e44/autopush/router/webpush.py#L228