### PR TITLE
feat: Support "gcm" as an alias to "fcm"

### DIFF
--- a/autoendpoint/src/extractors/router_data_input.rs
+++ b/autoendpoint/src/extractors/router_data_input.rs
@@ -44,7 +44,9 @@ impl FromRequest for RouterDataInput {
             // Validate the token according to each router's token schema
             let is_valid = match path_args.router_type {
                 RouterType::WebPush => true,
-                RouterType::FCM | RouterType::APNS => VALID_TOKEN.is_match(&data.token),
+                RouterType::FCM | RouterType::GCM | RouterType::APNS => {
+                    VALID_TOKEN.is_match(&data.token)
+                }
                 RouterType::ADM => VALID_ADM_TOKEN.is_match(&data.token),
             };
 

--- a/autoendpoint/src/extractors/routers.rs
+++ b/autoendpoint/src/extractors/routers.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 pub enum RouterType {
     WebPush,
     FCM,
+    GCM,
     APNS,
     ADM,
 }
@@ -28,6 +29,7 @@ impl FromStr for RouterType {
         match s {
             "webpush" => Ok(RouterType::WebPush),
             "fcm" => Ok(RouterType::FCM),
+            "gcm" => Ok(RouterType::GCM),
             "apns" => Ok(RouterType::APNS),
             "adm" => Ok(RouterType::ADM),
             _ => Err(()),
@@ -40,6 +42,7 @@ impl Display for RouterType {
         f.write_str(match self {
             RouterType::WebPush => "webpush",
             RouterType::FCM => "fcm",
+            RouterType::GCM => "gcm",
             RouterType::APNS => "apns",
             RouterType::ADM => "adm",
         })
@@ -84,7 +87,7 @@ impl Routers {
     pub fn get(&self, router_type: RouterType) -> &dyn Router {
         match router_type {
             RouterType::WebPush => &self.webpush,
-            RouterType::FCM => self.fcm.as_ref(),
+            RouterType::FCM | RouterType::GCM => self.fcm.as_ref(),
             RouterType::APNS => self.apns.as_ref(),
             RouterType::ADM => self.adm.as_ref(),
         }


### PR DESCRIPTION
It seems we'll have to support users with the router type "gcm" until we can migrate them to use "fcm" instead.

Closes #204 