### PR TITLE
chore: Add autoendpoint building and deploying to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
           name: Build Docker image
           command: |
             docker build -t <<parameters.image>> \
-              --build-arg CRATE=<<paramters.crate>> \
-              --build-arg BINARY=<<paramters.binary>> .
+              --build-arg CRATE=<<parameters.crate>> \
+              --build-arg BINARY=<<parameters.binary>> .
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 # These environment variables must be set in CircleCI UI
 #
 # DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
+# DOCKERHUB_ENDPOINT_REPO - same as DOCKERHUB_REPO, but for autoendpoint
 # DOCKER_EMAIL   - login info for docker hub
 # DOCKER_USER
 # DOCKER_PASS
 #
-version: 2
+
+version: 2.1
+
 jobs:
   audit:
     docker:
@@ -25,18 +28,24 @@ jobs:
           command: |
             # cargo audit
             echo audit temporarily disabled
+
   build:
     docker:
       - image: docker:18.03.0-ce
-    working_directory: /dockerflow
+    parameters:
+      image:
+        type: string
+      crate:
+        type: string
+      binary:
+        type: string
     steps:
+      # Install these packages before checkout because git may not exist or work
       - run:
           name: Install Docker build dependencies
           command: apk add --no-cache openssh-client git
-
       - checkout
       - setup_remote_docker
-
       - run:
           name: Create a version.json
           command: |
@@ -47,47 +56,52 @@ jobs:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
-
       - run:
           name: Build Docker image
-          command: docker build -t app:build .
-
+          command: |
+            docker build -t <<parameters.image>> \
+              --build-arg CRATE=<<paramters.crate>> \
+              --build-arg BINARY=<<paramters.binary>> .
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.
       - run:
-          name: docker save app:build
-          command: mkdir -p /cache; docker save -o /cache/docker.tar "app:build"
+          name: docker save <<parameters.image>>
+          command: mkdir -p /cache; docker save -o /cache/docker.tar "<<parameters.image>>"
       - save_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-<<parameters.image>>-{{ epoch }}
           paths:
             - /cache/docker.tar
 
   deploy:
     docker:
       - image: docker:18.03.0-ce
+    parameters:
+      image:
+        type: string
+      repo:
+        type: string
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-<<parameters.image>>
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar
-
       - run:
           name: Deploy to Dockerhub
           command: |
-            # deploy master
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              # deploy master
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker tag app:build ${DOCKERHUB_REPO}:latest
-              docker push ${DOCKERHUB_REPO}:latest
+              docker tag <<parameters.image>> <<parameters.repo>>:latest
+              docker push <<parameters.repo>>:latest
             elif  [ ! -z "${CIRCLE_TAG}" ]; then
-            # deploy a release tag...
+              # deploy a release tag
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-              echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              docker tag app:build "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              echo "<<parameters.repo>>:${CIRCLE_TAG}"
+              docker tag <<parameters.image>> "<<parameters.repo>>:${CIRCLE_TAG}"
               docker images
-              docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              docker push "<<parameters.repo>>:${CIRCLE_TAG}"
             fi
 
 workflows:
@@ -98,14 +112,43 @@ workflows:
           filters:
             tags:
               only: /.*/
+
       - build:
+          name: build-autopush
+          image: autopush:build
+          crate: autopush
+          binary: autopush_rs
+          filters:
+            tags:
+              only: /.*/
+
+      - build:
+          name: build-autoendpoint
+          image: autoendpoint:build
+          crate: autoendpoint
+          binary: autoendpoint
           filters:
             tags:
               only: /.*/
 
       - deploy:
+          name: deploy-autopush
+          image: autopush:build
+          repo: ${DOCKERHUB_REPO}
           requires:
-            - build
+            - build-autopush
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
+
+      - deploy:
+          name: deploy-autoendpoint
+          image: autoendpoint:build
+          repo: ${DOCKERHUB_ENDPOINT_REPO}
+          requires:
+            - build-autoendpoint
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@
 # DOCKER_USER
 # DOCKER_PASS
 #
+#
 
 version: 2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,15 +62,15 @@ jobs:
             docker build -t <<parameters.image>> \
               --build-arg CRATE=<<parameters.crate>> \
               --build-arg BINARY=<<parameters.binary>> .
-      # save the built docker container into CircleCI's cache. This is
+      # save the built docker container into CircleCI's workspace cache. This is
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save <<parameters.image>>
           command: mkdir -p /cache; docker save -o /cache/docker.tar "<<parameters.image>>"
-      - save_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-<<parameters.image>>-{{ epoch }}
+      - persist_to_workspace:
+          root: /cache
           paths:
-            - /cache/docker.tar
+            - docker.tar
 
   deploy:
     docker:
@@ -82,8 +82,8 @@ jobs:
         type: string
     steps:
       - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-<<parameters.image>>
+      - attach_workspace:
+          at: /cache
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,5 @@ include/*
 lib_pypy/*
 pypy
 .coverage
+target
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,12 @@ RUN \
 
 COPY --from=builder /app/bin /app/bin
 COPY --from=builder /app/version.json /app
+COPY --from=builder /app/entrypoint.sh /app
 
 WORKDIR /app
 # XXX: ensure we no longer bind to privileged ports and re-enable this later
 #USER app
 
-# ARG variables aren't available in CMD/ENTRYPOINT
+# ARG variables aren't available at runtime
 ENV BINARY=/app/bin/$BINARY
-CMD ["sh", "-c", "$BINARY"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.45 as builder
+ARG CRATE
 
 ADD . /app
 WORKDIR /app
@@ -8,10 +9,11 @@ RUN \
     cargo --version && \
     rustc --version && \
     mkdir -m 755 bin && \
-    cargo install --path autopush --locked --root /app
+    cargo install --path $CRATE --locked --root /app
 
 
 FROM debian:buster-slim
+ARG BINARY
 # FROM debian:buster  # for debugging docker build
 MAINTAINER <src+push-dev@mozilla.com>
 RUN \
@@ -29,4 +31,4 @@ WORKDIR /app
 # XXX: ensure we no longer bind to privileged ports and re-enable this later
 #USER app
 
-CMD ["/app/bin/autopush_rs"]
+CMD ["/app/bin/$BINARY"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ WORKDIR /app
 # XXX: ensure we no longer bind to privileged ports and re-enable this later
 #USER app
 
-CMD ["/app/bin/$BINARY"]
+# ARG variables aren't available in CMD/ENTRYPOINT
+ENV BINARY=/app/bin/$BINARY
+CMD ["sh", "-c", "$BINARY"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Execute the binary with our arguments
+exec "$BINARY" "$@"


### PR DESCRIPTION
The Dockerfile and CircleCI config are parameterized to support building and deploying the autoendpoint crate.

This requires some Ops changes:
- Add a Docker Hub repo for autoendpoint.
- Add a `DOCKERHUB_ENDPOINT_REPO` variable to CircleCI with the new repo name.
- Update the required GitHub checks to use the new job names

https://bugzilla.mozilla.org/show_bug.cgi?id=1658357