### PR TITLE
docs: Add a sample config for autoendpoint and normalize router settings

### DIFF
--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -34,7 +34,7 @@ impl FcmClient {
 
         Ok(FcmClient {
             endpoint: settings
-                .fcm_url
+                .base_url
                 .join(&format!(
                     "v1/projects/{}/messages:send",
                     credential.project_id
@@ -186,7 +186,7 @@ pub mod tests {
     async fn make_client(auth_file: PathBuf) -> FcmClient {
         FcmClient::new(
             &FcmSettings {
-                fcm_url: Url::parse(&mockito::server_url()).unwrap(),
+                base_url: Url::parse(&mockito::server_url()).unwrap(),
                 ..Default::default()
             },
             FcmCredential {

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -110,7 +110,7 @@ impl Router for FcmRouter {
             .get("app_id")
             .and_then(Value::as_str)
             .ok_or(FcmError::NoAppId)?;
-        let ttl = MAX_TTL.min(self.settings.ttl.max(notification.headers.ttl as usize));
+        let ttl = MAX_TTL.min(self.settings.min_ttl.max(notification.headers.ttl as usize));
         let message_data = build_message_data(notification, self.settings.max_data)?;
 
         // Send the notification to FCM
@@ -169,7 +169,7 @@ mod tests {
     async fn make_router(auth_file: PathBuf, ddb: Box<dyn DbClient>) -> FcmRouter {
         FcmRouter::new(
             FcmSettings {
-                fcm_url: Url::parse(&mockito::server_url()).unwrap(),
+                base_url: Url::parse(&mockito::server_url()).unwrap(),
                 credentials: format!(
                     r#"{{ "dev": {{ "project_id": "{}", "auth_file": "{}" }} }}"#,
                     PROJECT_ID,

--- a/autoendpoint/src/routers/fcm/settings.rs
+++ b/autoendpoint/src/routers/fcm/settings.rs
@@ -8,14 +8,14 @@ use url::Url;
 #[serde(deny_unknown_fields)]
 pub struct FcmSettings {
     /// The minimum TTL to use for FCM notifications
-    pub ttl: usize,
+    pub min_ttl: usize,
     /// A JSON dict of `FcmCredential`s. This must be a `String` because
     /// environment variables cannot encode a `HashMap<String, FcmCredential>`
     pub credentials: String,
     /// The max size of notification data in bytes
     pub max_data: usize,
     /// The base URL to use for FCM requests
-    pub fcm_url: Url,
+    pub base_url: Url,
     /// The number of seconds to wait for FCM requests to complete
     pub timeout: usize,
 }
@@ -30,10 +30,10 @@ pub struct FcmCredential {
 impl Default for FcmSettings {
     fn default() -> Self {
         Self {
-            ttl: 60,
+            min_ttl: 60,
             credentials: "{}".to_string(),
             max_data: 4096,
-            fcm_url: Url::parse("https://fcm.googleapis.com").unwrap(),
+            base_url: Url::parse("https://fcm.googleapis.com").unwrap(),
             timeout: 3,
         }
     }

--- a/configs/autoendpoint.toml.sample
+++ b/configs/autoendpoint.toml.sample
@@ -1,0 +1,107 @@
+# The URI scheme to use when referencing this server
+#scheme = "http"
+
+# The host to use
+#host = "127.0.0.1"
+
+# The port to use
+#port = 8000
+
+# The router table name
+#router_table_name = "router"
+
+# The message table name
+#message_table_name = "message"
+
+# The maximum payload size to accept in HTTP requests to this server
+#max_data_bytes = 4096
+
+# The fernet keys to use. Multiple are allowed when separated by a comma.
+#crypto_keys = "[AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=]"
+
+# The HMAC SHA256 keys to use, for authenticating registration update requests.
+# Multiple are allowed when separated by a comma.
+#auth_keys = "[AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=]"
+
+# If human-readable logging should be used
+#human_logs = false
+
+# The host to use for metrics.
+# By default there is no value for this setting (`None`).
+#statsd_host = "localhost"
+
+# The port to use for metrics
+#statsd_port = 8125
+
+# The label to use for metrics
+#statsd_label = "autoendpoint"
+
+# Settings for the Firebase Cloud Messaging router
+[fcm]
+# The minimum TTL to use. If a notification's TTL is shorter than this, it will
+# be set to this value.
+#min_ttl = 60
+
+# The max size of notification data in bytes. This is usually dictated by FCM to
+# be 4KB.
+#max_data = 4096
+
+# The number of seconds to wait for FCM requests to complete
+#timeout = 3
+
+# The base URL to use when sending messages
+#base_url = "https://fcm.googleapis.com"
+
+# The credentials to use for each application. This setting is a JSON dictionary
+# where the key is the app ID. The project ID and path to the service auth file
+# are supplied for each application.
+#credentials = """{
+#    "test": {
+#        "project_id": "autoendpoint-test",
+#        "auth_file": "autoendpoint-test-credentials.json"
+#    }
+#}"""
+
+# Settings for the Apple Push Notification Service router
+[apns]
+# The max size of notification data in bytes. This is usually dictated by Apple
+# to be 4KB.
+#max_data = 4096
+
+# The credentials to use for each channel. This setting is a JSON dictionary
+# where the key is the app ID. The auth files, topic, and API sandbox switch
+# are supplied for each application.
+#channels = """{
+#    "test": {
+#        "cert": "apns_cert.pem",
+#        "key": "apns_key.pem",
+#        "topic": "com.mozilla.org.Firefox",
+#        "sandbox": true
+#    }
+#}"""
+
+# Settings for the Amazon Device Messaging router
+[adm]
+# The minimum TTL to use. If a notification's TTL is shorter than this, it will
+# be set to this value.
+#min_ttl = 60
+
+# The max size of notification data in bytes. This is usually dictated by ADM to
+# be about 6KB.
+#max_data = 6000
+
+# The number of seconds to wait for FCM requests to complete
+#timeout = 3
+
+# The base URL to use when sending messages
+#base_url = "https://api.amazon.com"
+
+# The credentials to use for each profile. This setting is a JSON dictionary
+# where the key is the app ID. The client ID and secret are supplied for each
+# application.
+#profiles = """{
+#    "test": {
+#        "client_id": "...",
+#        "client_secret": "..."
+#    }
+#}"""


### PR DESCRIPTION
This might be useful when we start deploying autoendpoint-rs.

Related to #10