### PR TITLE
feat: Include minimal debug info in release builds

### DIFF
--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.0.0"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 
+[profile.release]
+debug = 1
+
 [dependencies]
 # Using a fork temporarily until these three PRs are merged:
 # - https://github.com/pimeys/a2/pull/49

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 name = "autopush_rs"
 path = "src/main.rs"
 
+[profile.release]
+debug = 1
+
 [dependencies]
 autopush_common = { path = "../autopush-common" }
 base64 = "0.12.1"


### PR DESCRIPTION
This will enhance error backtraces in Sentry.

Edit: Example of an error in release mode: https://sentry.prod.mozaws.net/operations/autopush-dev/issues/9368645/

Closes #77