### PR TITLE
fix: Fix debug info setting being ignored

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "autopush",
     "autoendpoint",
 ]
+
+[profile.release]
+debug = 1

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -4,9 +4,6 @@ version = "1.0.0"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 
-[profile.release]
-debug = 1
-
 [dependencies]
 # Using a fork temporarily until these three PRs are merged:
 # - https://github.com/pimeys/a2/pull/49

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -13,9 +13,6 @@ edition = "2018"
 name = "autopush_rs"
 path = "src/main.rs"
 
-[profile.release]
-debug = 1
-
 [dependencies]
 autopush_common = { path = "../autopush-common" }
 base64 = "0.12.1"


### PR DESCRIPTION
Fixes an issue introduced in #215.

Turns out when using a workspace you have to specify profile settings in the workspace's Cargo.toml, not in each crate.

New Sentry example error (includes more debug info than the previous one, and interestingly shows which frames were inlined):
https://sentry.prod.mozaws.net/operations/autopush-dev/issues/9376915/