### PR TITLE
chore: Re-enable cargo-audit in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,22 +9,16 @@ version: 2
 jobs:
   audit:
     docker:
-      - image: circleci/rust:latest
+      - image: rust:latest
     steps:
       - checkout
       - run:
-          name: Setup rust
+          name: Setup cargo-audit
           command: |
-            rustup install stable
-            rustup default stable
-            rustup update
-            cargo install cargo-audit
             rustc --version
+            cargo install cargo-audit
       - run:
-          name: Do audit
-          command: |
-            # cargo audit
-            echo audit temporarily disabled
+          command: cargo audit
   build:
     docker:
       - image: docker:18.03.0-ce


### PR DESCRIPTION
It currently just prints a few warnings about deprecated/unmaintained crates which we can't do much about.