### PR TITLE
chore: tag 1.57.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,13 @@ jobs:
           # ignoring RUSTSEC-2020-0049 => requires non-standard release (actix-codec 0.3.0-beta.1)
           # ignoring RUSTSEC-2020-0048 => requires non-standard release (actix-http 2.0.0-alpha.1)
           # ignoring RUSTSEC-2020-0041 => no upgrade available for im 14.2.0 (sentry 0.18.1)
+          # ignoring RUSTSEC-2020-0071 => dependent chain update required (actix-cors > 0.5.2)
           command: |
             cargo audit \
             --ignore RUSTSEC-2020-0041 \
             --ignore RUSTSEC-2020-0048 \
-            --ignore RUSTSEC-2020-0049
+            --ignore RUSTSEC-2020-0049 \
+            --ignore RUSTSEC-2020-0071
 
   test:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="1.57.1"></a>
+## 1.57.1 (2020-11-19)
+
+
+#### Bug Fixes
+
+*   Allow JSON formatted Auth keys ([d177a759](https://github.com/mozilla-services/autopush-rs/commit/d177a759b7550fcdb582d5463fc9f36b1838ffe0), closes [#234](https://github.com/mozilla-services/autopush-rs/issues/234))
+
+#### Chore
+
+*   release 1.57.0 (#231) ([761d91f4](https://github.com/mozilla-services/autopush-rs/commit/761d91f4fc06176dbc1ddc0d654d2b1981eebe81))
+*   update circleci to use new docker auth ([fabe4954](https://github.com/mozilla-services/autopush-rs/commit/fabe4954c64944cf94d2b36bea5bcac89671bbbf))
+
+
+
 <a name="1.57.0"></a>
 ## 1.57.0 (2020-10-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.57.0"
+version = "1.57.1"
 dependencies = [
  "autopush_common",
  "base64 0.13.0",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.57.0"
+version = "1.57.1"
 dependencies = [
  "base64 0.12.3",
  "cadence 0.20.0",

--- a/autoendpoint/src/metrics.rs
+++ b/autoendpoint/src/metrics.rs
@@ -71,7 +71,7 @@ impl From<&HttpRequest> for Metrics {
     fn from(req: &HttpRequest) -> Self {
         let exts = req.extensions();
         let def_tags = Tags::from_request_head(req.head());
-        let tags = exts.get::<Tags>().unwrap_or_else(|| &def_tags);
+        let tags = exts.get::<Tags>().unwrap_or(&def_tags);
         Metrics {
             client: Some(metrics_from_req(req)),
             tags: Some(tags.clone()),

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.0"
+version = "1.57.1"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush-common/src/logging.rs
+++ b/autopush-common/src/logging.rs
@@ -11,7 +11,7 @@ pub fn init_logging(json: bool) -> Result<()> {
         let hostname = get_ec2_instance_id()
             .map(&str::to_owned)
             .or_else(get_hostname)
-            .ok_or_else(|| "Couldn't get_hostname")?;
+            .ok_or("Couldn't get_hostname")?;
 
         let drain = MozLogJson::new(io::stdout())
             .logger_name(format!(

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.57.0"
+version = "1.57.1"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/src/server/mod.rs
+++ b/autopush/src/server/mod.rs
@@ -273,6 +273,7 @@ impl Server {
         }
     }
 
+    #[allow(clippy::single_char_push_str)]
     fn new(opts: &Arc<ServerOptions>) -> Result<(Rc<Server>, Core)> {
         let core = Core::new()?;
         let broadcaster = if let Some(ref megaphone_url) = opts.megaphone_api_url {


### PR DESCRIPTION
## 1.57.1 (2020-11-19)

#### Bug Fixes

*   Allow JSON formatted Auth keys ([d177a759](https://github.com/mozilla-services/autopush-rs/commit/d177a759b7550fcdb582d5463fc9f36b1838ffe0), closes [#234](https://github.com/mozilla-services/autopush-rs/issues/234))

#### Chore

*   release 1.57.0 (#231) ([761d91f4](https://github.com/mozilla-services/autopush-rs/commit/761d91f4fc06176dbc1ddc0d654d2b1981eebe81))
*   update circleci to use new docker auth ([fabe4954](https://github.com/mozilla-services/autopush-rs/commit/fabe4954c64944cf94d2b36bea5bcac89671bbbf))

