### PR TITLE
bug: Accept either paths or strings containing the cert for APNS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "reqwest 0.10.8",
  "rusoto_core 0.45.0",
  "rusoto_dynamodb 0.45.0",
- "sentry 0.21.0",
+ "sentry 0.20.1",
  "serde 1.0.117",
  "serde_dynamodb 0.6.0",
  "serde_json",
@@ -3358,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933beb0343c84eefd69a368318e9291b179e09e51982d49c65d7b362b0e9466f"
+checksum = "144e85b28d129f056ef91664fe2b985eade906d2838752c2f61c9f233cd98e4a"
 dependencies = [
  "httpdate",
  "log",
@@ -3368,14 +3368,15 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-failure",
  "sentry-panic",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e528fb457baf53fcd6c90beb420705f35c12c3d8caed8817dcf7be00eff7c7"
+checksum = "92dabd890482f152fb6d261fe2034a193facc2c99c0c571bbf7687c356fcb2e8"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3385,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3a560a34cffac347f0b588fc29b31db969e27bf57208f946d6a2d588668b0b"
+checksum = "039ac50d2d740d51c5d376c2e9e93725eea662fa3acdcbcfe1b8b93a3b30c478"
 dependencies = [
  "hostname 0.3.1",
  "lazy_static",
@@ -3400,24 +3401,35 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b8c235063c1007fd8e2fc7e35ce7eac09dd678d198ecc996daee33d46b3dcc"
+checksum = "3fe4fe890b12416701f838c702898a9c5e574c333cfbbee9fb7855a14e6490a3"
 dependencies = [
  "im 15.0.0",
  "lazy_static",
  "log",
  "rand 0.7.3",
- "sentry-types 0.21.0",
+ "sentry-types 0.20.1",
  "serde 1.0.117",
  "serde_json",
 ]
 
 [[package]]
-name = "sentry-panic"
-version = "0.21.0"
+name = "sentry-failure"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ee338d8292fcdcfb032929c9f53bc0dfac8e0b9d3096be79ceee96818851ed"
+checksum = "ead35e7019f77a79ed0345b3f3c28427139100f87f318c1c3e2788db2cdea8b7"
+dependencies = [
+ "failure",
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8a3ac989339a76efd6155f9d02675ce4b04419cd8083ca58d083c222554147"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3440,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbbea6debac0a24880a38239d4c2fc3dbb0b1b398f621bea03ed761796b7dfb"
+checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
 dependencies = [
  "chrono",
  "debugid",

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = "0.10.6"
 rusoto_core = "0.45.0"
 rusoto_dynamodb = "0.45.0"
 # Using debug-logs avoids https://github.com/getsentry/sentry-rust/issues/237
-sentry = { version = "0.21", features = ["debug-logs"] }
+sentry = { version = "0.20", features = ["debug-logs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_dynamodb = "0.6"
 serde_json = "1.0"

--- a/autoendpoint/src/routers/apns/router.rs
+++ b/autoendpoint/src/routers/apns/router.rs
@@ -82,8 +82,16 @@ impl ApnsRouter {
         } else {
             Endpoint::Production
         };
-        let cert = tokio::fs::read(settings.cert).await?;
-        let key = tokio::fs::read(settings.key).await?;
+        let cert = if settings.cert.starts_with('/') {
+            tokio::fs::read(settings.cert).await?
+        } else {
+            settings.cert.as_bytes().to_vec()
+        };
+        let key = if settings.key.starts_with('/') {
+            tokio::fs::read(settings.key).await?
+        } else {
+            settings.key.as_bytes().to_vec()
+        };
         let client = ApnsClientData {
             client: Box::new(
                 a2::Client::certificate_parts(&cert, &key, endpoint)

--- a/autoendpoint/src/routers/apns/router.rs
+++ b/autoendpoint/src/routers/apns/router.rs
@@ -82,12 +82,12 @@ impl ApnsRouter {
         } else {
             Endpoint::Production
         };
-        let cert = if settings.cert.starts_with('/') {
+        let cert = if !settings.cert.starts_with('-') {
             tokio::fs::read(settings.cert).await?
         } else {
             settings.cert.as_bytes().to_vec()
         };
-        let key = if settings.key.starts_with('/') {
+        let key = if !settings.key.starts_with('-') {
             tokio::fs::read(settings.key).await?
         } else {
             settings.key.as_bytes().to_vec()

--- a/autoendpoint/src/routers/apns/settings.rs
+++ b/autoendpoint/src/routers/apns/settings.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 /// Settings for `ApnsRouter`
 #[derive(Clone, Debug, serde::Deserialize)]

--- a/autoendpoint/src/routers/apns/settings.rs
+++ b/autoendpoint/src/routers/apns/settings.rs
@@ -18,8 +18,10 @@ pub struct ApnsSettings {
 #[serde(default)]
 #[serde(deny_unknown_fields)]
 pub struct ApnsChannel {
-    pub cert: PathBuf,
-    pub key: PathBuf,
+    /// the cert and key are either fully qualified paths (starts with "/")
+    /// or an inline value.
+    pub cert: String,
+    pub key: String,
     pub topic: Option<String>,
     pub sandbox: bool,
 }

--- a/autoendpoint/src/routers/apns/settings.rs
+++ b/autoendpoint/src/routers/apns/settings.rs
@@ -17,8 +17,9 @@ pub struct ApnsSettings {
 #[serde(default)]
 #[serde(deny_unknown_fields)]
 pub struct ApnsChannel {
-    /// the cert and key are either fully qualified paths (starts with "/")
-    /// or an inline value.
+    /// the cert and key are either paths
+    /// or an inline value that starts with "-"
+    /// e.g. `-----BEGIN PRIVATE KEY-----\n`
     pub cert: String,
     pub key: String,
     pub topic: Option<String>,

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -68,7 +68,9 @@ impl Settings {
         }
 
         // Merge the environment overrides
-        config.merge(Environment::with_prefix(ENV_PREFIX))?;
+        // Note: Specify the separator here so that the shell can properly pass args
+        // down to the sub structures.
+        config.merge(Environment::with_prefix(ENV_PREFIX).separator("__"))?;
 
         config.try_into::<Self>().map_err(|error| match error {
             // Configuration errors are not very sysop friendly, Try to make them


### PR DESCRIPTION
Closes #240

## Description

Allow APNS certificates to be inlined into environment variables.

*NOTE* 
The Environment Variable name needs to be specified as:

`AUTOEND_APNS__CHANNELS` (note the double underscore between `APNS` and `CHANNELS`.)

inlined certificates should include new line characters (e.g. 
`AUTOEND_APNS__CHANNELS='{"dev":{"cert":"-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----","key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"}}' `

Values that do not begin with a "-" are presumed to be paths to key and certificates. 

## Testing

While this will not produce a valid APNS key, you can generate a readable PKCS8 cert and key file using the following:
```
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
openssl pkcs8 -topk8 -inform pem -outform pem -in key.pem -out pkcs8.key -nocrypt
```

`cert.pem` =  the `cert` value
`pkcs8.key` = the `key` value

These can be incorporated into a bash command  to verify that the APNS service is started. 

## Issue

Closes #240