### PR TITLE
chore: release/1.57.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="1.57.3"></a>
+## 1.57.3 (2020-12-02)
+
+
+#### Bug Fixes
+
+*   Accept either paths or strings containing the cert for APNS (#241) ([b3dd8a3e](https://github.com/mozilla-services/autopush-rs/commit/b3dd8a3ee3a47424e13a4661337aa8f4a8106612), closes [#240](https://github.com/mozilla-services/autopush-rs/issues/240))
+
+#### Chore
+
+*   tag 1.57.1 (#239) ([0f168c93](https://github.com/mozilla-services/autopush-rs/commit/0f168c93c9758b515732231e0cae0f7a8a6779bb))
+
+
+
 <a name="1.57.1"></a>
 ## 1.57.1 (2020-11-19)
 

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autoendpoint"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.0"
+version = "1.57.3"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.1"
+version = "1.57.3"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.57.1"
+version = "1.57.3"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes

*   Accept either paths or strings containing the cert for APNS (#241) ([b3dd8a3e](https://github.com/mozilla-services/autopush-rs/commit/b3dd8a3ee3a47424e13a4661337aa8f4a8106612), closes [#240](https://github.com/mozilla-servicesautopush-rs/issues/240))

#### Chore

*   tag 1.57.1 (#239) ([0f168c93](https://github.com/mozilla-services/autopush-rs/commit0f168c93c9758b515732231e0cae0f7a8a6779bb))

