### PR TITLE
feat: convert FCM credential to string parameter

### DIFF
--- a/autoendpoint/src/db/client.rs
+++ b/autoendpoint/src/db/client.rs
@@ -141,6 +141,7 @@ impl DbClientImpl {
     }
 }
 
+#[allow(clippy::field_reassign_with_default)]
 #[async_trait]
 impl DbClient for DbClientImpl {
     async fn add_user(&self, user: &DynamoDbUser) -> DbResult<()> {

--- a/autoendpoint/src/middleware/sentry.rs
+++ b/autoendpoint/src/middleware/sentry.rs
@@ -72,6 +72,7 @@ fn sentry_request_from_http(request: &ServiceRequest) -> sentry::protocol::Reque
 }
 
 /// Add request data to a Sentry event
+#[allow(clippy::unnecessary_wraps)]
 fn process_event(
     mut event: Event<'static>,
     request: &sentry::protocol::Request,

--- a/autoendpoint/src/routers/fcm/settings.rs
+++ b/autoendpoint/src/routers/fcm/settings.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+
 use url::Url;
 
 /// Settings for `FcmRouter`
@@ -24,7 +24,7 @@ pub struct FcmSettings {
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct FcmCredential {
     pub project_id: String,
-    pub auth_file: PathBuf,
+    pub credential: String,
 }
 
 impl Default for FcmSettings {

--- a/configs/autoendpoint.toml.sample
+++ b/configs/autoendpoint.toml.sample
@@ -60,7 +60,7 @@
 #credentials = """{
 #    "test": {
 #        "project_id": "autoendpoint-test",
-#        "auth_file": "autoendpoint-test-credentials.json"
+#        "credential": "{\"type\":\"service_account\",...
 #    }
 #}"""
 


### PR DESCRIPTION
FCM credentials are now specified as a JSON structure with an embedded credential string. Please note that additional escaping may be required. The original `auth_file` parameter is now deprecated.

### Operations
As per above, please specify the FCM credential file content as an included String. Additional string escapes may be required to properly specify the inline JSON.

Closes #254