### PR TITLE
Release/1.57.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="1.57.6"></a>
+## 1.57.6 (2021-03-16)
+
+#### Bug
+
+*   always return status 201 for success ([267213b8](https://github.com/mozilla-services/autopush-rs/pull/260/commits/123f970430e1b01ad6f31765be41ebbb267213b8), closes [#259](https://github.com/mozilla-services/autopush-rs/issues/259))
+
+
+#### Features
+
+*   convert FCM credential to string parameter ([5ba885af](https://github.com/mozilla-services/autopush-rs/commit/5ba885af5f2b68548047e2f83da36e364de7fbcb), closes [#254](https://github.com/mozilla-services/autopush-rs/issues/254))
+
+#### Chore
+
+*   tag 1.57.5 (#258) ([a95b7b97](https://github.com/mozilla-services/autopush-rs/commit/a95b7b979e5c75b2be80aa399b3bd36caa3156ab))
+*   update dependencies for Mar 2021 ([7ec16f08](https://github.com/mozilla-services/autopush-rs/commit/7ec16f0877c1c6de5b08e429e1321536ae8ff9d8), closes [#256](https://github.com/mozilla-services/autopush-rs/issues/256))
+*   tag 1.57.4 (#253) ([b4c5e5e3](https://github.com/mozilla-services/autopush-rs/commit/b4c5e5e38ecf9d9b4d06320a0daa457b2d280359))
+
+
+
 <a name="1.57.5"></a>
 ## 1.57.5 (2021-03-01)
 

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autoendpoint"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.5"
+version = "1.57.6"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.5"
+version = "1.57.6"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.57.5"
+version = "1.57.6"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug

*   always return status 201 for success ([267213b8](https://github.com/mozilla-services/autopush-rs/pull/260/commits/123f970430e1b01ad6f31765be41ebbb267213b8), closes [#259](https://github.com/mozilla-services/autopush-rs/issues/259))


#### Features

*   convert FCM credential to string parameter ([5ba885af](https://github.com/mozilla-services/autopush-rs/commit/5ba885af5f2b68548047e2f83da36e364de7fbcb), closes [#254](https://github.com/mozilla-services/autopush-rs/issues/254))

#### Chore

*   tag 1.57.5 (#258) ([a95b7b97](https://github.com/mozilla-services/autopush-rs/commit/a95b7b979e5c75b2be80aa399b3bd36caa3156ab))
*   update dependencies for Mar 2021 ([7ec16f08](https://github.com/mozilla-services/autopush-rs/commit/7ec16f0877c1c6de5b08e429e1321536ae8ff9d8), closes [#256](https://github.com/mozilla-services/autopush-rs/issues/256))
*   tag 1.57.4 (#253) ([b4c5e5e3](https://github.com/mozilla-services/autopush-rs/commit/b4c5e5e38ecf9d9b4d06320a0daa457b2d280359))


