### PR TITLE
feat: Drop aesgcm128 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "autoendpoint"
-version = "1.57.5"
+version = "1.57.6"
 dependencies = [
  "a2",
  "actix-cors",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.57.5"
+version = "1.57.6"
 dependencies = [
  "autopush_common",
  "base64 0.13.0",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.57.5"
+version = "1.57.6"
 dependencies = [
  "base64 0.13.0",
  "cadence",

--- a/autoendpoint/src/extractors/notification_headers.rs
+++ b/autoendpoint/src/extractors/notification_headers.rs
@@ -122,7 +122,6 @@ impl NotificationHeaders {
         })?;
 
         match encoding {
-            "aesgcm128" => self.validate_encryption_01_rules()?,
             "aesgcm" => self.validate_encryption_04_rules()?,
             "aes128gcm" => self.validate_encryption_06_rules()?,
             _ => {
@@ -132,16 +131,6 @@ impl NotificationHeaders {
                 .into());
             }
         }
-
-        Ok(())
-    }
-
-    /// Validates encryption headers according to
-    /// draft-ietf-webpush-encryption-01
-    fn validate_encryption_01_rules(&self) -> ApiResult<()> {
-        Self::assert_base64_item_exists("Encryption", self.encryption.as_deref(), "salt")?;
-        Self::assert_base64_item_exists("Encryption-Key", self.encryption_key.as_deref(), "dh")?;
-        Self::assert_not_exists("aesgcm128 Crypto-Key", self.crypto_key.as_deref(), "dh")?;
 
         Ok(())
     }
@@ -351,32 +340,7 @@ mod tests {
         assert_encryption_error(result, "Missing Content-Encoding header");
     }
 
-    /// Valid 01 draft encryption passes validation
-    #[test]
-    fn valid_01_encryption() {
-        let req = TestRequest::post()
-            .header("TTL", "10")
-            .header("Content-Encoding", "aesgcm128")
-            .header("Encryption", "salt=foo")
-            .header("Encryption-Key", "dh=bar")
-            .to_http_request();
-        let result = NotificationHeaders::from_request(&req, true);
-
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            NotificationHeaders {
-                ttl: 10,
-                topic: None,
-                encoding: Some("aesgcm128".to_string()),
-                encryption: Some("salt=foo".to_string()),
-                encryption_key: Some("dh=bar".to_string()),
-                crypto_key: None
-            }
-        );
-    }
-
-    /// Valid 04 draft encryption passes validation
+    /// Valid 04 draft encryption passes validationgit o
     #[test]
     fn valid_04_encryption() {
         let req = TestRequest::post()

--- a/autoendpoint/src/extractors/notification_headers.rs
+++ b/autoendpoint/src/extractors/notification_headers.rs
@@ -340,7 +340,7 @@ mod tests {
         assert_encryption_error(result, "Missing Content-Encoding header");
     }
 
-    /// Valid 04 draft encryption passes validationgit o
+    /// Valid 04 draft encryption passes validation
     #[test]
     fn valid_04_encryption() {
         let req = TestRequest::post()


### PR DESCRIPTION
## Description

Drops support for legacy `aesgcm128` encryption format.  This is in parallel with https://github.com/mozilla/rust-ece/issues/53 which will drop support for the format for mobile devices.

We're also seeing zero messages containing this form, so it's absolutely safe to drop it.

## Testing

messages encoded with `aesgcm128` should be rejected.

## Issue

Closes: #266