### PR TITLE
chore: tag 1.57.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="1.57.8"></a>
+## 1.57.8 (2021-06-02)
+
+
+#### Bug Fixes
+
+*   use sentry 0.19 to match our backend server  (#276) ([44c85c0c](https://github.com/mozilla-services/autopush-rs/commit/44c85c0c6b6f093bebc4ca3383df7750140db236), closes [#275](https://github.com/mozilla-services/autopush-rs/issues/275))
+
+#### Features
+
+*   Drop aesgcm128 support (#268) ([d8b7ca83](https://github.com/mozilla-services/autopush-rs/commit/d8b7ca83542e2f0acf6dc6a3b277efe60aef276b))
+
+#### Chore
+
+*   tag 1.57.7 (#271) ([4857f0b1](https://github.com/mozilla-services/autopush-rs/commit/4857f0b1ea4e74ae4fce0dc411e1e4ba9758b26c))
+
+
+
 <a name="1.57.7"></a>
 ## 1.57.7 (2021-03-26)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "autoendpoint"
-version = "1.57.7"
+version = "1.57.8"
 dependencies = [
  "a2",
  "actix-cors",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.57.7"
+version = "1.57.8"
 dependencies = [
  "autopush_common",
  "base64 0.13.0",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.57.7"
+version = "1.57.8"
 dependencies = [
  "base64 0.13.0",
  "cadence",
@@ -1655,9 +1655,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autoendpoint"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.7"
+version = "1.57.8"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.57.7"
+version = "1.57.8"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.57.7"
+version = "1.57.8"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes

*   use sentry 0.19 to match our backend server  (#276) ([44c85c0c](https://github.com/mozilla-services/autopush-rs/commit/44c85c0c6b6f093bebc4ca3383df7750140db236), closes [#275](https://github.com/mozilla-services/autopush-rs/issues/275))

#### Features

*   Drop aesgcm128 support (#268) ([d8b7ca83](https://github.com/mozilla-services/autopush-rs/commit/d8b7ca83542e2f0acf6dc6a3b277efe60aef276b))

#### Chore

*   tag 1.57.7 (#271) ([4857f0b1](https://github.com/mozilla-services/autopush-rs/commit/4857f0b1ea4e74ae4fce0dc411e1e4ba9758b26c))