### PR TITLE
chore: 1.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="1.59.1"></a>
+## 1.59.1 (2022-02-25)
+
+
+#### Chore
+
+*   tag 1.59 (#296) ([8b8e5fb3](https://github.com/mozilla-services/autopush-rs/commit/8b8e5fb36eb8909341af8c12e11ded6fc724d3c6))
+
+
+
 <a name="1.59.0"></a>
 ## 1.59.0 (2022-02-25)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autoendpoint"
-version = "1.59.0"
+version = "1.59.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.59.0"
+version = "1.59.1"
 dependencies = [
  "autopush_common",
  "base64 0.13.0",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.59.0"
+version = "1.59.1"
 dependencies = [
  "base64 0.13.0",
  "cadence",

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autoendpoint"
 # Should match version in ../autopush/Cargo.toml
-version = "1.59.0"
+version = "1.59.1"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.59.0"
+version = "1.59.1"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.59.0"
+version = "1.59.1"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.59 (#296) ([8b8e5fb3](https://github.com/mozilla-services/autopush-rs/commit/8b8e5fb36eb8909341af8c12e11ded6fc724d3c6))

* add clippy fixes to tag