### PR TITLE
chore: tag 1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="1.60.0"></a>
+## 1.60.0 (2022-03-22)
+
+#### Bug Fixes
+
+*    bug: Do not report non-actionable errors to sentry (#299) ([3d18b10d2](https://github.com/mozilla-services/autopush-rs/commit/3d18b10d2e05a768f4cb1c2fa23f86b8df825a87))
+
+#### Features
+
+*   feat: return more explicit VAPID error message (#299) ([3d18b10d2](https://github.com/mozilla-services/autopush-rs/commit/3d18b10d2e05a768f4cb1c2fa23f86b8df825a87))
+
+
+#### Chore
+
+*   1.59.1 (#297) ([01d39582](https://github.com/mozilla-services/autopush-rs/commit/01d395826c1ab7359dea5b5405e2b1ffdd5e22df))
+
+
+
 <a name="1.59.1"></a>
 ## 1.59.1 (2022-02-25)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autoendpoint"
-version = "1.59.1"
+version = "1.60.0"
 dependencies = [
  "a2",
  "actix-cors",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.59.1"
+version = "1.60.0"
 dependencies = [
  "autopush_common",
  "base64 0.13.0",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.59.1"
+version = "1.60.0"
 dependencies = [
  "base64 0.13.0",
  "cadence",

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autoendpoint"
 # Should match version in ../autopush/Cargo.toml
-version = "1.59.1"
+version = "1.60.0"
 authors = ["Mark Drobnak <mdrobnak@mozilla.com>", "jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"
 

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "autopush_common"
 # Should match version in ../autopush/Cargo.toml
-version = "1.59.1"
+version = "1.60.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autopush"
-version = "1.59.1"
+version = "1.60.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes

*    bug: Do not report non-actionable errors to sentry (#299) ([3d18b10d2](https://github.com/mozilla-services/autopush-rs/commit/3d18b10d2e05a768f4cb1c2fa23f86b8df825a87))

#### Features

*   feat: return more explicit VAPID error message (#299) ([3d18b10d2](https://github.com/mozilla-services/autopush-rs/commit/3d18b10d2e05a768f4cb1c2fa23f86b8df825a87))


(Holding off on #291 for now. It's not critical and we can release a new version when it lands)