### PR TITLE
bug: Fix GCM handling

### DIFF
--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -58,7 +58,7 @@ validator_derive = "0.14"
 yup-oauth2 = "4.1.2"  # 5.0+ requires tokio 1.1+
 
 # For mockito test debugging
-# ureq={ version="2.4", features=["json"] }
+#ureq={ version="2.4", features=["json"] }
 
 [dev-dependencies]
 mockall = "0.8.3"  # 0.9+ requires reworking tests

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -152,6 +152,16 @@ impl ApiErrorKind {
         }
     }
 
+    /// Should the User record be removed?
+    pub fn user_still_valid(&self) -> bool {
+        match self {
+            ApiErrorKind::NoUser | ApiErrorKind::NoSubscription | ApiErrorKind::InvalidToken => {
+                false
+            }
+            _ => true,
+        }
+    }
+
     /// Specify the label to use for metrics reporting.
     pub fn metric_label(&self) -> &'static str {
         match self {

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -152,11 +152,6 @@ impl ApiErrorKind {
         }
     }
 
-    /// Should the User record be removed?
-    pub fn user_still_valid(&self) -> bool {
-        !matches!(self, ApiErrorKind::InvalidToken)
-    }
-
     /// Specify the label to use for metrics reporting.
     pub fn metric_label(&self) -> &'static str {
         match self {

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -203,8 +203,8 @@ impl ApiErrorKind {
             self,
             // Ignore common webpush errors
             ApiErrorKind::NoTTL | ApiErrorKind::InvalidEncryption(_) |
-            // Ignore GCM router authentication errors otherwise
-            // we could blow through our quota.
+            // Do not report GCMAuthentication failures to Sentry since
+            // they're not really actionable and could flood our quota
             ApiErrorKind::Router(RouterError::GCMAuthentication) |
             // Ignore common VAPID erros
             ApiErrorKind::VapidError(_)

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -154,12 +154,7 @@ impl ApiErrorKind {
 
     /// Should the User record be removed?
     pub fn user_still_valid(&self) -> bool {
-        match self {
-            ApiErrorKind::NoUser | ApiErrorKind::NoSubscription | ApiErrorKind::InvalidToken => {
-                false
-            }
-            _ => true,
-        }
+        !matches!(self, ApiErrorKind::InvalidToken)
     }
 
     /// Specify the label to use for metrics reporting.

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -203,6 +203,9 @@ impl ApiErrorKind {
             self,
             // Ignore common webpush errors
             ApiErrorKind::NoTTL | ApiErrorKind::InvalidEncryption(_) |
+            // Ignore GCM router authentication errors otherwise
+            // we could blow through our quota.
+            ApiErrorKind::Router(RouterError::GCMAuthentication) |
             // Ignore common VAPID erros
             ApiErrorKind::VapidError(_)
             | ApiErrorKind::Jwt(_)

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -198,9 +198,6 @@ impl ApiErrorKind {
             self,
             // Ignore common webpush errors
             ApiErrorKind::NoTTL | ApiErrorKind::InvalidEncryption(_) |
-            // Do not report GCMAuthentication failures to Sentry since
-            // they're not really actionable and could flood our quota
-            ApiErrorKind::Router(RouterError::GCMAuthentication) |
             // Ignore common VAPID erros
             ApiErrorKind::VapidError(_)
             | ApiErrorKind::Jwt(_)

--- a/autoendpoint/src/extractors/user.rs
+++ b/autoendpoint/src/extractors/user.rs
@@ -69,7 +69,7 @@ async fn validate_webpush_user(
 }
 
 /// Drop a user and increment associated metric
-async fn drop_user(uaid: Uuid, ddb: &dyn DbClient, metrics: &StatsdClient) -> ApiResult<()> {
+pub async fn drop_user(uaid: Uuid, ddb: &dyn DbClient, metrics: &StatsdClient) -> ApiResult<()> {
     metrics
         .incr_with_tags("updates.drop_user")
         .with_tag("errno", "102")

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -58,7 +58,7 @@ pub async fn handle_error(
             );
         }
         RouterError::GCMAuthentication => {
-            // Don't record the GCM auth error.
+            warn!("GCM Authentication error");
             incr_error_metric(
                 metrics,
                 platform,

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -57,6 +57,17 @@ pub async fn handle_error(
                 error.errno(),
             );
         }
+        RouterError::GCMAuthentication => {
+            // Don't record the GCM auth error.
+            incr_error_metric(
+                metrics,
+                platform,
+                app_id,
+                "gcm authentication",
+                error.status(),
+                error.errno(),
+            );
+        }
         RouterError::RequestTimeout => {
             warn!("Bridge timeout");
             incr_error_metric(

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -78,7 +78,7 @@ impl FcmClient {
                 .expect("Project ID is not URL-safe"),
             gcm_endpoint: settings
                 .base_url
-                .join("gcm/send")
+                .join("fcm/send")
                 .expect("GCM Project ID is not URL-safe"),
             timeout: Duration::from_secs(settings.timeout as u64),
             max_data: settings.max_data,

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -145,7 +145,7 @@ impl FcmClient {
                 .map_err(FcmError::DeserializeResponse)?;
 
             return Err(match (status, data.error) {
-                (StatusCode::UNAUTHORIZED, _) => RouterError::Authentication,
+                (StatusCode::UNAUTHORIZED, _) => RouterError::GCMAuthentication,
                 (StatusCode::NOT_FOUND, _) => RouterError::NotFound,
                 (_, Some(error)) => RouterError::Upstream {
                     status: error.status,

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -17,6 +17,7 @@ const OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/firebase.messag
 /// handles sending notifications to Firebase.
 pub struct FcmClient {
     endpoint: Url,
+    gcm_endpoint: Url,
     timeout: Duration,
     max_data: usize,
     fcm_authenticator: Option<DefaultAuthenticator>,
@@ -75,6 +76,10 @@ impl FcmClient {
                     server_credential.project_id
                 ))
                 .expect("Project ID is not URL-safe"),
+            gcm_endpoint: settings
+                .base_url
+                .join("gcm/send")
+                .expect("GCM Project ID is not URL-safe"),
             timeout: Duration::from_secs(settings.timeout as u64),
             max_data: settings.max_data,
             fcm_authenticator: auth,
@@ -121,7 +126,7 @@ impl FcmClient {
         let server_access_token = &self.server_credential.server_access_token;
         let response = self
             .http_client
-            .post(self.endpoint.clone())
+            .post(self.gcm_endpoint.clone())
             .header("Authorization", format!("key={}", server_access_token))
             .header("Content-Type", "application/json")
             .json(&message)

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -360,6 +360,9 @@ mod tests {
         let fcm_mock = mock_gcm_endpoint_builder()
             .match_header("Authorization", format!("key={}", &auth_key).as_str())
             .match_header("Content-Type", "application/json")
+            .with_body(
+                r#"{ "multicast_id": 216,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:02"}]}"#,
+            )
             .match_body(body.as_str())
             .create();
         let notification = make_notification(

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -229,8 +229,8 @@ mod tests {
     use crate::extractors::routers::RouterType;
     use crate::routers::common::tests::{make_notification, CHANNEL_ID};
     use crate::routers::fcm::client::tests::{
-        make_service_key, mock_fcm_endpoint_builder, mock_token_endpoint, GCM_PROJECT_ID,
-        PROJECT_ID,
+        make_service_key, mock_fcm_endpoint_builder, mock_gcm_endpoint_builder,
+        mock_token_endpoint, GCM_PROJECT_ID, PROJECT_ID,
     };
     use crate::routers::fcm::error::FcmError;
     use crate::routers::fcm::router::FcmRouter;
@@ -342,7 +342,7 @@ mod tests {
     async fn successful_gcm_fallback() {
         let auth_key = "AIzaSyB0ecSrqnEDXQ7yjLXqVc0CUGOeSlq9BsM"; // this is a nonce value used only for testing.
         let registration_id = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let project_id = GCM_PROJECT_ID;
+        // let project_id = GCM_PROJECT_ID;
         let ddb = MockDbClient::new().into_boxed_arc();
         let router = make_router(make_service_key(), auth_key.to_owned(), ddb).await;
         assert!(router.active());
@@ -357,7 +357,7 @@ mod tests {
         })
         .to_string();
         let _token_mock = mock_token_endpoint();
-        let fcm_mock = mock_fcm_endpoint_builder(project_id)
+        let fcm_mock = mock_gcm_endpoint_builder()
             .match_header("Authorization", format!("key={}", &auth_key).as_str())
             .match_header("Content-Type", "application/json")
             .match_body(body.as_str())

--- a/autoendpoint/src/routers/mod.rs
+++ b/autoendpoint/src/routers/mod.rs
@@ -121,12 +121,12 @@ impl RouterError {
 
             RouterError::SaveDb(_) => StatusCode::SERVICE_UNAVAILABLE,
 
-            RouterError::GCMAuthentication | // Treat GCM auth failures as special, we reset the user.
             RouterError::UserWasDeleted | RouterError::NotFound => StatusCode::GONE,
 
             RouterError::TooMuchData(_) => StatusCode::PAYLOAD_TOO_LARGE,
 
             RouterError::Authentication
+            | RouterError::GCMAuthentication
             | RouterError::RequestTimeout
             | RouterError::Connect(_)
             | RouterError::Upstream { .. } => StatusCode::BAD_GATEWAY,

--- a/autoendpoint/src/routers/mod.rs
+++ b/autoendpoint/src/routers/mod.rs
@@ -95,6 +95,9 @@ pub enum RouterError {
     #[error("Bridge authentication error")]
     Authentication,
 
+    #[error("GCM Bridge authentication error")]
+    GCMAuthentication,
+
     #[error("Bridge request timeout")]
     RequestTimeout,
 
@@ -118,6 +121,7 @@ impl RouterError {
 
             RouterError::SaveDb(_) => StatusCode::SERVICE_UNAVAILABLE,
 
+            RouterError::GCMAuthentication | // Treat GCM auth failures as special, we reset the user.
             RouterError::UserWasDeleted | RouterError::NotFound => StatusCode::GONE,
 
             RouterError::TooMuchData(_) => StatusCode::PAYLOAD_TOO_LARGE,
@@ -149,6 +153,8 @@ impl RouterError {
             RouterError::Connect(_) => Some(902),
 
             RouterError::RequestTimeout => Some(903),
+
+            RouterError::GCMAuthentication => Some(904),
 
             RouterError::Upstream { .. } => None,
         }

--- a/autoendpoint/src/routes/webpush.rs
+++ b/autoendpoint/src/routes/webpush.rs
@@ -26,12 +26,13 @@ pub async fn webpush_route(
             if !e.kind.user_still_valid() {
                 // The user record is no longer valid. We should remove it so that the client
                 // can attempt to recover. We don't care if this succeeds or fails at this point.
-                if let Ok(_) = drop_user(
+                if drop_user(
                     notification.subscription.user.uaid,
                     state.ddb.as_ref(),
                     &state.metrics,
                 )
                 .await
+                .is_ok()
                 {};
             }
             Err(e)

--- a/autoendpoint/src/routes/webpush.rs
+++ b/autoendpoint/src/routes/webpush.rs
@@ -4,7 +4,6 @@ use crate::error::{ApiErrorKind, ApiResult};
 use crate::extractors::message_id::MessageId;
 use crate::extractors::notification::Notification;
 use crate::extractors::routers::{RouterType, Routers};
-use crate::extractors::user::drop_user;
 use crate::server::ServerState;
 use actix_web::web::Data;
 use actix_web::HttpResponse;
@@ -13,31 +12,14 @@ use actix_web::HttpResponse;
 pub async fn webpush_route(
     notification: Notification,
     routers: Routers,
-    state: Data<ServerState>,
+    _state: Data<ServerState>,
 ) -> ApiResult<HttpResponse> {
     let router = routers.get(
         RouterType::from_str(&notification.subscription.user.router_type)
             .map_err(|_| ApiErrorKind::InvalidRouterType)?,
     );
 
-    match router.route_notification(&notification).await {
-        Ok(v) => Ok(v.into()),
-        Err(e) => {
-            if !e.kind.user_still_valid() {
-                // The user record is no longer valid. We should remove it so that the client
-                // can attempt to recover. We don't care if this succeeds or fails at this point.
-                if drop_user(
-                    notification.subscription.user.uaid,
-                    state.ddb.as_ref(),
-                    &state.metrics,
-                )
-                .await
-                .is_ok()
-                {};
-            }
-            Err(e)
-        }
-    }
+    Ok(router.route_notification(&notification).await?.into())
 }
 
 /// Handle the `DELETE /m/{message_id}` route


### PR DESCRIPTION
This patch improves GCM handling, using recently discovered docs of the discontinued protocol. 

POST DEPLOY NOTE: 
There is currently an ignore in place for `Bridge authentication error` that will need to be removed.


Closes: #308