### PR TITLE
feat: Rename the connection server as "autoconnect"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ workflows:
           name: build-autopush
           image: autopush:build
           crate: autopush
-          binary: autopush_rs
+          binary: autoconnect
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,8 +205,8 @@ workflows:
             tags:
               only: /.*/
       - build:
-          name: build-autopush
-          image: autopush:build
+          name: build-autoconnect
+          image: autoconnect:build
           crate: autopush
           binary: autoconnect
           filters:
@@ -223,11 +223,11 @@ workflows:
               only: /.*/
 
       - deploy:
-          name: deploy-autopush
-          image: autopush:build
+          name: deploy-autoconnect
+          image: autoconnect:build
           repo: ${DOCKERHUB_REPO}
           requires:
-            - build-autopush
+            - build-autoconnect
             - test
           filters:
             tags:

--- a/autopush/Cargo.toml
+++ b/autopush/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 edition = "2021"
 
 [[bin]]
-name = "autopush_rs"
+name = "autoconnect"
 path = "src/main.rs"
 
 [dependencies]

--- a/tests/test_integration_all_rust.py
+++ b/tests/test_integration_all_rust.py
@@ -421,7 +421,7 @@ def process_logs(testcase):
     conn_count = sum(queue.qsize() for queue in CN_QUEUES)
     endpoint_count = sum(queue.qsize() for queue in EP_QUEUES)
 
-    print_lines_in_queues(CN_QUEUES, "AUTOPUSH: ")
+    print_lines_in_queues(CN_QUEUES, "AUTOCONNECT : ")
     print_lines_in_queues(EP_QUEUES, "AUTOENDPOINT: ")
 
     if not STRICT_LOG_COUNTS:
@@ -615,7 +615,7 @@ def setup_module():
 
     setup_mock_server()
 
-    connection_binary = get_rust_binary_path("autopush_rs")
+    connection_binary = get_rust_binary_path("autoconnect")
     setup_connection_server(connection_binary)
     setup_megaphone_server(connection_binary)
     setup_endpoint_server()


### PR DESCRIPTION
Change the confusingly named connection server from `autopush` to `autoconnect`

_QA_: Minor change in the test script to call the new exec and use a `AUTOCONNECT :` label.

## BREAKING CHANGE

The executable name for the autopush connection server is now `autoconnect`. Deployment scripts and configurations may need to be updated. 

Closes: #310