### PR TITLE
feat: Add timeouts for Client::reqwest calls [CONSVC-3289]

### DIFF
--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -24,6 +24,7 @@ use actix_web::{
 use cadence::StatsdClient;
 use fernet::MultiFernet;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct ServerState {
@@ -51,7 +52,11 @@ impl Server {
             settings.router_table_name.clone(),
             settings.message_table_name.clone(),
         )?);
-        let http = reqwest::Client::new();
+        let http = reqwest::ClientBuilder::new()
+            .connect_timeout(Duration::from_millis(settings.connection_timeout_millis))
+            .timeout(Duration::from_millis(settings.request_timeout_millis))
+            .build()
+            .expect("Could not generate request client");
         let fcm_router = Arc::new(
             FcmRouter::new(
                 settings.fcm.clone(),

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -27,6 +27,9 @@ pub struct Settings {
     pub auth_keys: String,
     pub human_logs: bool,
 
+    pub connection_timeout_millis: u64,
+    pub request_timeout_millis: u64,
+
     pub statsd_host: Option<String>,
     pub statsd_port: u16,
     pub statsd_label: String,
@@ -53,6 +56,8 @@ impl Default for Settings {
             crypto_keys: format!("[{}]", Fernet::generate_key()),
             auth_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]"#.to_string(),
             human_logs: false,
+            connection_timeout_millis: 1000,
+            request_timeout_millis: 3000,
             statsd_host: None,
             statsd_port: 8125,
             statsd_label: "autoendpoint".to_string(),


### PR DESCRIPTION
These are used for routing and the like.
Currently default for:

```
// Initial connection timeout
connection_timeout_millis: 1000
// Total request timeout
request_timeout_millis: 3000
```
Closes: #CONSVC-1632