### PR TITLE
fix: channel_id should be hyphenated

### DIFF
--- a/autopush-common/src/db/dynamodb/mod.rs
+++ b/autopush-common/src/db/dynamodb/mod.rs
@@ -291,7 +291,7 @@ impl DbClient for DdbClientImpl {
     ) -> DbResult<()> {
         let chids: Vec<String> = channel_list
             .into_iter()
-            .map(|v| v.simple().to_string())
+            .map(|v| v.as_hyphenated().to_string())
             .collect();
         let expiry = sec_since_epoch() + 2 * MAX_EXPIRY;
         let attr_values = hashmap! {


### PR DESCRIPTION
see remove_channel: it renders channel_id w/ Uuid::to_string (or via as_hyphenated in the old rust state machine db impl)

or autopush python's normalize_id: str(<uuid.UUID>)

SYNC-3444