### PR TITLE
fix: don't eat WebpushSocket poll_complete errors

### DIFF
--- a/autopush-common/src/errors.rs
+++ b/autopush-common/src/errors.rs
@@ -31,19 +31,9 @@ pub struct ApcError {
     pub backtrace: Box<Backtrace>,
 }
 
-// Print out the error and backtrace, including source errors
 impl Display for ApcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Error: {}\nBacktrace: \n{:?}", self.kind, self.backtrace)?;
-
-        // Go down the chain of errors
-        let mut error: &dyn std::error::Error = &self.kind;
-        while let Some(source) = error.source() {
-            write!(f, "\n\nCaused by: {source}")?;
-            error = source;
-        }
-
-        Ok(())
+        self.kind.fmt(f)
     }
 }
 

--- a/autopush/src/client.rs
+++ b/autopush/src/client.rs
@@ -638,6 +638,9 @@ where
         let error = if let Some(ref err) = error {
             let ua_info = ua_info.clone();
             let mut event = sentry::event_from_error(err);
+            event.exception.last_mut().unwrap().stacktrace =
+                sentry::integrations::backtrace::backtrace_to_stacktrace(&err.backtrace);
+
             event.user = Some(sentry::User {
                 id: Some(webpush.uaid.as_simple().to_string()),
                 ..Default::default()


### PR DESCRIPTION
instead check specifically for the harmless connection closed error and don't log it

also remove the stacktrace from ApcError::to_string, include it in the sentry event exception instead

Issue SYNC-3444