### PR TITLE
fix: disable sentry's debug-images feature

### DIFF
--- a/autoconnect/src/main.rs
+++ b/autoconnect/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
         release: sentry::release_name!(),
         session_mode: sentry::SessionMode::Request, // new session per request
         auto_session_tracking: true,
-        ..Default::default()
+        ..autopush_common::sentry::client_options()
     });
 
     let port = settings.port;

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let _sentry = sentry::init(sentry::ClientOptions {
         release: sentry::release_name!(),
         attach_stacktrace: true,
-        ..Default::default()
+        ..autopush_common::sentry::client_options()
     });
 
     // Run server...

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod errors;
 pub mod logging;
 pub mod metrics;
 pub mod notification;
-// pending actix 4:
+pub mod sentry;
 pub mod tags;
 
 #[macro_use]

--- a/autopush-common/src/sentry.rs
+++ b/autopush-common/src/sentry.rs
@@ -1,0 +1,10 @@
+/// Return a `sentry::::ClientOptions` w/ the `debug-images` integration
+/// disabled
+pub fn client_options() -> sentry::ClientOptions {
+    // debug-images conflicts w/ our debug = 1 rustc build option:
+    // https://github.com/getsentry/sentry-rust/issues/574
+    let mut opts = sentry::apply_defaults(sentry::ClientOptions::default());
+    opts.integrations.retain(|i| i.name() != "debug-images");
+    opts.default_integrations = false;
+    opts
+}

--- a/autopush/src/server/mod.rs
+++ b/autopush/src/server/mod.rs
@@ -89,7 +89,7 @@ impl AutopushServer {
                 dsn,
                 sentry::ClientOptions {
                     release: sentry::release_name!(),
-                    ..Default::default()
+                    ..autopush_common::sentry::client_options()
                 },
             ));
             /*


### PR DESCRIPTION
which produced errors when sentry ingests events

https://github.com/getsentry/sentry-rust/issues/574