### PR TITLE
feat: make DbClient's message table month optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,10 +1422,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "downcast"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
@@ -1703,15 +1703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding 2.2.0",
-]
-
-[[package]]
-name = "fragile"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7464c5c4a3f014d9b2ec4073650e5c06596f385060af740fc45ad5a19f959e8"
-dependencies = [
- "fragile 2.0.0",
 ]
 
 [[package]]
@@ -2698,13 +2689,13 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.8.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "downcast",
- "fragile 1.2.2",
+ "fragile",
  "lazy_static",
  "mockall_derive",
  "predicates",
@@ -2713,11 +2704,11 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.8.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "proc-macro2 1.0.59",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -2875,9 +2866,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2907,9 +2898,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -3137,12 +3128,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
- "difference",
+ "difflib",
  "float-cmp",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ httparse = "1.3"
 hyper = "0.14"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
-mockall = "0.8.3"  # 0.9+ requires reworking tests
+mockall = "0.11"
 mozsvc-common = "0.2"
 openssl = "0.10"
 rand = "0.8"

--- a/autoconnect/autoconnect-common/src/test_support.rs
+++ b/autoconnect/autoconnect-common/src/test_support.rs
@@ -20,9 +20,9 @@ pub const CURRENT_MONTH: &str = "message_2018_06";
 /// Return a simple MockDbClient that responds to hello (once) with a new uaid.
 pub fn hello_db() -> MockDbClient {
     let mut db = MockDbClient::new();
-    db.expect_message_table()
+    db.expect_rotating_message_table()
         .times(1)
-        .return_const(CURRENT_MONTH.to_owned());
+        .return_const(Some(CURRENT_MONTH));
     db
 }
 
@@ -37,9 +37,9 @@ pub fn hello_again_db(uaid: Uuid) -> MockDbClient {
             ..Default::default()
         }))
     });
-    db.expect_message_table()
+    db.expect_rotating_message_table()
         .times(1)
-        .return_const(CURRENT_MONTH.to_owned());
+        .return_const(Some(CURRENT_MONTH));
     db.expect_update_user().times(1).return_once(|_| Ok(()));
     db.expect_fetch_messages()
         .times(1)

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
@@ -256,32 +256,33 @@ pub async fn process_existing_user(
     app_state: &Arc<AppState>,
     user: &User,
 ) -> DbResult<Option<ClientFlags>> {
-    // TODO: current_month likely not applicable on BigTable. autoendpoint also
-    // has this code
-    let Some(ref current_month) = user.current_month else {
-        debug!("Missing `current_month` value, dropping user"; "user" => ?user);
-        app_state
-            .metrics
-            .incr_with_tags("ua.expiration")
-            .with_tag("errno", "104")
-            .send();
-        app_state.db.remove_user(&user.uaid).await?;
-        return Ok(None);
-    };
+    // TODO: if BigTable, can we assume the user is migrated at this point (so
+    // we wouldn't need to validate `current_month` is not None?)
+    if let Some(rotating_message_table) = app_state.db.rotating_message_table() {
+        let Some(ref current_month) = user.current_month else {
+            debug!("Missing `current_month` value, dropping user"; "user" => ?user);
+            app_state
+                .metrics
+                .incr_with_tags("ua.expiration")
+                .with_tag("errno", "104")
+                .send();
+            app_state.db.remove_user(&user.uaid).await?;
+            return Ok(None);
+        };
 
-    let message_table = app_state.db.message_table();
-    if current_month != message_table {
-        debug!("User is inactive, dropping user";
-            "db.message_table" => message_table,
-            "user.current_month" => current_month,
-            "user" => ?user);
-        app_state
-            .metrics
-            .incr_with_tags("ua.expiration")
-            .with_tag("errno", "105")
-            .send();
-        app_state.db.remove_user(&user.uaid).await?;
-        return Ok(None);
+        if current_month != rotating_message_table {
+            debug!("User is inactive, dropping user";
+                   "db.message_table" => rotating_message_table,
+                   "user.current_month" => current_month,
+                   "user" => ?user);
+            app_state
+                .metrics
+                .incr_with_tags("ua.expiration")
+                .with_tag("errno", "105")
+                .send();
+            app_state.db.remove_user(&user.uaid).await?;
+            return Ok(None);
+        }
     }
 
     let flags = ClientFlags {

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
@@ -136,7 +136,11 @@ impl UnidentifiedClient {
         // TODO: NOTE: A new User doesn't get a `set_last_connect()` (matching
         // the previous impl)
         let user = User {
-            current_month: Some(self.app_state.db.message_table().to_owned()),
+            current_month: self
+                .app_state
+                .db
+                .rotating_message_table()
+                .map(str::to_owned),
             node_id: Some(self.app_state.router_url.to_owned()),
             connected_at,
             ..Default::default()

--- a/autoconnect/autoconnect-ws/src/session.rs
+++ b/autoconnect/autoconnect-ws/src/session.rs
@@ -11,7 +11,7 @@ use crate::error::WSError;
 /// This takes `ServerMessage`s and returns `WSErrors` to ease integration and
 /// usage via mocking. `Binary` WebSocket messages aren't supported (as we
 /// don't use them).
-#[automock]
+#[automock] // must appear before #[async_trait]
 #[async_trait]
 pub trait Session {
     /// See [`actix_ws::Session::text`]

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -59,7 +59,7 @@ yup-oauth2 = "8.1"
 #ureq={ version="2.4", features=["json"] }
 
 [dev-dependencies]
-mockall = {version = "0.8.3"}  # 0.9+ requires reworking tests
+mockall.workspace = true
 mockito = "0.31"
 tempfile = "3.2.0"
 tokio = { workspace = true, features = ["fs", "macros"] }

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -38,7 +38,7 @@ pub async fn register_uaid_route(
     let user = User {
         router_type: path_args.router_type.to_string(),
         router_data: Some(router_data),
-        current_month: Some(app_state.db.message_table().to_string()),
+        current_month: app_state.db.rotating_message_table().map(str::to_owned),
         ..Default::default()
     };
     let channel_id = router_data_input.channel_id.unwrap_or_else(Uuid::new_v4);

--- a/autopush-common/src/db/mock.rs
+++ b/autopush-common/src/db/mock.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::ptr_arg)]
 
 use crate::db::client::DbClient;
+pub use crate::db::client::MockDbClient;
 use crate::db::error::DbResult;
 use crate::db::User;
 use crate::notification::Notification;
@@ -13,117 +14,52 @@ use uuid::Uuid;
 
 use super::client::FetchMessageResponse;
 
-// mockall currently has issues mocking async traits with #[automock], so we use
-// this workaround. See https://github.com/asomers/mockall/issues/75
-mockall::mock! {
-    pub DbClient {
-        fn add_user(&self, user: &User) -> DbResult<()>;
-
-        fn update_user(&self, user: &User) -> DbResult<()>;
-
-        fn get_user(&self, uaid: &Uuid) -> DbResult<Option<User>>;
-
-        fn remove_user(&self, uaid: &Uuid) -> DbResult<()>;
-
-        fn add_channel(&self, uaid: &Uuid, channel_id: &Uuid) -> DbResult<()>;
-
-        fn save_channels(&self, uaid: &Uuid, channel_list: HashSet<Uuid>, message_month: &str) -> DbResult<()>;
-
-        fn get_channels(&self, uaid: &Uuid) -> DbResult<HashSet<Uuid>>;
-
-        fn remove_channel(&self, uaid: &Uuid, channel_id: &Uuid) -> DbResult<bool>;
-
-        fn remove_node_id(&self, uaid: &Uuid, node_id: &str, connected_at: u64) -> DbResult<()>;
-
-        fn save_message(&self, uaid: &Uuid, message: Notification) -> DbResult<()>;
-
-        fn save_messages(
-            &self,
-            uaid: &Uuid,
-            messages: Vec<Notification>,
-        ) -> DbResult<()>;
-
-        fn fetch_messages(&self, uaid: &Uuid, limit: usize) -> DbResult<FetchMessageResponse>;
-
-        fn fetch_timestamp_messages(
-            &self,
-            uaid: &Uuid,
-            timestamp: Option<u64>,
-            limit: usize,
-        ) -> DbResult<FetchMessageResponse>;
-
-        fn increment_storage(&self, uaid: &Uuid, timestamp: u64) -> DbResult<()>;
-
-        fn remove_message(&self, uaid: &Uuid, sort_key: &str) -> DbResult<()>;
-
-        fn router_table_exists(&self) -> DbResult<bool>;
-
-        fn message_table_exists(&self) -> DbResult<bool>;
-
-        fn message_table(&self) -> &str;
-
-        fn box_clone(&self) -> Box<dyn DbClient>;
-    }
-}
-
 #[async_trait]
 impl DbClient for Arc<MockDbClient> {
     async fn add_user(&self, user: &User) -> DbResult<()> {
-        Arc::as_ref(self).add_user(user)
+        Arc::as_ref(self).add_user(user).await
     }
 
     async fn update_user(&self, user: &User) -> DbResult<()> {
-        Arc::as_ref(self).update_user(user)
+        Arc::as_ref(self).update_user(user).await
     }
 
     async fn get_user(&self, uaid: &Uuid) -> DbResult<Option<User>> {
-        Arc::as_ref(self).get_user(uaid)
+        Arc::as_ref(self).get_user(uaid).await
     }
 
     async fn remove_user(&self, uaid: &Uuid) -> DbResult<()> {
-        Arc::as_ref(self).remove_user(uaid)
+        Arc::as_ref(self).remove_user(uaid).await
     }
 
     async fn add_channel(&self, uaid: &Uuid, channel_id: &Uuid) -> DbResult<()> {
-        Arc::as_ref(self).add_channel(uaid, channel_id)
-    }
-
-    async fn save_channels(
-        &self,
-        uaid: &Uuid,
-        channel_list: HashSet<&Uuid>,
-        message_month: &str,
-    ) -> DbResult<()> {
-        // because `HashSet<&Uuid>` is not an iterator, so `.map()` doesn't work.`
-        let mut clist: HashSet<Uuid> = HashSet::new();
-        for v in channel_list {
-            clist.insert(*v);
-        }
-        Arc::as_ref(self).save_channels(uaid, clist, message_month)
+        Arc::as_ref(self).add_channel(uaid, channel_id).await
     }
 
     async fn get_channels(&self, uaid: &Uuid) -> DbResult<HashSet<Uuid>> {
-        Arc::as_ref(self).get_channels(uaid)
+        Arc::as_ref(self).get_channels(uaid).await
     }
 
     async fn remove_channel(&self, uaid: &Uuid, channel_id: &Uuid) -> DbResult<bool> {
-        Arc::as_ref(self).remove_channel(uaid, channel_id)
+        Arc::as_ref(self).remove_channel(uaid, channel_id).await
     }
 
     async fn remove_node_id(&self, uaid: &Uuid, node_id: &str, connected_at: u64) -> DbResult<()> {
-        Arc::as_ref(self).remove_node_id(uaid, node_id, connected_at)
+        Arc::as_ref(self)
+            .remove_node_id(uaid, node_id, connected_at)
+            .await
     }
 
     async fn save_message(&self, uaid: &Uuid, message: Notification) -> DbResult<()> {
-        Arc::as_ref(self).save_message(uaid, message)
+        Arc::as_ref(self).save_message(uaid, message).await
     }
 
     async fn save_messages(&self, uaid: &Uuid, messages: Vec<Notification>) -> DbResult<()> {
-        Arc::as_ref(self).save_messages(uaid, messages)
+        Arc::as_ref(self).save_messages(uaid, messages).await
     }
 
     async fn fetch_messages(&self, uaid: &Uuid, limit: usize) -> DbResult<FetchMessageResponse> {
-        Arc::as_ref(self).fetch_messages(uaid, limit)
+        Arc::as_ref(self).fetch_messages(uaid, limit).await
     }
 
     async fn fetch_timestamp_messages(
@@ -132,27 +68,29 @@ impl DbClient for Arc<MockDbClient> {
         timestamp: Option<u64>,
         limit: usize,
     ) -> DbResult<FetchMessageResponse> {
-        Arc::as_ref(self).fetch_timestamp_messages(uaid, timestamp, limit)
+        Arc::as_ref(self)
+            .fetch_timestamp_messages(uaid, timestamp, limit)
+            .await
     }
 
     async fn increment_storage(&self, uaid: &Uuid, timestamp: u64) -> DbResult<()> {
-        Arc::as_ref(self).increment_storage(uaid, timestamp)
+        Arc::as_ref(self).increment_storage(uaid, timestamp).await
     }
 
     async fn remove_message(&self, uaid: &Uuid, sort_key: &str) -> DbResult<()> {
-        Arc::as_ref(self).remove_message(uaid, sort_key)
+        Arc::as_ref(self).remove_message(uaid, sort_key).await
     }
 
     async fn router_table_exists(&self) -> DbResult<bool> {
-        Arc::as_ref(self).router_table_exists()
+        Arc::as_ref(self).router_table_exists().await
     }
 
     async fn message_table_exists(&self) -> DbResult<bool> {
-        Arc::as_ref(self).message_table_exists()
+        Arc::as_ref(self).message_table_exists().await
     }
 
-    fn message_table(&self) -> &str {
-        Arc::as_ref(self).message_table()
+    fn rotating_message_table(&self) -> Option<&str> {
+        Arc::as_ref(self).rotating_message_table()
     }
 
     fn box_clone(&self) -> Box<dyn DbClient> {


### PR DESCRIPTION
(for BigTable)

also:
- kill save_channels (only needed by legacy autoconnect)
- update mockall/cleanup old workaround
- update openssl per RUSTSEC-2023-0044

SYNC-3449