### PR TITLE
fix: remove mozsvc-common

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   audit:
     docker:
-      - image: rust:latest
+      - image: rust:1.70
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "futures 0.3.28",
  "futures-backoff",
  "futures-util",
+ "gethostname",
  "hex",
  "httparse",
  "hyper 0.14.26",
@@ -794,7 +795,6 @@ dependencies = [
  "log",
  "mockall",
  "mockito",
- "mozsvc-common",
  "openssl",
  "rand 0.8.5",
  "regex",
@@ -1898,6 +1898,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.68-buster as builder
+# NOTE: Ensure builder's Rust version matches CI's in .circleci/config.yml
+FROM rust:1.70-buster as builder
 ARG CRATE
 
 ADD . /app

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -55,8 +55,8 @@ url.workspace = true
 
 again = "0.1"
 async-trait = "0.1"
+gethostname = "0.4"
 futures-backoff = "0.1.0"
-mozsvc-common = "0.2"
 woothee = "0.13"
 
 [dev-dependencies]


### PR DESCRIPTION
its older get_ec2_instance_id isn't compat w/ modern tokio (and the crate's deprecated)

SYNC-3449