### PR TITLE
feat: Topic messages shouldn't have sortkey_timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
@@ -370,11 +370,12 @@ mod tests {
 
     use autoconnect_common::{
         protocol::{ClientMessage, ServerMessage, ServerNotification},
-        test_support::{DUMMY_UAID, UA},
+        test_support::{DUMMY_CHID, DUMMY_UAID, UA},
     };
     use autoconnect_settings::AppState;
     use autopush_common::{
         db::{client::FetchMessageResponse, mock::MockDbClient},
+        notification::Notification,
         util::{ms_since_epoch, sec_since_epoch},
     };
 
@@ -392,6 +393,17 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    /// Generate a dummy timestamp `Notification`
+    fn new_timestamp_notif(channel_id: &Uuid, ttl: u64) -> Notification {
+        Notification {
+            channel_id: *channel_id,
+            ttl,
+            timestamp: sec_since_epoch(),
+            sortkey_timestamp: Some(ms_since_epoch()),
+            ..Default::default()
+        }
     }
 
     #[actix_rt::test]
@@ -424,7 +436,10 @@ mod tests {
             .return_once(move |_, _, _| {
                 Ok(FetchMessageResponse {
                     timestamp: Some(timestamp),
-                    messages: vec![Default::default(), Default::default()],
+                    messages: vec![
+                        new_timestamp_notif(&DUMMY_CHID, 0),
+                        new_timestamp_notif(&DUMMY_CHID, 0),
+                    ],
                 })
             });
         // EOF

--- a/autoconnect/src/main.rs
+++ b/autoconnect/src/main.rs
@@ -55,18 +55,6 @@ async fn main() -> Result<()> {
     logging::init_logging(!settings.human_logs).expect("Logging failed to initialize");
     debug!("Starting up...");
 
-    //TODO: Eventually this will match between the various storage engines that
-    // we support. For now, it's just the one, DynamoDB.
-    // Perform any app global storage initialization.
-    match autopush_common::db::StorageType::from_dsn(&settings.db_dsn) {
-        autopush_common::db::StorageType::DynamoDb => {
-            env::set_var("AWS_LOCAL_DYNAMODB", settings.db_dsn.clone().unwrap())
-        }
-        autopush_common::db::StorageType::INVALID => {
-            panic!("Invalid Storage type. Check DB_DSN.");
-        }
-    }
-
     // Sentry requires the environment variable "SENTRY_DSN".
     if env::var("SENTRY_DSN")
         .unwrap_or_else(|_| "".to_owned())

--- a/autoendpoint/src/extractors/notification.rs
+++ b/autoendpoint/src/extractors/notification.rs
@@ -93,14 +93,16 @@ impl FromRequest for Notification {
 
 impl From<Notification> for autopush_common::notification::Notification {
     fn from(notification: Notification) -> Self {
+        let topic = notification.headers.topic.clone();
+        let sortkey_timestamp = topic.is_none().then_some(notification.sort_key_timestamp);
         autopush_common::notification::Notification {
             channel_id: notification.subscription.channel_id,
             version: notification.message_id,
             ttl: notification.headers.ttl as u64,
-            topic: notification.headers.topic.clone(),
+            topic,
             timestamp: notification.timestamp,
             data: notification.data,
-            sortkey_timestamp: Some(notification.sort_key_timestamp),
+            sortkey_timestamp,
             headers: {
                 let headers: HashMap<String, String> = notification.headers.into();
                 if headers.is_empty() {

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -57,11 +57,6 @@ impl Server {
                 settings.db_settings.clone()
             },
         };
-        // NOTE: Eventually, this should use a `*_DB_DSN` setting to indicate the database storage
-        // location and method. Existing versions of Autopush do not specify this, but instead
-        // rely on either the environment variable `AWS_LOCAL_DYNAMODB` or fall back to the
-        // rusoto_core::Region::default(), which complicates things.
-        // `StorageType::from_dsn` is very preferential toward DynamoDB.
         let db: Box<dyn DbClient> = match StorageType::from_dsn(&db_settings.dsn) {
             StorageType::DynamoDb => Box::new(DdbClientImpl::new(metrics.clone(), &db_settings)?),
             StorageType::INVALID => {


### PR DESCRIPTION
- fix autoconnect's db initialization to match autoendpoint's (don't panic when no DB_DSN is set)

- don't unnecessarily remove expired messages in a background task during check storage

SYNC-3777
SYNC-3809