### PR TITLE
fix: load test script modifies kubernetes config on first run only

### DIFF
--- a/tests/load/kubernetes-config/locust-master-controller.yml
+++ b/tests/load/kubernetes-config/locust-master-controller.yml
@@ -20,20 +20,22 @@ spec:
           env:
             - name: LOCUST_MODE_MASTER
               value: "true"
+            - name: TARGET_HOST
+              value:
             - name: LOCUST_CSV
-              value: [LOCUST_CSV]
+              value:
             - name: LOCUST_USERS
-              value: "[LOCUST_USERS]"
+              value:
             - name: LOCUST_SPAWN_RATE
-              value: "[LOCUST_SPAWN_RATE]"
+              value:
             - name: LOCUST_RUN_TIME
-              value: "[LOCUST_RUN_TIME]"
+              value:
             - name: LOCUST_LOGLEVEL
-              value: [LOCUST_LOGLEVEL]
+              value:
             - name: SERVER_URL
-              value: [SERVER_URL]
+              value:
             - name: ENDPOINT_URL
-              value: [ENDPOINT_URL]
+              value:
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/tests/load/kubernetes-config/locust-worker-controller.yml
+++ b/tests/load/kubernetes-config/locust-worker-controller.yml
@@ -22,9 +22,11 @@ spec:
               value: "true"
             - name: LOCUST_MASTER_NODE_HOST
               value: locust-master
+            - name: TARGET_HOST
+              value:
             - name: LOCUST_LOGLEVEL
-              value: [LOCUST_LOGLEVEL]
+              value:
             - name: SERVER_URL
-              value: [SERVER_URL]
+              value:
             - name: ENDPOINT_URL
-              value: [ENDPOINT_URL]                          
+              value:


### PR DESCRIPTION
- Improve load test setup script by using patterns fixed on constants instead of placeholders
- Add kubernetes target (was causing an error)

[SYNC-3834](https://mozilla-hub.atlassian.net/browse/SYNC-3834)