### PR TITLE
feat: switch the load tester to pypy-3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/sh
 CARGO = cargo
 LOAD_TEST_DIR := tests/load
 POETRY := poetry --directory $(LOAD_TEST_DIR)
+DOCKER_COMPOSE := docker compose
 PYPROJECT_TOML := $(LOAD_TEST_DIR)/pyproject.toml
 FLAKE8_CONFIG := $(LOAD_TEST_DIR)/.flake8
 STAGE_SERVER_URL := "wss://autopush.stage.mozaws.net"
@@ -29,13 +30,13 @@ lint:
 
 load:
 	SERVER_URL=$(STAGE_SERVER_URL) ENDPOINT_URL=$(STAGE_ENDPOINT_URL) \
-	  docker compose \
+	  $(DOCKER_COMPOSE) \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p autopush-rs-load-tests \
       up --scale locust_worker=1
 
 load-clean:
-	docker-compose \
+	$(DOCKER_COMPOSE) \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p autopush-rs-load-tests \
       down

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 
 load:
 	SERVER_URL=$(STAGE_SERVER_URL) ENDPOINT_URL=$(STAGE_ENDPOINT_URL) \
-	  docker-compose \
+	  docker compose \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p autopush-rs-load-tests \
       up --scale locust_worker=1

--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -1,14 +1,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM python:3.11-slim
+FROM pypy:3.10-slim-bookworm
 
 LABEL org.opencontainers.image.authors="contextual-services-team@mozilla.com"
 
 # Add gcc since there are no wheels for some packages for arm64/aarch64
+# (g++/make for gevent on pypy)
 RUN apt-get update && apt-get install -y git && \
   if [ -n "$(arch | grep 'arm64\|aarch64')" ]; then \
-    apt install -y --no-install-recommends gcc python3-dev; \
+    apt install -y --no-install-recommends gcc g++ make python3-dev; \
   fi
 
 ENV LANG=C.UTF-8

--- a/tests/load/pyproject.toml
+++ b/tests/load/pyproject.toml
@@ -6,7 +6,7 @@ profile = "black"
 skip_gitignore = true
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 disable_error_code = "attr-defined"
 disallow_untyped_calls = false
 follow_imports = "normal"


### PR DESCRIPTION
SYNC-3874

Here's a draft of using pypy. This seems to work locally for me via `make load`, running a 10k user load test w/ 10 per second ramp up against stage (however I was only seeing =~ 2k Autoconnect total connections established on grafana for some reason).