### PR TITLE
test: adjustments and fixes found during debug of SYNC-3846

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -43,10 +43,11 @@ Follow the steps bellow to execute the load tests locally:
 Environment variables, listed bellow or specified by [Locust][11], can be set in
 `tests\load\docker-compose.yml`.
 
-| Environment Variable | Node(s)          | Description                     |
-|----------------------|------------------|---------------------------------|
-| SERVER_URL           | master & worker  | The autopush web socket address |
-| ENDPOINT_URL         | master & worker  | The autopush HTTP address       |
+| Environment Variable | Node(s)         | Description                          |
+|----------------------|-----------------|--------------------------------------|
+| SERVER_URL           | master & worker | The autopush web socket address      |
+| ENDPOINT_URL         | master & worker | The autopush HTTP address            |
+| AUTOPUSH_WAIT_TIME   | master & worker | The wait time between task execution |
 
 #### 2. Host Locust via Docker
 
@@ -173,7 +174,11 @@ the load test will stop automatically.
 
 **Exceptions**
 
-* The number of exceptions raised by the test framework should be `0`
+* Exceptions indicate errors that occur during Locust's execution of the load tests and
+  should be minimal.
+* The following exceptions are known to happen, but make sure their occurrence isn't 
+  trending positively:
+    * ZeroStatusRequestError
 * Locust reports Exceptions via the "autopush_exceptions.csv" file and the UI
   (under the "Exceptions" tab)
 

--- a/tests/load/locustfiles/args.py
+++ b/tests/load/locustfiles/args.py
@@ -1,12 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from locust import between, constant
 
 
 def parse_wait_time(val: str):
     """Parse a wait_time
 
-    Either a single numeric (for `constant`) or two separated by a
-    comma (arguments to `between`)
-
+    Either a single numeric (for `constant`) or two separated by a comma (arguments to `between`)
     """
     match val.count(","):
         case 0:
@@ -18,5 +20,5 @@ def parse_wait_time(val: str):
 
 
 def float_or_int(val: str):
-    val = str(float(val))
-    return val
+    float_val: float = float(val)
+    return int(float_val) if float_val.is_integer() else float_val

--- a/tests/load/locustfiles/exceptions.py
+++ b/tests/load/locustfiles/exceptions.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+class ZeroStatusRequestError(Exception):
+    """Custom exception for when a Locust request fails with a '0' status code."""
+
+    def __init__(self):
+        error_message: str = (
+            "A connection, timeout or similar error happened while sending a request "
+            "from Locust. Status Code: 0"
+        )
+        super().__init__(error_message)

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -44,7 +44,9 @@ class AutopushLoadTestShape(LoadTestShape):
     """
 
     MAX_RUN_TIME: int = 600  # 10 minutes
-    MAX_USERS: int = 83300  # Calculation: 700 users * 119 locust workers (defined in setup_k8s.sh)
+    WORKER_COUNT: int = 119  # Must match value defined in setup_k8s.sh
+    USERS_PER_WORKER: int = 350  # Number of users supported on a worker running on a n1-standard-4
+    MAX_USERS: int = WORKER_COUNT * USERS_PER_WORKER
     trend: QuadraticTrend
     user_classes: list[Type[User]] = [AutopushUser]
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -117,6 +117,9 @@ class AutopushUser(FastHttpUser):
             + "=="
         )
 
+    def wait_time(self):
+        return self.environment.autopush_wait_time(self)
+
     def on_start(self) -> Any:
         self.connect()
         if not self.ws:
@@ -141,7 +144,7 @@ class AutopushUser(FastHttpUser):
         self.ws = create_connection(
             self.environment.parsed_options.websocket_url,
             header={"Origin": "http://localhost:1337"},
-            timeout=1,
+            timeout=30,  # timeout defaults to None
         )
 
     def disconnect(self) -> None:

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -48,7 +48,7 @@ def _(parser: Any):
         type=str,
         env_var="AUTOPUSH_WAIT_TIME",
         help="AutopushUser wait time between tasks",
-        default="120, 125",
+        default="60, 65",
     )
 
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -48,7 +48,7 @@ def _(parser: Any):
         type=str,
         env_var="AUTOPUSH_WAIT_TIME",
         help="AutopushUser wait time between tasks",
-        default="60, 65",
+        default="30, 35",
     )
 
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -75,13 +75,10 @@ class TimeEvent:
         if args[0] is not None:
             exception_type = args[0]
             exception_value = args[1]
-            traceback = args[2]
+            # traceback = args[2]
 
             if not isinstance(exception_value, (AssertionError, ValidationError)):
-                # An unexpected exception occurred log an exception and stop the user.
-                self.user.environment.events.user_error.fire(
-                    user_instance=self.user.context(), exception=exception_value, tb=traceback
-                )
+                # An unexpected exception occurred stop the user.
                 self.user.stop()
                 return None
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -48,7 +48,7 @@ def _(parser: Any):
         type=str,
         env_var="AUTOPUSH_WAIT_TIME",
         help="AutopushUser wait time between tasks",
-        default="30, 35",
+        default="20, 25",
     )
 
 


### PR DESCRIPTION
Adjustments and Fixes as discussed during code pairing on 2023/09/15

- remove notification_type command line argument in favour of distinct tasks for sending stored or direct messages
- use user.stop() instead of StopUser exception and stop the user if any exception other than the expected AssertionError or ValidationError is raised during task execution
- log an exception and stop the user in the event that Locust fails to post a notification
- log send and recv WSS calls separately
- fix wait time command argument
- calibrate load tests (350 users/worker 20-25 task wait time)
- update README