### PR TITLE
bug: Add better error messaging for GCM/FCM processing

### DIFF
--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -343,6 +343,14 @@ impl ReportableError for ApiError {
     fn metric_label(&self) -> Option<&'static str> {
         self.kind.metric_label()
     }
+
+    fn extras(&self) -> Vec<(&str, String)> {
+        match &self.kind {
+            ApiErrorKind::Router(e) => e.extras(),
+            ApiErrorKind::LogCheck => vec![("coffee", "Unsupported".to_owned())],
+            _ => vec![],
+        }
+    }
 }
 
 /// Get the error number from validation errors. If multiple errors are present,

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -238,10 +238,17 @@ impl FcmClient {
         // Handle error
         let status = response.status();
         if status.is_client_error() || status.is_server_error() {
-            let data: FcmResponse = response
-                .json()
+            let raw_data = response
+                .bytes()
                 .await
                 .map_err(FcmError::DeserializeResponse)?;
+            if raw_data.is_empty() {
+                return Err(FcmError::EmptyResponse.into());
+            }
+            let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
+                let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                FcmError::InvalidResponse(e, s)
+            })?;
 
             // we only ever send one.
             return Err(match (status, data.error) {

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -159,7 +159,7 @@ impl FcmClient {
             .await
             .map_err(FcmError::DeserializeResponse)?;
         if raw_data.is_empty() {
-            return Err(FcmError::EmptyResponse.into());
+            return Err(FcmError::EmptyResponse(status).into());
         }
         let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
             let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
@@ -252,7 +252,7 @@ impl FcmClient {
                 .await
                 .map_err(FcmError::DeserializeResponse)?;
             if raw_data.is_empty() {
-                return Err(FcmError::EmptyResponse.into());
+                return Err(FcmError::EmptyResponse(status).into());
             }
             let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
                 let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -163,6 +163,7 @@ impl FcmClient {
         }
         let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
             let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+            warn!("gcm response error: [{:?}] ({:?})", &status, &s);
             FcmError::InvalidResponse(e, s, status)
         })?;
 
@@ -255,6 +256,7 @@ impl FcmClient {
             }
             let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
                 let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                warn!("fcm response error: [{:?}] ({:?})", &status, &s);
                 FcmError::InvalidResponse(e, s, status)
             })?;
 

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -154,16 +154,17 @@ impl FcmClient {
 
         // Handle error
         let status = response.status();
-        let raw_data = response.bytes().await
+        let raw_data = response
+            .bytes()
+            .await
             .map_err(FcmError::DeserializeResponse)?;
         if raw_data.is_empty() {
-            return Err(FcmError::EmptyResponse.into())
+            return Err(FcmError::EmptyResponse.into());
         }
-        let data: GcmResponse = serde_json::from_slice(&raw_data)
-            .map_err(|e| {
-                let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-                FcmError::InvalidResponse(e, s, status)
-            })?;
+        let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
+            let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+            FcmError::InvalidResponse(e, s, status)
+        })?;
 
         if status.is_client_error() || status.is_server_error() || data.failure > 0 {
             let invalid = GcmResult::invalid();
@@ -245,16 +246,17 @@ impl FcmClient {
         // Handle error
         let status = response.status();
         if status.is_client_error() || status.is_server_error() {
-            let raw_data = response.bytes().await
+            let raw_data = response
+                .bytes()
+                .await
                 .map_err(FcmError::DeserializeResponse)?;
             if raw_data.is_empty() {
-                return Err(FcmError::EmptyResponse.into())
+                return Err(FcmError::EmptyResponse.into());
             }
-            let data: FcmResponse = serde_json::from_slice(&raw_data)
-                .map_err(|e| {
-                    let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-                    FcmError::InvalidResponse(e, s, status)
-                })?;
+            let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
+                let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                FcmError::InvalidResponse(e, s, status)
+            })?;
 
             // we only ever send one.
             return Err(match (status, data.error) {

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -163,7 +163,6 @@ impl FcmClient {
         }
         let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
             let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-            warn!("gcm response error: [{:?}] ({:?})", &status, &s);
             FcmError::InvalidResponse(e, s, status)
         })?;
 
@@ -256,7 +255,6 @@ impl FcmClient {
             }
             let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
                 let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-                warn!("fcm response error: [{:?}] ({:?})", &status, &s);
                 FcmError::InvalidResponse(e, s, status)
             })?;
 

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -154,10 +154,17 @@ impl FcmClient {
 
         // Handle error
         let status = response.status();
-        let data: GcmResponse = response
-            .json()
-            .await
+        let raw_data = response.bytes().await
             .map_err(FcmError::DeserializeResponse)?;
+        if raw_data.is_empty() {
+            return Err(FcmError::EmptyResponse.into())
+        }
+        let data: GcmResponse = serde_json::from_slice(&raw_data)
+            .map_err(|e| {
+                let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                FcmError::InvalidResponse(e, s, status)
+            })?;
+
         if status.is_client_error() || status.is_server_error() || data.failure > 0 {
             let invalid = GcmResult::invalid();
             return Err(
@@ -238,17 +245,16 @@ impl FcmClient {
         // Handle error
         let status = response.status();
         if status.is_client_error() || status.is_server_error() {
-            let raw_data = response
-                .bytes()
-                .await
+            let raw_data = response.bytes().await
                 .map_err(FcmError::DeserializeResponse)?;
             if raw_data.is_empty() {
-                return Err(FcmError::EmptyResponse.into());
+                return Err(FcmError::EmptyResponse.into())
             }
-            let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
-                let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-                FcmError::InvalidResponse(e, s)
-            })?;
+            let data: FcmResponse = serde_json::from_slice(&raw_data)
+                .map_err(|e| {
+                    let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                    FcmError::InvalidResponse(e, s, status)
+                })?;
 
             // we only ever send one.
             return Err(match (status, data.error) {

--- a/autoendpoint/src/routers/fcm/error.rs
+++ b/autoendpoint/src/routers/fcm/error.rs
@@ -18,7 +18,7 @@ pub enum FcmError {
     DeserializeResponse(#[source] reqwest::Error),
 
     #[error("Invalid JSON response from FCM")]
-    InvalidResponse(#[source] serde_json::Error, String),
+    InvalidResponse(#[source] serde_json::Error, String, StatusCode),
 
     #[error("Empty response from FCM")]
     EmptyResponse,
@@ -51,7 +51,7 @@ impl FcmError {
 
             FcmError::DeserializeResponse(_)
             | FcmError::EmptyResponse
-            | FcmError::InvalidResponse(_, _) => StatusCode::BAD_GATEWAY,
+            | FcmError::InvalidResponse(_, _, _) => StatusCode::BAD_GATEWAY,
         }
     }
 
@@ -67,7 +67,7 @@ impl FcmError {
             | FcmError::OAuthToken(_)
             | FcmError::DeserializeResponse(_)
             | FcmError::EmptyResponse
-            | FcmError::InvalidResponse(_, _)
+            | FcmError::InvalidResponse(_, _, _)
             | FcmError::NoOAuthToken => None,
         }
     }

--- a/autoendpoint/src/routers/fcm/error.rs
+++ b/autoendpoint/src/routers/fcm/error.rs
@@ -17,6 +17,12 @@ pub enum FcmError {
     #[error("Unable to deserialize FCM response")]
     DeserializeResponse(#[source] reqwest::Error),
 
+    #[error("Invalid JSON response from FCM")]
+    InvalidResponse(#[source] serde_json::Error, String),
+
+    #[error("Empty response from FCM")]
+    EmptyResponse,
+
     #[error("No OAuth token was present")]
     NoOAuthToken,
 
@@ -43,7 +49,9 @@ impl FcmError {
             | FcmError::OAuthToken(_)
             | FcmError::NoOAuthToken => StatusCode::INTERNAL_SERVER_ERROR,
 
-            FcmError::DeserializeResponse(_) => StatusCode::BAD_GATEWAY,
+            FcmError::DeserializeResponse(_)
+            | FcmError::EmptyResponse
+            | FcmError::InvalidResponse(_, _) => StatusCode::BAD_GATEWAY,
         }
     }
 
@@ -58,6 +66,8 @@ impl FcmError {
             | FcmError::OAuthClientBuild(_)
             | FcmError::OAuthToken(_)
             | FcmError::DeserializeResponse(_)
+            | FcmError::EmptyResponse
+            | FcmError::InvalidResponse(_, _)
             | FcmError::NoOAuthToken => None,
         }
     }

--- a/autoendpoint/src/routers/mod.rs
+++ b/autoendpoint/src/routers/mod.rs
@@ -203,4 +203,11 @@ impl RouterError {
             _ => true,
         }
     }
+
+    pub fn extras(&self) -> Vec<(&str, String)> {
+        match self {
+            RouterError::Fcm(e) => e.extras(),
+            _ => vec![],
+        }
+    }
 }

--- a/autopush-common/src/errors.rs
+++ b/autopush-common/src/errors.rs
@@ -194,6 +194,17 @@ pub trait ReportableError: std::error::Error + fmt::Display {
     /// Errors that don't emit Sentry events (!is_sentry_event()) emit an
     /// increment metric instead with this label
     fn metric_label(&self) -> Option<&'static str>;
+
+    /// Experimental: return tag key value pairs for metrics and Sentry
+    fn tags(&self) -> Vec<(&str, String)> {
+        vec![]
+    }
+
+    /// Experimental: return key value pairs for Sentry Event's extra data
+    /// TODO: should probably return Vec<(&str, Value)> or Vec<(String, Value)>
+    fn extras(&self) -> Vec<(&str, String)> {
+        vec![]
+    }
 }
 
 impl ReportableError for ApcError {


### PR DESCRIPTION
Attempt to determine the cause of the JSON parse fail for GCM messages

Issue: SYNC-3931