### PR TITLE
fix: don't emit backtraces in Display

### DIFF
--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -262,19 +262,9 @@ impl ApiErrorKind {
     }
 }
 
-// Print out the error and backtrace, including source errors
 impl Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Error: {}\nBacktrace: \n{:?}", self.kind, self.backtrace)?;
-
-        // Go down the chain of errors
-        let mut error: &dyn Error = &self.kind;
-        while let Some(source) = error.source() {
-            write!(f, "\n\nCaused by: {source}")?;
-            error = source;
-        }
-
-        Ok(())
+        self.kind.fmt(f)
     }
 }
 


### PR DESCRIPTION
as sentry renders these as the exception value