### PR TITLE
bug: Use `warn!()` 

### DIFF
--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -159,10 +159,12 @@ impl FcmClient {
             .await
             .map_err(FcmError::DeserializeResponse)?;
         if raw_data.is_empty() {
+            warn!("Empty GCM response [{status}]");
             return Err(FcmError::EmptyResponse(status).into());
         }
         let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
             let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+            warn!("Invalid GCM response [{status}], \"{s}\"");
             FcmError::InvalidResponse(e, s, status)
         })?;
 
@@ -251,10 +253,12 @@ impl FcmClient {
                 .await
                 .map_err(FcmError::DeserializeResponse)?;
             if raw_data.is_empty() {
+                warn!("Empty FCM response [{status}]");
                 return Err(FcmError::EmptyResponse(status).into());
             }
             let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
                 let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
+                warn!("Invalid FCM response [{status}] \"{s}\"");
                 FcmError::InvalidResponse(e, s, status)
             })?;
 


### PR DESCRIPTION
supplement sentry errors, since they don't show up regularly.