### PR TITLE
feat: Run GCM through FCMv1 HTTP API

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,5 @@ ignore = [
     "RUSTSEC-2021-0124", # Bound by tokio restrictions, rusoto, reqwest, hyper...
     "RUSTSEC-2023-0034", # Bound by Rusoto 0.42, Reqwest 0.9, a2 0.5 requiring Hyper 0.12
     "RUSTSEC-2023-0052", # Bound by Rusoto 0.47, Rustls 0.20, hyper-rustls 0.22, a2 0.8
+    "RUSTSEC-2023-0065", # Bound by tokio-tungstenite
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,14 +20,15 @@ dependencies = [
 
 [[package]]
 name = "actix"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
+checksum = "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
 dependencies = [
+ "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 1.3.2",
- "bytes 1.4.0",
+ "bitflags 2.4.0",
+ "bytes 1.5.0",
  "crossbeam-channel",
  "futures-core",
  "futures-sink",
@@ -37,7 +38,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.13",
- "smallvec 1.11.0",
+ "smallvec 1.11.1",
  "tokio 1.32.0",
  "tokio-util",
 ]
@@ -49,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
 dependencies = [
  "bitflags 1.3.2",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "futures-core",
  "futures-sink",
  "memchr",
@@ -71,24 +72,24 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "smallvec 1.11.0",
+ "smallvec 1.11.1",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash 0.8.3",
- "base64 0.21.3",
- "bitflags 1.3.2",
+ "base64 0.21.4",
+ "bitflags 2.4.0",
  "brotli",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "bytestring",
  "derive_more",
  "encoding_rs",
@@ -106,7 +107,7 @@ dependencies = [
  "pin-project-lite 0.2.13",
  "rand 0.8.5",
  "sha1",
- "smallvec 1.11.0",
+ "smallvec 1.11.1",
  "tokio 1.32.0",
  "tokio-util",
  "tracing",
@@ -126,7 +127,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "awc",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "futures-core",
  "http 0.2.9",
  "log",
@@ -145,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -184,7 +185,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio 0.8.8",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio 1.32.0",
  "tracing",
 ]
@@ -202,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "actix-test"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c7d37a955bfa3ccde83c12bc8987262abaf6c90ae9dd24fcdbd78c6c01ffaf"
+checksum = "2173910d0c7d0a21730d3e1304576d9c969eead2b91f3257a7435f7face702e0"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -225,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70bd48b6604191a700372f60bdc997db560eff5e4d41a7f00664390b5228b38"
+checksum = "72616e7fbec0aa99c6f3164677fa48ff5a60036d0799c98cab894a44f3e0efc3"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -236,6 +237,8 @@ dependencies = [
  "http 0.2.9",
  "impl-more",
  "pin-project-lite 0.2.13",
+ "rustls 0.21.7",
+ "rustls-webpki",
  "tokio 1.32.0",
  "tokio-util",
  "tracing",
@@ -253,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -266,8 +269,8 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
- "bytes 1.4.0",
+ "ahash 0.8.3",
+ "bytes 1.5.0",
  "bytestring",
  "cfg-if 1.0.0",
  "cookie 0.16.2",
@@ -275,7 +278,6 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.9",
  "itoa 1.0.9",
  "language-tags",
  "log",
@@ -286,22 +288,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "smallvec 1.11.0",
- "socket2 0.4.9",
- "time 0.3.28",
+ "smallvec 1.11.1",
+ "socket2 0.5.4",
+ "time 0.3.29",
  "url 2.4.1",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
+checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -319,13 +321,13 @@ dependencies = [
 
 [[package]]
 name = "actix_derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
+checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -379,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -476,9 +478,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -487,9 +489,9 @@ version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -616,7 +618,7 @@ dependencies = [
  "autoconnect_ws",
  "autopush_common",
  "backtrace",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "bytestring",
  "cadence",
  "ctor",
@@ -691,7 +693,7 @@ dependencies = [
  "async-trait",
  "autopush_common",
  "backtrace",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytebuffer",
  "cadence",
  "config",
@@ -739,7 +741,7 @@ name = "autopush"
 version = "1.68.0"
 dependencies = [
  "autopush_common",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes 0.4.12",
  "cadence",
  "chrono",
@@ -797,7 +799,7 @@ dependencies = [
  "again",
  "async-trait",
  "backtrace",
- "base64 0.21.3",
+ "base64 0.21.4",
  "cadence",
  "chrono",
  "config",
@@ -850,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "awc"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ef547a81796eb2dfe9b345aba34c2e08391a0502493711395b36dd64052b69"
+checksum = "7fa3c705a9c7917ac0f41c0757a0a747b43bbc29b0b364b081bd7c5fc67fb223"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -860,9 +862,8 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.7.6",
- "base64 0.21.3",
- "bytes 1.4.0",
+ "base64 0.21.4",
+ "bytes 1.5.0",
  "cfg-if 1.0.0",
  "cookie 0.16.2",
  "derive_more",
@@ -926,9 +927,9 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bindgen"
@@ -945,11 +946,11 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
  "rustc-hash",
- "shlex 1.1.0",
+ "shlex 1.2.0",
  "which",
 ]
 
@@ -1026,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1037,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1047,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-tools"
@@ -1059,9 +1060,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytebuffer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2468af960a9069ae7f77b6c16836e0ccc13f0caf8c8856b942924241c72f7b"
+checksum = "fa7bfaf7cd08cacd74cdc6b521c37ac39cbc92692e5ab5c21ed5657a749b577c"
 dependencies = [
  "byteorder",
 ]
@@ -1091,9 +1092,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytestring"
@@ -1101,7 +1102,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
 ]
 
 [[package]]
@@ -1146,18 +1147,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1263,7 +1263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding 2.3.0",
- "time 0.3.28",
+ "time 0.3.29",
  "version_check",
 ]
 
@@ -1446,12 +1446,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
+checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1514,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustc_version 0.4.0",
  "syn 1.0.109",
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1717,7 +1717,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
@@ -1731,9 +1731,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fernet"
@@ -1741,7 +1741,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3364d69f691f3903b1a71605fa04f40a7c2d259f0f0512347e36d19a63debf1f"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "byteorder",
  "getrandom 0.2.10",
  "openssl",
@@ -1946,9 +1946,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2120,7 +2120,7 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2168,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2196,6 +2196,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -2226,7 +2235,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "fnv",
  "itoa 1.0.9",
 ]
@@ -2249,7 +2258,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "http 0.2.9",
  "pin-project-lite 0.2.13",
 ]
@@ -2308,7 +2317,7 @@ version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2333,7 +2342,7 @@ source = "git+https://github.com/WalletConnect/hyper-alpn#9761c744b8ba274dfaea04
 dependencies = [
  "hyper 0.14.27",
  "log",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-pemfile",
  "tokio 1.32.0",
  "tokio-rustls 0.23.4",
@@ -2367,7 +2376,7 @@ dependencies = [
  "http 0.2.9",
  "hyper 0.14.27",
  "log",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-native-certs 0.6.3",
  "tokio 1.32.0",
  "tokio-rustls 0.24.1",
@@ -2392,7 +2401,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "hyper 0.14.27",
  "native-tls",
  "tokio 1.32.0",
@@ -2521,7 +2530,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys",
 ]
@@ -2582,7 +2591,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "pem",
  "ring",
  "serde",
@@ -2620,9 +2629,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -2654,19 +2663,18 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "local-channel"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+checksum = "e0a493488de5f18c8ffcba89eebb8532ffc562dc400490eb65b84893fae0b178"
 dependencies = [
  "futures-core",
  "futures-sink",
- "futures-util",
  "local-waker",
 ]
 
@@ -2738,9 +2746,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.6.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -2879,7 +2887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2994,7 +3002,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -3009,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -3055,9 +3063,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3068,9 +3076,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -3162,7 +3170,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec 1.11.0",
+ "smallvec 1.11.1",
  "winapi 0.3.9",
 ]
 
@@ -3175,7 +3183,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.3.5",
- "smallvec 1.11.0",
+ "smallvec 1.11.1",
  "windows-targets",
 ]
 
@@ -3220,19 +3228,20 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3240,26 +3249,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3339,7 +3348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
@@ -3351,7 +3360,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "version_check",
 ]
@@ -3367,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -3405,7 +3414,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
 ]
 
 [[package]]
@@ -3655,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3667,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3728,8 +3737,8 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.3",
- "bytes 1.4.0",
+ "base64 0.21.4",
+ "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3819,7 +3828,7 @@ checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "crc32fast",
  "futures 0.3.28",
  "http 0.2.9",
@@ -3869,7 +3878,7 @@ dependencies = [
  "hyper 0.14.27",
  "serde",
  "serde_json",
- "shlex 1.1.0",
+ "shlex 1.2.0",
  "tokio 1.32.0",
  "zeroize",
 ]
@@ -3895,7 +3904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7935e1f9ca57c4ee92a4d823dcd698eb8c992f7e84ca21976ae72cd2b03016e7"
 dependencies = [
  "async-trait",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "futures 0.3.28",
  "rusoto_core 0.47.0",
  "serde",
@@ -3933,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
 dependencies = [
  "base64 0.13.1",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "chrono",
  "digest 0.9.0",
  "futures 0.3.28",
@@ -4001,14 +4010,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.19",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.9"
+version = "0.38.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -4032,21 +4041,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
  "sct 0.7.0",
- "webpki 0.22.0",
+ "webpki 0.22.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -4084,14 +4093,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -4199,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "semver-parser"
@@ -4211,9 +4220,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e95efd0cefa32028cdb9766c96de71d96671072f9fb494dc9fb84c0ef93e52b"
+checksum = "0097a48cd1999d983909f07cb03b15241c5af29e5e679379efac1c06296abecc"
 dependencies = [
  "httpdate",
  "log",
@@ -4231,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795851be3047d9be16ea8a808383f89e75d2aebc9b53d25fe708c27bc56b4488"
+checksum = "856a0131ca91c402aba7ce3b4f199b4fabc0b2d2b7fe0e8fdeac2a131ae75126"
 dependencies = [
  "actix-web",
  "futures-util",
@@ -4242,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac2bac6f310c4c4c4bb094d1541d32ae497f8c5c23405e85492cefdfe0971a9"
+checksum = "18a7b80fa1dd6830a348d38a8d3a9761179047757b7dca29aef82db0118b9670"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -4254,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3e17295cecdbacf66c5bd38d6e1147e09e1e9d824d2d5341f76638eda02a3a"
+checksum = "7615dc588930f1fd2e721774f25844ae93add2dbe2d3c2f995ce5049af898147"
 dependencies = [
  "hostname",
  "libc",
@@ -4268,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8339474f587f36cb110fa1ed1b64229eea6d47b0b886375579297b7e47aeb055"
+checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
 dependencies = [
  "log",
  "once_cell",
@@ -4282,9 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c11e7d2b809b06497a18a2e60f513206462ae2db27081dfb7be9ade1f329cc8"
+checksum = "2fe6180fa564d40bb942c9f0084ffb5de691c7357ead6a2b7a3154fae9e401dd"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4293,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b69f506da75bd664029eafb05f8934297d2990192896d17325f066bd665b7"
+checksum = "323160213bba549f9737317b152af116af35c0410f4468772ee9b606d3d6e0fa"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4303,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89feead9bdd116f8035e89567651340fc382db29240b6c55ef412078b08d1aa3"
+checksum = "38033822128e73f7b6ca74c1631cef8868890c6cb4008a291cf73530f87b4eac"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4315,17 +4324,17 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dc599bd6646884fc403d593cdcb9816dd67c50cff3271c01ff123617908dcd"
+checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
 dependencies = [
  "debugid",
- "getrandom 0.2.10",
  "hex",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.29",
  "url 2.4.1",
  "uuid 1.4.1",
 ]
@@ -4345,9 +4354,9 @@ version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4366,16 +4375,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a485bf5e371e28d4978444686ffa91830d4719b92fb31960fbd8f494816239"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "rusoto_dynamodb 0.47.0",
  "serde",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa 1.0.9",
  "ryu",
@@ -4420,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4456,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4473,9 +4482,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook"
@@ -4511,7 +4520,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -4603,7 +4612,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.28",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -4617,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
@@ -4633,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -4695,7 +4704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -4730,18 +4739,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -4752,7 +4761,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -4790,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -4814,22 +4823,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4855,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
@@ -4870,15 +4879,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -4940,14 +4949,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "libc",
  "mio 0.8.8",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.13",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros 2.1.0",
  "windows-sys",
 ]
@@ -5041,7 +5050,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -5052,9 +5061,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5133,9 +5142,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "tokio 1.32.0",
- "webpki 0.22.0",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -5144,7 +5153,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "tokio 1.32.0",
 ]
 
@@ -5264,11 +5273,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.13",
@@ -5358,9 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -5394,9 +5403,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -5415,9 +5424,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -5439,11 +5448,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "log",
  "native-tls",
  "once_cell",
@@ -5522,7 +5531,7 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
  "syn 1.0.109",
@@ -5535,7 +5544,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
@@ -5565,9 +5574,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -5630,9 +5639,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -5664,9 +5673,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5714,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted",
@@ -5728,18 +5737,19 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.0",
+ "webpki 0.22.2",
 ]
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5772,9 +5782,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -5901,9 +5911,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "yaml-rust"
@@ -5930,12 +5940,12 @@ dependencies = [
  "itertools",
  "log",
  "percent-encoding 2.3.0",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "seahash",
  "serde",
  "serde_json",
- "time 0.3.28",
+ "time 0.3.29",
  "tokio 1.32.0",
  "tower-service",
  "url 2.4.1",
@@ -5956,9 +5966,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -367,7 +367,7 @@ pub mod tests {
     async fn unknown_fcm_error() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
-            is_gcm: Some(false),
+            is_gcm: Some(true),
             server_access_token: make_service_key(),
         })
         .await;

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -17,12 +17,11 @@ const OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/firebase.messag
 /// handles sending notifications to Firebase.
 pub struct FcmClient {
     endpoint: Url,
-    gcm_endpoint: Url,
     timeout: Duration,
     max_data: usize,
-    fcm_authenticator: Option<DefaultAuthenticator>,
+    authenticator: Option<DefaultAuthenticator>,
+    pub is_gcm: bool,
     http_client: reqwest::Client,
-    server_credential: FcmServerCredential, // Only used for legacy GCM
 }
 
 impl FcmClient {
@@ -34,8 +33,7 @@ impl FcmClient {
     ) -> std::io::Result<Self> {
         // `map`ping off of `serde_json::from_str` gets hairy and weird, requiring
         // async blocks and a number of other specialty items. Doing a very stupid
-        // json detection does not. GCM keys are base64 values, so  `{` will never
-        // appear in a GCM key. FCM keys are serialized JSON constructs.
+        // json detection does not. FCM keys are serialized JSON constructs.
         // These are both set in the settings and come from the `credentials` value.
         let auth = if server_credential.server_access_token.contains('{') {
             trace!(
@@ -76,124 +74,12 @@ impl FcmClient {
                     server_credential.project_id
                 ))
                 .expect("Project ID is not URL-safe"),
-            gcm_endpoint: settings
-                .base_url
-                .join("fcm/send")
-                .expect("GCM Project ID is not URL-safe"),
             timeout: Duration::from_secs(settings.timeout as u64),
             max_data: settings.max_data,
-            fcm_authenticator: auth,
+            authenticator: auth,
+            is_gcm: server_credential.is_gcm.unwrap_or_default(),
             http_client: http,
-            server_credential,
         })
-    }
-
-    /// Send the message as GCM
-    /// Note: GCM is a beyond deprecated protocol, however older clients
-    /// may still use it (which includes about half of our traffic at
-    /// the time this comment was written). GCM documentation was also
-    /// removed from Google's site. It still persists in obscure corners
-    /// of the internet, but I have no idea for how long.
-    /// <https://stuff.mit.edu/afs/sipb/project/android/docs/google/gcm/gcm.html>
-    ///
-    /// There is no way to generate GCM credentials. (They are disabled
-    /// on Google's server side.) There is no way to test GCM compatibility
-    /// other than monitoring errors. Users really should be migrated to the
-    /// new FCM endpoints, but we don't have full control over that.
-    pub async fn send_gcm(
-        &self,
-        data: HashMap<&'static str, String>,
-        registration_id: String,
-        ttl: usize,
-    ) -> Result<(), RouterError> {
-        let data_json = serde_json::to_string(&data).unwrap();
-        message_size_check(data_json.as_bytes(), self.max_data)?;
-
-        // Build the GCM message
-        let message = serde_json::json!({
-            "registration_ids": [registration_id],
-            "time_to_live": ttl,
-            "delay_while_idle": false,
-            "data": data
-        });
-
-        /*
-        // For testing mock...
-        // mockito reports the error in the status line. e.g.
-        // 501 Mock not found ...
-        // reqwest eats the status line, therefore we use ureq here.
-        // You can also turn on internal debugging, see
-        // https://docs.rs/mockito/latest/mockito/#debug
-        dbg!(self.endpoint.clone().as_str());
-        let rr = ureq::post(self.gcm_endpoint.clone().as_str())
-            .set("Authorization",
-                    format!("key={}", self.server_credential.server_access_token.as_str()).as_str())
-            .set("Content-Type", "application/json")
-            .send_json(&message).unwrap();
-        dbg!(rr.status(), rr.status_text());
-        // */
-
-        // Make the request
-        let server_access_token = &self.server_credential.server_access_token;
-        let response = self
-            .http_client
-            .post(self.gcm_endpoint.clone())
-            .header("Authorization", format!("key={server_access_token}"))
-            .header("Content-Type", "application/json")
-            .json(&message)
-            .timeout(self.timeout)
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    RouterError::RequestTimeout
-                } else {
-                    RouterError::Connect(e)
-                }
-            })?;
-
-        // Handle error
-        let status = response.status();
-        let raw_data = response
-            .bytes()
-            .await
-            .map_err(FcmError::DeserializeResponse)?;
-        if raw_data.is_empty() {
-            warn!("Empty GCM response [{status}]");
-            return Err(FcmError::EmptyResponse(status).into());
-        }
-        let data: GcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
-            let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
-            warn!("Invalid GCM response [{status}], \"{s}\"");
-            FcmError::InvalidResponse(e, s, status)
-        })?;
-
-        if status.is_client_error() || status.is_server_error() || data.failure > 0 {
-            let invalid = GcmResult::invalid();
-            return Err(
-                match (status, &data.results.get(0).unwrap_or(&invalid).error) {
-                    (StatusCode::UNAUTHORIZED, _) => RouterError::GCMAuthentication,
-                    (StatusCode::NOT_FOUND, _) => RouterError::NotFound,
-                    (_, Some(error)) => match error.as_str() {
-                        "NotRegistered" | "InvalidRegistration" => RouterError::NotFound,
-                        "Unavailable" => RouterError::Upstream {
-                            status: "USER UNAVAILABLE".to_owned(),
-                            message: "User Unavailable. Try again later.".to_owned(),
-                        },
-                        _ => RouterError::Upstream {
-                            status: StatusCode::BAD_GATEWAY.to_string(),
-                            message: format!("Unexpected error: {error}"),
-                        },
-                    },
-                    (status, None) => RouterError::Upstream {
-                        status: status.to_string(),
-                        message: "Unknown reason".to_string(),
-                    },
-                },
-            );
-        }
-
-        Ok(())
     }
 
     /// Send the message data to FCM
@@ -220,7 +106,7 @@ impl FcmClient {
         });
 
         let server_access_token = self
-            .fcm_authenticator
+            .authenticator
             .as_ref()
             .unwrap()
             .token(OAUTH_SCOPES)
@@ -254,7 +140,7 @@ impl FcmClient {
                 .map_err(FcmError::DeserializeResponse)?;
             if raw_data.is_empty() {
                 warn!("Empty FCM response [{status}]");
-                return Err(FcmError::EmptyResponse(status).into());
+                return Err(FcmError::EmptyResponse(status, self.is_gcm).into());
             }
             let data: FcmResponse = serde_json::from_slice(&raw_data).map_err(|e| {
                 let s = String::from_utf8(raw_data.to_vec()).unwrap_or_else(|e| e.to_string());
@@ -264,8 +150,25 @@ impl FcmClient {
 
             // we only ever send one.
             return Err(match (status, data.error) {
-                (StatusCode::UNAUTHORIZED, _) => RouterError::Authentication,
-                (StatusCode::NOT_FOUND, _) => RouterError::NotFound,
+                (StatusCode::UNAUTHORIZED, _) => {
+                    if self.is_gcm {
+                        RouterError::GCMAuthentication
+                    } else {
+                        RouterError::Authentication
+                    }
+                }
+                (StatusCode::NOT_FOUND, _) => {
+                    // GCM ERROR
+                    if self.is_gcm {
+                        warn!("Converting GCM NOT FOUND to FCM SERVICE_UNAVAILABLE");
+                        RouterError::Upstream {
+                            status: StatusCode::SERVICE_UNAVAILABLE.to_string(),
+                            message: "FCM did not find GCM user".to_owned(),
+                        }
+                    } else {
+                        RouterError::NotFound
+                    }
+                }
                 (_, Some(error)) => RouterError::Upstream {
                     status: error.status,
                     message: error.message,
@@ -290,40 +193,6 @@ struct FcmResponse {
 struct FcmErrorResponse {
     status: String,
     message: String,
-}
-
-/// This is a joint structure that would reflect the status of each delivered
-/// message. (We only send one at a time.)
-#[derive(Clone, Deserialize, Debug, Default)]
-struct GcmResult {
-    error: Option<String>, // Optional, standardized error message
-    #[serde(rename = "message_id")]
-    _message_id: Option<String>, // Optional identifier for a successful send
-    #[serde(rename = "registration_id")]
-    _registration_id: Option<String>, // Optional replacement registration ID
-}
-
-impl GcmResult {
-    pub fn invalid() -> GcmResult {
-        Self {
-            error: Some("Invalid GCM Response".to_string()),
-            ..Default::default()
-        }
-    }
-}
-
-// The expected GCM response message. (Being explicit here because
-// the offical documentation has been removed)
-#[derive(Clone, Deserialize, Debug, Default)]
-struct GcmResponse {
-    results: Vec<GcmResult>,
-    #[serde(rename = "multicast_id")]
-    _multicast_id: u64, // ID for this set of messages/results
-    #[serde(rename = "success")]
-    _success: u32, // Number of messages succeeding.
-    failure: u32, // number of messages failing.
-    #[serde(rename = "canonical_ids")]
-    _canonical_ids: u32, // number of IDs that are reassigned.
 }
 
 #[cfg(test)]
@@ -374,10 +243,6 @@ pub mod tests {
         mockito::mock("POST", format!("/v1/projects/{id}/messages:send").as_str())
     }
 
-    pub fn mock_gcm_endpoint_builder() -> mockito::Mock {
-        mockito::mock("POST", "/fcm/send")
-    }
-
     /// Make a FcmClient from the service auth data
     async fn make_client(credential: FcmServerCredential) -> FcmClient {
         FcmClient::new(
@@ -399,6 +264,7 @@ pub mod tests {
     async fn sends_correct_fcm_request() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
+            is_gcm: None,
             server_access_token: make_service_key(),
         })
         .await;
@@ -417,40 +283,12 @@ pub mod tests {
         fcm_mock.assert();
     }
 
-    #[tokio::test]
-    async fn sends_correct_gcm_request() {
-        // from settings, the projects Auth Key.
-        let registration_id = "AIzaSyB0ecSrqnEDXQ7yjLXqVc0CUGOeSlq9BsM"; // this is a nonce value used only for testing.
-        let project_id = GCM_PROJECT_ID;
-        // GCM_ACCESS_TOKEN comes from the device, it's the registration_id
-        // sent as part of message registration for a GCM capable client.
-        let client = make_client(FcmServerCredential {
-            project_id: project_id.to_owned(),
-            server_access_token: registration_id.to_owned(),
-        })
-        .await;
-        let body = format!(
-            r#"{{"data":{{"is_test":"true"}},"delay_while_idle":false,"registration_ids":["{}"],"time_to_live":42}}"#,
-            &registration_id
-        );
-        let gcm_mock = mock_gcm_endpoint_builder()
-            .match_header("Authorization", format!("key={registration_id}").as_str())
-            .match_header("Content-Type", "application/json")
-            .with_body(r#"{"multicast_id":216,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:02"}]}"#,)
-            .match_body(body.as_str())
-            .create();
-        let mut data = HashMap::new();
-        data.insert("is_test", "true".to_string());
-        let result = client.send_gcm(data, registration_id.to_owned(), 42).await;
-        assert!(result.is_ok(), "result={result:?}");
-        gcm_mock.assert();
-    }
-
     /// Authorization errors are handled
     #[tokio::test]
     async fn unauthorized() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
+            is_gcm: None,
             server_access_token: make_service_key(),
         })
         .await;
@@ -470,47 +308,12 @@ pub mod tests {
         );
     }
 
-    /// GCM errors are handled
-    #[tokio::test]
-    async fn gcm_unavailable() {
-        let token = make_service_key();
-        let client = make_client(FcmServerCredential {
-            project_id: PROJECT_ID.to_owned(),
-            server_access_token: token.clone(),
-        })
-        .await;
-        let _token_mock = mock_token_endpoint();
-        // Other potential GCM errors:
-        // "Unavailable" => client unavailable, retry sending.
-        // "InvalidRegistration" => registration corrupted, remove.
-        let _gcm_mock = mock_gcm_endpoint_builder()
-            .match_body(r#"{"data":{"is_test":"true"},"delay_while_idle":false,"registration_ids":["test-token"],"time_to_live":42}"#)
-            .match_header("Authorization", format!("key={token}").as_str())
-            .match_header("Content-Type", "application/json")
-            .with_status(200)
-            .with_body(r#"{"multicast_id":216,"success":0,"failure":1,"canonical_ids":0,"results":[{"error":"NotRegistered"}]}"#,
-            )
-            .create();
-
-        let result = client
-            .send_gcm(
-                HashMap::from([("is_test", "true".to_owned())]),
-                "test-token".to_string(),
-                42,
-            )
-            .await;
-        assert!(result.is_err());
-        assert!(
-            matches!(result.as_ref().unwrap_err(), RouterError::NotFound),
-            "result = {result:?}"
-        );
-    }
-
     /// 404 errors are handled
     #[tokio::test]
     async fn not_found() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
+            is_gcm: None,
             server_access_token: make_service_key(),
         })
         .await;
@@ -535,6 +338,7 @@ pub mod tests {
     async fn other_fcm_error() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
+            is_gcm: Some(false),
             server_access_token: make_service_key(),
         })
         .await;
@@ -563,6 +367,7 @@ pub mod tests {
     async fn unknown_fcm_error() {
         let client = make_client(FcmServerCredential {
             project_id: PROJECT_ID.to_owned(),
+            is_gcm: Some(false),
             server_access_token: make_service_key(),
         })
         .await;

--- a/autoendpoint/src/routers/fcm/error.rs
+++ b/autoendpoint/src/routers/fcm/error.rs
@@ -21,7 +21,7 @@ pub enum FcmError {
     InvalidResponse(#[source] serde_json::Error, String, StatusCode),
 
     #[error("Empty response from FCM")]
-    EmptyResponse(StatusCode),
+    EmptyResponse(StatusCode, bool),
 
     #[error("No OAuth token was present")]
     NoOAuthToken,
@@ -50,7 +50,7 @@ impl FcmError {
             | FcmError::NoOAuthToken => StatusCode::INTERNAL_SERVER_ERROR,
 
             FcmError::DeserializeResponse(_)
-            | FcmError::EmptyResponse(_)
+            | FcmError::EmptyResponse(_, _)
             | FcmError::InvalidResponse(_, _, _) => StatusCode::BAD_GATEWAY,
         }
     }
@@ -66,7 +66,7 @@ impl FcmError {
             | FcmError::OAuthClientBuild(_)
             | FcmError::OAuthToken(_)
             | FcmError::DeserializeResponse(_)
-            | FcmError::EmptyResponse(_)
+            | FcmError::EmptyResponse(_, _)
             | FcmError::InvalidResponse(_, _, _)
             | FcmError::NoOAuthToken => None,
         }
@@ -74,7 +74,12 @@ impl FcmError {
 
     pub fn extras(&self) -> Vec<(&str, String)> {
         match self {
-            FcmError::EmptyResponse(status) => vec![("status", status.to_string())],
+            FcmError::EmptyResponse(status, is_gcm) => {
+                vec![
+                    ("status", status.to_string()),
+                    ("is_gcm", is_gcm.to_string()),
+                ]
+            }
             FcmError::InvalidResponse(_, body, status) => {
                 vec![("status", status.to_string()), ("body", body.to_owned())]
             }

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -3,7 +3,6 @@ use autopush_common::db::client::DbClient;
 use crate::error::ApiResult;
 use crate::extractors::notification::Notification;
 use crate::extractors::router_data_input::RouterDataInput;
-use crate::extractors::routers::RouterType;
 use crate::routers::common::{build_message_data, handle_error, incr_success_metrics};
 use crate::routers::fcm::client::FcmClient;
 use crate::routers::fcm::error::FcmError;
@@ -13,7 +12,6 @@ use async_trait::async_trait;
 use cadence::StatsdClient;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
 use uuid::Uuid;
@@ -178,46 +176,40 @@ impl Router for FcmRouter {
             .ok_or_else(|| FcmError::InvalidAppId(app_id.clone()))?;
 
         // GCM is the older message format for android, and it's not possible to generate
-        // new test keys. It operates by using a project level bearer token as authorization.
+        // new test keys. As of 2023-09, GCM should use FCM OAuth2 in order to authenticate.
         // FCM operates by using the more complex token as part of an OAuth2
         // transaction. According to the documentation, GCM and FCM are interoperable,
         // meaning that the client provided tokens should match up, and that the structure
-        // of the data should also not make a huge difference. (Although, that's untested.)
+        // of the data should also not make a huge difference.
         //
-        match RouterType::from_str(&notification.subscription.user.router_type)
-            .unwrap_or(RouterType::FCM)
-        {
-            RouterType::GCM => {
-                trace!("Sending message to GCM: [{:?}]", &app_id);
-                if let Err(e) = client.send_gcm(message_data, routing_token, ttl).await {
-                    return Err(handle_error(
-                        e,
-                        &self.metrics,
-                        self.db.as_ref(),
-                        "gcm",
-                        &app_id,
-                        notification.subscription.user.uaid,
-                    )
-                    .await);
-                }
-                incr_success_metrics(&self.metrics, "gcm", &app_id, notification);
-            }
-            _ => {
-                trace!("Sending message to FCM: [{:?}]", &app_id);
-                if let Err(e) = client.send(message_data, routing_token, ttl).await {
-                    return Err(handle_error(
-                        e,
-                        &self.metrics,
-                        self.db.as_ref(),
-                        "fcmv1",
-                        &app_id,
-                        notification.subscription.user.uaid,
-                    )
-                    .await);
-                }
-                incr_success_metrics(&self.metrics, "fcmv1", &app_id, notification);
-            }
-        }
+        // In Oct of 2023, "legacy" GCM support was deprecated. After some
+        // research, it was hypothesised that the current FCM project may be able
+        // to accept GCM routing identifiers as FCM message tokens. The current code presumes
+        // that this is a fragile relationship and so GCM errors do not immediately drop the
+        // remote user's endpoint (potentially causing a UA reset.)
+        //
+        trace!(
+            "Sending message to {platform}: [{:?}]",
+            &app_id,
+            platform = if client.is_gcm { "GCM as FCM" } else { "FCM" }
+        );
+        if let Err(e) = client.send(message_data, routing_token, ttl).await {
+            return Err(handle_error(
+                e,
+                &self.metrics,
+                self.db.as_ref(),
+                if client.is_gcm { "gcm_as_fcm" } else { "fcm" },
+                &app_id,
+                notification.subscription.user.uaid,
+            )
+            .await);
+        };
+        incr_success_metrics(
+            &self.metrics,
+            if client.is_gcm { "gcm_as_fcm" } else { "fcm" },
+            &app_id,
+            notification,
+        );
         // Sent successfully, update metrics and make response
         trace!("Send request was successful");
 
@@ -237,8 +229,8 @@ mod tests {
     use crate::extractors::routers::RouterType;
     use crate::routers::common::tests::{make_notification, CHANNEL_ID};
     use crate::routers::fcm::client::tests::{
-        make_service_key, mock_fcm_endpoint_builder, mock_gcm_endpoint_builder,
-        mock_token_endpoint, GCM_PROJECT_ID, PROJECT_ID,
+        make_service_key, mock_fcm_endpoint_builder, mock_token_endpoint, GCM_PROJECT_ID,
+        PROJECT_ID,
     };
     use crate::routers::fcm::error::FcmError;
     use crate::routers::fcm::router::FcmRouter;
@@ -299,20 +291,6 @@ mod tests {
         map
     }
 
-    /// Get the GCM credential data from the database (this needs to read
-    /// historic values).
-    fn gcm_router_data(credential: String) -> HashMap<String, serde_json::Value> {
-        let mut map = HashMap::new();
-        let mut creds = HashMap::new();
-        map.insert("senderID".to_string(), GCM_PROJECT_ID.to_string());
-        creds.insert("creds".to_string(), serde_json::to_value(map).unwrap());
-        creds.insert(
-            "token".to_string(),
-            serde_json::to_value(credential).unwrap(),
-        );
-        creds
-    }
-
     /// A notification with no data is sent to FCM
     #[tokio::test]
     async fn successful_routing_no_data() {
@@ -349,47 +327,49 @@ mod tests {
     }
 
     /// A notification with no data is sent to GCM if the subscription specifies it.
-    #[tokio::test]
-    async fn successful_gcm_fallback() {
-        let auth_key = "AIzaSyB0ecSrqnEDXQ7yjLXqVc0CUGOeSlq9BsM"; // this is a nonce value used only for testing.
-        let registration_id = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        // let project_id = GCM_PROJECT_ID;
-        let db = MockDbClient::new().into_boxed_arc();
-        let router = make_router(make_service_key(), auth_key.to_owned(), db).await;
-        assert!(router.active());
-        // body must match the composed body in `gcm_send` exactly (order, values, etc.)
-        let body = serde_json::json!({
-            "registration_ids": [registration_id],
-            "time_to_live": 60_i32,
-            "delay_while_idle": false,
-            "data": {
-                "chid": CHANNEL_ID
-            },
-        })
-        .to_string();
-        let _token_mock = mock_token_endpoint();
-        let fcm_mock = mock_gcm_endpoint_builder()
-            .match_header("Authorization", format!("key={}", &auth_key).as_str())
-            .match_header("Content-Type", "application/json")
-            .with_body(
-                r#"{ "multicast_id": 216,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:02"}]}"#,
-            )
-            .match_body(body.as_str())
-            .create();
-        let notification = make_notification(
-            gcm_router_data(registration_id.to_owned()),
-            None,
-            RouterType::GCM,
-        );
+    /*
+        #[tokio::test]
+        async fn successful_gcm_fallback() {
+            let auth_key = "AIzaSyB0ecSrqnEDXQ7yjLXqVc0CUGOeSlq9BsM"; // this is a nonce value used only for testing.
+            let registration_id = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+            // let project_id = GCM_PROJECT_ID;
+            let db = MockDbClient::new().into_boxed_arc();
+            let router = make_router(make_service_key(), auth_key.to_owned(), db).await;
+            assert!(router.active());
+            // body must match the composed body in `gcm_send` exactly (order, values, etc.)
+            let body = serde_json::json!({
+                "registration_ids": [registration_id],
+                "time_to_live": 60_i32,
+                "delay_while_idle": false,
+                "data": {
+                    "chid": CHANNEL_ID
+                },
+            })
+            .to_string();
+            let _token_mock = mock_token_endpoint();
+            let fcm_mock = mock_gcm_endpoint_builder()
+                .match_header("Authorization", format!("key={}", &auth_key).as_str())
+                .match_header("Content-Type", "application/json")
+                .with_body(
+                    r#"{ "multicast_id": 216,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:02"}]}"#,
+                )
+                .match_body(body.as_str())
+                .create();
+            let notification = make_notification(
+                gcm_router_data(registration_id.to_owned()),
+                None,
+                RouterType::GCM,
+            );
 
-        let result = router.route_notification(&notification).await;
-        assert!(result.is_ok(), "result = {result:?}");
-        assert_eq!(
-            result.unwrap(),
-            RouterResponse::success("http://localhost:8080/m/test-message-id".to_string(), 0)
-        );
-        fcm_mock.assert();
-    }
+            let result = router.route_notification(&notification).await;
+            assert!(result.is_ok(), "result = {result:?}");
+            assert_eq!(
+                result.unwrap(),
+                RouterResponse::success("http://localhost:8080/m/test-message-id".to_string(), 0)
+            );
+            fcm_mock.assert();
+        }
+    */
 
     /// A notification with data is sent to FCM
     #[tokio::test]

--- a/autoendpoint/src/routers/fcm/settings.rs
+++ b/autoendpoint/src/routers/fcm/settings.rs
@@ -48,6 +48,7 @@ pub struct FcmSettings {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct FcmServerCredential {
     pub project_id: String,
+    pub is_gcm: Option<bool>,
     #[serde(rename = "credential")]
     pub server_access_token: String,
 }


### PR DESCRIPTION
This runs GCM messages through the FCMv1 HTTP API (Using existing FCM OAuth credentials, but GCM routing IDs.) This patch is part of an emergency deploy to address 100% GCM failure rates.

Delivery errors for GCM WILL NOT DELETE the GCM route, but will record a metric. This is to prevent potential loss.

It is recommended that this branch be deployed to a canary.

BREAKING CHANGE: 
Please alter GCM credentials in `AUTOEND__FCM__CREDENTIALS` 
These should use the same credential set as main FCM channel.  
(e.g. 
```
"0123456789" : { "project_id": "0123456789", "credential":"012ABC..."}
```
should become:
```
"0123456789": {"project_id": "0123456789", "is_gcm": true, "credential":"{\"type\":\"service_account\",\"project_id\":\"box...\"}"
```

Issue: Sync-3943