### PR TITLE
feat: Reject Legacy GCM endpoints

### DIFF
--- a/autoendpoint/src/extractors/user.rs
+++ b/autoendpoint/src/extractors/user.rs
@@ -3,6 +3,7 @@
 use crate::error::{ApiErrorKind, ApiResult};
 use crate::extractors::routers::RouterType;
 use crate::server::AppState;
+use actix_http::StatusCode;
 use autopush_common::db::{client::DbClient, User};
 use cadence::{CountedExt, StatsdClient};
 use uuid::Uuid;
@@ -26,6 +27,24 @@ pub async fn validate_user(
             return Err(ApiErrorKind::NoSubscription.into());
         }
     };
+
+    // Legacy GCM support was discontinued by Google in Sept 2023.
+    // Since we do not have access to the account that originally created the GCM project
+    // and credentials, we cannot move those users to modern FCM implementations, so we
+    // must drop them.
+    if router_type == RouterType::GCM {
+        debug!("Encountered GCM record, dropping user"; "user" => ?user);
+        // record the bridge error for accounting reasons.
+        app_state
+            .metrics
+            .incr_with_tags("notification.bridge.error")
+            .with_tag("platform", "gcm")
+            .with_tag("reason", "gcm_kill")
+            .with_tag("error", &StatusCode::GONE.to_string())
+            .send();
+        drop_user(user.uaid, app_state.db.as_ref(), &app_state.metrics).await?;
+        return Err(ApiErrorKind::Router(crate::routers::RouterError::NotFound).into());
+    }
 
     if router_type == RouterType::WebPush {
         validate_webpush_user(user, channel_id, app_state.db.as_ref(), &app_state.metrics).await?;

--- a/autoendpoint/src/routers/fcm/error.rs
+++ b/autoendpoint/src/routers/fcm/error.rs
@@ -21,7 +21,7 @@ pub enum FcmError {
     InvalidResponse(#[source] serde_json::Error, String, StatusCode),
 
     #[error("Empty response from FCM")]
-    EmptyResponse(StatusCode, bool),
+    EmptyResponse(StatusCode),
 
     #[error("No OAuth token was present")]
     NoOAuthToken,
@@ -50,7 +50,7 @@ impl FcmError {
             | FcmError::NoOAuthToken => StatusCode::INTERNAL_SERVER_ERROR,
 
             FcmError::DeserializeResponse(_)
-            | FcmError::EmptyResponse(_, _)
+            | FcmError::EmptyResponse(_)
             | FcmError::InvalidResponse(_, _, _) => StatusCode::BAD_GATEWAY,
         }
     }
@@ -66,7 +66,7 @@ impl FcmError {
             | FcmError::OAuthClientBuild(_)
             | FcmError::OAuthToken(_)
             | FcmError::DeserializeResponse(_)
-            | FcmError::EmptyResponse(_, _)
+            | FcmError::EmptyResponse(_)
             | FcmError::InvalidResponse(_, _, _)
             | FcmError::NoOAuthToken => None,
         }
@@ -74,11 +74,8 @@ impl FcmError {
 
     pub fn extras(&self) -> Vec<(&str, String)> {
         match self {
-            FcmError::EmptyResponse(status, is_gcm) => {
-                vec![
-                    ("status", status.to_string()),
-                    ("is_gcm", is_gcm.to_string()),
-                ]
+            FcmError::EmptyResponse(status) => {
+                vec![("status", status.to_string())]
             }
             FcmError::InvalidResponse(_, body, status) => {
                 vec![("status", status.to_string()), ("body", body.to_owned())]


### PR DESCRIPTION
This will force GCM endpoints to return 410, and remove the subscription from the user's record.

Closes: SYNC-3946