### PR TITLE
feat: Use the calling crate's name and version for init_logging()

### DIFF
--- a/autoconnect/src/main.rs
+++ b/autoconnect/src/main.rs
@@ -47,7 +47,12 @@ async fn main() -> Result<()> {
     }
     let settings =
         Settings::with_env_and_config_files(&filenames).map_err(ApcErrorKind::ConfigError)?;
-    logging::init_logging(!settings.human_logs).expect("Logging failed to initialize");
+    logging::init_logging(
+        !settings.human_logs,
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .expect("Logging failed to initialize");
     debug!("Starting up autoconnect...");
 
     // Sentry requires the environment variable "SENTRY_DSN".

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -40,7 +40,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|e| e.exit());
     let settings = settings::Settings::with_env_and_config_file(&args.flag_config)?;
     let host_port = format!("{}:{}", &settings.host, &settings.port);
-    logging::init_logging(!settings.human_logs).expect("Logging failed to initialize");
+    logging::init_logging(
+        !settings.human_logs,
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .expect("Logging failed to initialize");
     debug!("Starting up autoendpoint...");
 
     let _sentry = sentry::init(sentry::ClientOptions {

--- a/autopush-common/src/logging.rs
+++ b/autopush-common/src/logging.rs
@@ -8,19 +8,15 @@ use crate::errors::Result;
 
 static EC2_INSTANCE_ID: OnceLock<Option<String>> = OnceLock::new();
 
-pub fn init_logging(json: bool) -> Result<()> {
+pub fn init_logging(json: bool, name: &str, version: &str) -> Result<()> {
     let logger = if json {
         let ec2_instance_id = EC2_INSTANCE_ID.get_or_init(|| get_ec2_instance_id().ok());
         let hostname = ec2_instance_id
             .clone()
             .unwrap_or_else(|| gethostname().to_string_lossy().to_string());
         let drain = MozLogJson::new(io::stdout())
-            .logger_name(format!(
-                "{}-{}",
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION")
-            ))
-            .msg_type(format!("{}:log", env!("CARGO_PKG_NAME")))
+            .logger_name(format!("{}-{}", name, version))
+            .msg_type(format!("{}:log", name))
             .hostname(hostname)
             .build()
             .fuse();

--- a/autopush/src/server/mod.rs
+++ b/autopush/src/server/mod.rs
@@ -108,7 +108,12 @@ impl AutopushServer {
     }
 
     pub fn start(&self) {
-        logging::init_logging(!self.app_state.human_logs).expect("init_logging failed");
+        logging::init_logging(
+            !self.app_state.human_logs,
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .expect("init_logging failed");
         let handles = Server::start(&self.app_state).expect("failed to start server");
         self.shutdown_handles.set(Some(handles));
     }


### PR DESCRIPTION
Closes: SYNC-3951