### PR TITLE
chore: tag 1.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="1.69.0"></a>
+## 1.69.0 (2023-10-04)
+
+
+#### Chore
+
+*   tag 1.68.3 (#456) ([2a97e678](https://github.com/mozilla-services/autopush-rs/commit/2a97e6781999df67fd8c0086586924ef2463d4a0))
+
+#### Features
+
+*   Use the calling crate's name and version for init_logging() (#461) ([d3bd4c07](https://github.com/mozilla-services/autopush-rs/commit/d3bd4c072a031e00ac5d08cb15d8e84512881295))
+*   Reject Legacy GCM endpoints (#459) ([aaa47139](https://github.com/mozilla-services/autopush-rs/commit/aaa47139aae3a6dc42c063a6b59cc21202dfe5dd))
+
+
+
 <a name="1.68.3"></a>
 ## 1.68.3 (2023-10-02)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autoconnect"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "a2",
  "actix-cors",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "autopush"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "autopush_common",
  "base64 0.21.4",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.68.3"
+version = "1.69.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.68.3"
+version = "1.69.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.68.3 (#456) ([2a97e678](https://github.com/mozilla-services/autopush-rs/commit/2a97e6781999df67fd8c0086586924ef2463d4a0))

#### Features

*   Use the calling crate's name and version for init_logging() (#461) ([d3bd4c07](https://github.com/mozilla-services/autopush-rs/commit/d3bd4c072a031e00ac5d08cb15d8e84512881295))
*   Reject Legacy GCM endpoints (#459) ([aaa47139](https://github.com/mozilla-services/autopush-rs/commit/aaa47139aae3a6dc42c063a6b59cc21202dfe5dd))


