### PR TITLE
feat: hide common SessionClosed errors from sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "reqwest 0.11.22",
  "serde",
  "serde_derive",
+ "serde_json",
  "slog",
  "slog-scope",
  "tokio 1.32.0",

--- a/autoconnect/autoconnect-settings/Cargo.toml
+++ b/autoconnect/autoconnect-settings/Cargo.toml
@@ -13,6 +13,7 @@ mozsvc-common.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
+serde_json.workspace = true
 slog.workspace = true
 slog-scope.workspace = true
 tokio.workspace = true

--- a/autoconnect/autoconnect-settings/src/app_state.rs
+++ b/autoconnect/autoconnect-settings/src/app_state.rs
@@ -136,6 +136,6 @@ impl AppState {
 /// For tests
 impl Default for AppState {
     fn default() -> Self {
-        Self::from_settings(Default::default()).unwrap()
+        Self::from_settings(Settings::test_settings()).unwrap()
     }
 }

--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -11,6 +11,7 @@ use config::{Config, ConfigError, Environment, File};
 use fernet::Fernet;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Deserializer};
+use serde_json::json;
 
 pub use app_state::AppState;
 
@@ -210,6 +211,18 @@ impl Settings {
         non_zero(self.auto_ping_interval, "AUTO_PING_INTERVAL")?;
         non_zero(self.auto_ping_timeout, "AUTO_PING_TIMEOUT")?;
         Ok(())
+    }
+
+    pub fn test_settings() -> Self {
+        let db_settings = json!({
+            "message_table": "message_test",
+            "router_table": "router_test"
+        })
+        .to_string();
+        Self {
+            db_settings,
+            ..Default::default()
+        }
     }
 }
 

--- a/autoconnect/autoconnect-web/src/test.rs
+++ b/autoconnect/autoconnect-web/src/test.rs
@@ -175,7 +175,7 @@ pub async fn broadcast_after_ping() {
     let settings = Settings {
         auto_ping_interval: Duration::from_secs_f32(0.15),
         auto_ping_timeout: Duration::from_secs_f32(0.15),
-        ..Default::default()
+        ..Settings::test_settings()
     };
     let app_state = AppState {
         db: hello_db().into_boxed_arc(),

--- a/autoconnect/autoconnect-ws/src/error.rs
+++ b/autoconnect/autoconnect-ws/src/error.rs
@@ -61,7 +61,7 @@ impl ReportableError for WSError {
     fn is_sentry_event(&self) -> bool {
         match &self.kind {
             WSErrorKind::SM(e) => e.is_sentry_event(),
-            e => !matches!(e, WSErrorKind::Json(_)),
+            e => !matches!(e, WSErrorKind::Json(_) | WSErrorKind::SessionClosed(_)),
         }
     }
 

--- a/autoconnect/autoconnect-ws/src/test.rs
+++ b/autoconnect/autoconnect-ws/src/test.rs
@@ -25,7 +25,7 @@ fn uclient(app_state: AppState) -> UnidentifiedClient {
 async fn handshake_timeout() {
     let settings = Settings {
         open_handshake_timeout: Duration::from_secs_f32(0.15),
-        ..Default::default()
+        ..Settings::test_settings()
     };
     let client = uclient(AppState::from_settings(settings).unwrap());
 
@@ -67,7 +67,7 @@ async fn basic() {
 async fn websocket_ping() {
     let settings = Settings {
         auto_ping_interval: Duration::from_secs_f32(0.15),
-        ..Default::default()
+        ..Settings::test_settings()
     };
     let client = uclient(AppState {
         db: hello_db().into_boxed_arc(),
@@ -92,7 +92,7 @@ async fn auto_ping_timeout() {
     let settings = Settings {
         auto_ping_interval: Duration::from_secs_f32(0.15),
         auto_ping_timeout: Duration::from_secs_f32(0.15),
-        ..Default::default()
+        ..Settings::test_settings()
     };
     let client = uclient(AppState {
         db: hello_db().into_boxed_arc(),
@@ -116,7 +116,7 @@ async fn auto_ping_timeout_after_pong() {
     let settings = Settings {
         auto_ping_interval: Duration::from_secs_f32(0.15),
         auto_ping_timeout: Duration::from_secs_f32(0.15),
-        ..Default::default()
+        ..Settings::test_settings()
     };
     let client = uclient(AppState {
         db: hello_db().into_boxed_arc(),


### PR DESCRIPTION
- require valid dynamodb db_settings json
- kill the unused message_table/current_message_month fields

SYNC-3952
SYNC-3954