### PR TITLE
fix: capture sentry events for the unidentified state

### DIFF
--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
@@ -255,12 +255,12 @@ impl WebPushClient {
     }
 
     /// Add User information and tags for this Client to a Sentry Event
-    pub fn add_sentry_info(&self, event: &mut sentry::protocol::Event) {
+    pub fn add_sentry_info(self, event: &mut sentry::protocol::Event) {
         event.user = Some(sentry::User {
             id: Some(self.uaid.as_simple().to_string()),
             ..Default::default()
         });
-        let ua_info = self.ua_info.clone();
+        let ua_info = self.ua_info;
         event
             .tags
             .insert("ua_name".to_owned(), ua_info.browser_name);

--- a/autoconnect/autoconnect-ws/src/error.rs
+++ b/autoconnect/autoconnect-ws/src/error.rs
@@ -52,7 +52,7 @@ impl WSError {
         self.kind.as_ref()
     }
 
-    /// Emit an event for this Error to Sentry if set to
+    /// Emit an event for this Error to Sentry
     pub fn capture_sentry_event(&self, client: Option<WebPushClient>) {
         if !self.is_sentry_event() {
             return;

--- a/autoconnect/autoconnect-ws/src/handler.rs
+++ b/autoconnect/autoconnect-ws/src/handler.rs
@@ -29,7 +29,7 @@ pub fn spawn_webpush_ws(
         let close_reason = webpush_ws(client, &mut session, msg_stream)
             .await
             .unwrap_or_else(|e| {
-                error!("spawn_webpush_ws: Error: {}", e);
+                trace!("spawn_webpush_ws: Error: {}", e);
                 Some(CloseReason {
                     code: e.close_code(),
                     description: Some(e.close_description().to_owned()),

--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -30,7 +30,6 @@ use crate::db::error::DbError;
 
 /// The settings for accessing the BigTable contents.
 #[derive(Clone, Debug, Deserialize)]
-#[serde(default)]
 pub struct BigTableDbSettings {
     /// The Table name matches the GRPC template for table paths.
     /// e.g. `projects/{projectid}/instances/{instanceid}/tables/{tablename}`
@@ -46,25 +45,6 @@ pub struct BigTableDbSettings {
     pub message_family: String,
     #[serde(default)]
     pub message_topic_family: String,
-}
-
-/// NOTE: autopush will not autogenerate these families. They should
-/// be created when the table is first provisioned. See
-/// [BigTable schema](https://cloud.google.com/bigtable/docs/schema-design)
-///
-/// BE SURE TO CONFIRM the names of the families. These are not checked on
-/// initialization, but will throw errors if not present or incorrectly
-/// spelled.
-///
-impl Default for BigTableDbSettings {
-    fn default() -> Self {
-        Self {
-            table_name: "autopush".to_owned(),
-            router_family: "router".to_owned(),
-            message_family: "message".to_owned(),
-            message_topic_family: "message_topic".to_owned(),
-        }
-    }
 }
 
 impl TryFrom<&str> for BigTableDbSettings {

--- a/autopush-common/src/db/dynamodb/mod.rs
+++ b/autopush-common/src/db/dynamodb/mod.rs
@@ -42,15 +42,6 @@ pub struct DynamoDbSettings {
     pub message_table: String,
 }
 
-impl Default for DynamoDbSettings {
-    fn default() -> Self {
-        Self {
-            router_table: "router".to_string(),
-            message_table: "message".to_string(),
-        }
-    }
-}
-
 impl TryFrom<&str> for DynamoDbSettings {
     type Error = DbError;
     fn try_from(setting_string: &str) -> Result<Self, Self::Error> {


### PR DESCRIPTION
and kill db settings defaults

SYNC-3975
SYNC-3976
