### PR TITLE
fix: defer Error::source methods to inner kind's

### DIFF
--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/error.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/error.rs
@@ -1,26 +1,26 @@
-use std::fmt;
+use std::{error::Error, fmt};
 
 use actix_ws::CloseCode;
 use backtrace::Backtrace;
 
 use autopush_common::{db::error::DbError, errors::ReportableError};
 
-pub type NonStdBacktrace = backtrace::Backtrace;
-
 /// WebSocket state machine errors
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub struct SMError {
     pub kind: SMErrorKind,
-    /// Avoid thiserror's automatic `std::backtrace::Backtrace` integration by
-    /// not using the type name "Backtrace". The older `backtrace::Backtrace`
-    /// is still preferred for Sentry integration:
-    /// https://github.com/getsentry/sentry-rust/issues/600
-    backtrace: NonStdBacktrace,
+    backtrace: Backtrace,
 }
 
 impl fmt::Display for SMError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)
+    }
+}
+
+impl Error for SMError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.kind.source()
     }
 }
 

--- a/autoconnect/autoconnect-ws/src/error.rs
+++ b/autoconnect/autoconnect-ws/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{error::Error, fmt};
 
 use actix_ws::CloseCode;
 use backtrace::Backtrace;
@@ -7,7 +7,7 @@ use autoconnect_ws_sm::{SMError, WebPushClient};
 use autopush_common::{errors::ReportableError, sentry::event_from_error};
 
 /// WebPush WebSocket Handler Errors
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub struct WSError {
     pub kind: WSErrorKind,
     backtrace: Option<Backtrace>,
@@ -16,6 +16,12 @@ pub struct WSError {
 impl fmt::Display for WSError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)
+    }
+}
+
+impl Error for WSError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.kind.source()
     }
 }
 

--- a/autopush-common/src/errors.rs
+++ b/autopush-common/src/errors.rs
@@ -180,7 +180,7 @@ impl ApcErrorKind {
 }
 
 /// Interface for reporting our Error types to Sentry or as metrics
-pub trait ReportableError: std::error::Error + fmt::Display {
+pub trait ReportableError: std::error::Error {
     /// Return a `Backtrace` for this Error if one was captured
     fn backtrace(&self) -> Option<&Backtrace>;
 


### PR DESCRIPTION
and kill ReportableError's redundant inheritance of fmt::Display

SYNC-3977