### PR TITLE
feat: emit metrics for megaphone polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ version = "1.69.1"
 dependencies = [
  "actix-web",
  "autopush_common",
+ "cadence",
  "futures 0.3.28",
  "futures-locks 0.7.1",
  "reqwest 0.11.22",

--- a/autoconnect/autoconnect-common/Cargo.toml
+++ b/autoconnect/autoconnect-common/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 
 [dependencies]
 actix-web.workspace = true
+cadence.workspace = true
 futures.workspace = true
 futures-locks.workspace = true
 reqwest.workspace = true

--- a/autoconnect/autoconnect-settings/src/app_state.rs
+++ b/autoconnect/autoconnect-settings/src/app_state.rs
@@ -123,6 +123,7 @@ impl AppState {
         init_and_spawn_megaphone_updater(
             &self.broadcaster,
             &self.http,
+            &self.metrics,
             url,
             token,
             self.settings.megaphone_poll_interval,


### PR DESCRIPTION
only emit uncommon errors to sentry. don't emit WS ProtocolErrors either

SYNC-3978