### PR TITLE
feat: further detect common io errors in megaphone's updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "cadence",
  "futures 0.3.28",
  "futures-locks 0.7.1",
+ "hyper 0.14.27",
  "reqwest 0.11.22",
  "sentry",
  "serde",

--- a/autoconnect/autoconnect-common/Cargo.toml
+++ b/autoconnect/autoconnect-common/Cargo.toml
@@ -11,6 +11,7 @@ actix-web.workspace = true
 cadence.workspace = true
 futures.workspace = true
 futures-locks.workspace = true
+hyper.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
 sentry.workspace = true

--- a/autoconnect/autoconnect-ws/src/error.rs
+++ b/autoconnect/autoconnect-ws/src/error.rs
@@ -73,7 +73,12 @@ impl WSError {
 
 impl ReportableError for WSError {
     fn backtrace(&self) -> Option<&Backtrace> {
-        self.backtrace.as_ref()
+        // XXX: dumb hack: return SMError's backtrace for now as our
+        // sentry::event_from_error doesn't capture it
+        match &self.kind {
+            WSErrorKind::SM(e) => e.backtrace(),
+            _ => self.backtrace.as_ref(),
+        }
     }
 
     fn is_sentry_event(&self) -> bool {


### PR DESCRIPTION
return SMError's backtrace for WSError (for now)

SYNC-3978