### PR TITLE
chore: report test results in CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
           name: Restoring Rust cache
           key: rust-v1-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
       - run:
+          name: Create Workspace
+          command: mkdir -p workspace
+      - run:
           name: Set up system
           command: |
             apt update
@@ -128,9 +131,15 @@ jobs:
       - run:
           name: Integration tests (Autopush Legacy)
           command: make integration-test-legacy
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
       - run:
           name: Integration tests (Autoconnect)
           command: make integration-test
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
+      - store_test_results:
+          path: workspace/test-results
       - save_cache:
           name: Save Python cache
           key: python-v1-{{ checksum "tests/poetry.lock" }}-{{ checksum "tests/integration/test_integration_all_rust.py"}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,6 @@ jobs:
       # Need to download the poetry.lock files so we can use their
       # checksums in restore_cache.
       - restore_cache:
-          name: Restoring Python cache
-          key: python-v1-{{ checksum "tests/poetry.lock" }}-{{ checksum "tests/integration/test_integration_all_rust.py"}}
-      - restore_cache:
           name: Restoring Rust cache
           key: rust-v1-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
       - run:
@@ -140,12 +137,6 @@ jobs:
             TEST_RESULTS_DIR: workspace/test-results
       - store_test_results:
           path: workspace/test-results
-      - save_cache:
-          name: Save Python cache
-          key: python-v1-{{ checksum "tests/poetry.lock" }}-{{ checksum "tests/integration/test_integration_all_rust.py"}}
-          paths:
-            - /home/circleci/.local/bin/
-            - /home/circleci/.local/lib/
       - save_cache:
           name: Save Rust cache
           key: rust-v1-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ docs/old
 *.local.toml
 .cargo/config
 .vscode/*
+
+# circleCI
+workspace

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/sh
 CARGO = cargo
 TESTS_DIR := tests
+TEST_RESULTS_DIR ?= workspace/test-results
 INTEGRATION_TEST_FILE := $(TESTS_DIR)/integration/test_integration_all_rust.py
 LOAD_TEST_DIR := $(TESTS_DIR)/load
 POETRY := poetry --directory $(TESTS_DIR)
@@ -25,14 +26,18 @@ upgrade:
 integration-test-legacy:
 	$(POETRY) -V
 	$(POETRY) install --without dev,load
-	$(POETRY) run pytest $(INTEGRATION_TEST_FILE) -v
+	$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
+		--junit-xml=$(TEST_RESULTS_DIR)/integration_test_legacy_results.xml \
+		-v
 
 integration-test:
 	$(POETRY) -V
 	$(POETRY) install --without dev,load
 	CONNECTION_BINARY=autoconnect \
 		CONNECTION_SETTINGS_PREFIX=autoconnect__ \
-		$(POETRY) run pytest $(INTEGRATION_TEST_FILE) -v
+		$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
+		--junit-xml=$(TEST_RESULTS_DIR)/integration_test_results.xml \
+		-v
 
 lint:
 	$(POETRY) -V

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ upgrade:
 
 integration-test-legacy:
 	$(POETRY) -V
-	$(POETRY) install --without dev,load
+	$(POETRY) install --without dev,load --no-root
 	$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
 		--junit-xml=$(TEST_RESULTS_DIR)/integration_test_legacy_results.xml \
 		-v
 
 integration-test:
 	$(POETRY) -V
-	$(POETRY) install --without dev,load
+	$(POETRY) install --without dev,load --no-root
 	CONNECTION_BINARY=autoconnect \
 		CONNECTION_SETTINGS_PREFIX=autoconnect__ \
 		$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
@@ -41,7 +41,7 @@ integration-test:
 
 lint:
 	$(POETRY) -V
-	$(POETRY) install
+	$(POETRY) install --no-root
 	$(POETRY) run isort --sp $(PYPROJECT_TOML) -c $(TESTS_DIR)
 	$(POETRY) run black --quiet --diff --config $(PYPROJECT_TOML) --check $(TESTS_DIR)
 	$(POETRY) run flake8 --config $(FLAKE8_CONFIG) $(TESTS_DIR)


### PR DESCRIPTION
- Test results are output in junit-xml format and uploaded to CircleCI
- Fix the following error when installing python dependencies
  <img width="697" alt="image" src="https://github.com/mozilla-services/autopush-rs/assets/3422688/c0f6a86c-95bc-45f6-a7cb-7b95333dde48">
- Remove the python caching from the test CI job
    - The paths set by the `save_cache` step need to be updated to the following, however the performance gains are negligible, so that I recommend removing the steps.
    ```
          paths:
            - /root/.cache/pip
            - /root/.cache/pypoetry
    ```

[SYNC-3934](https://mozilla-hub.atlassian.net/browse/SYNC-3934)

[SYNC-3934]: https://mozilla-hub.atlassian.net/browse/SYNC-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ