### PR TITLE
docs: Document VAPID key should be base64 encoded

### DIFF
--- a/autopush-common/src/endpoint.rs
+++ b/autopush-common/src/endpoint.rs
@@ -24,8 +24,8 @@ pub fn make_endpoint(
 
     if let Some(k) = key {
         let raw_key = b64_decode_url(k).map_err(|e| {
-            warn!("Payload: error decrypting user provided VAPID key:{:?}", e);
-            ApcErrorKind::PayloadError("Error encrypting VAPID key".to_owned())
+            warn!("Payload: error decoding user provided VAPID key:{:?}", e);
+            ApcErrorKind::PayloadError("Error decoding VAPID key".to_owned())
         })?;
         let key_digest = hash::hash(hash::MessageDigest::sha256(), &raw_key).map_err(|e| {
             warn!("Payload: Error creating digest for VAPID key: {:?}", e);

--- a/docs/src/http.md
+++ b/docs/src/http.md
@@ -250,7 +250,7 @@ An example of the Authorization header would be:
     Authorization: Bearer 00secret00
 ```
 **{vapidKey}**  
-_The [VAPID Key](https://datatracker.ietf.org/doc/html/draft-ietf-webpush-vapid-01) provided by the subscribing third party_
+_The [VAPID Key](https://datatracker.ietf.org/doc/html/rfc8292#section-3.2) provided by the subscribing third party_
 
 The VAPID key is optional and provides a way for an application server to voluntarily identify itself.
 When the VAPID key is provided, autopush will return an endpoint that can only be used by the application server that provided the key.

--- a/docs/src/http.md
+++ b/docs/src/http.md
@@ -249,6 +249,14 @@ An example of the Authorization header would be:
 ```html
     Authorization: Bearer 00secret00
 ```
+**{vapidKey}**  
+_The [VAPID Key](https://datatracker.ietf.org/doc/html/draft-ietf-webpush-vapid-01) provided by the subscribing third party_
+
+The VAPID key is optional and provides a way for an application server to voluntarily identify itself.
+When the VAPID key is provided, autopush will return an endpoint that can only be used by the application server that provided the key.
+**The VAPID key is formatted as a URL-safe Base64 encoded string with no padding.**
+
+
 
 ## Calls
 
@@ -269,11 +277,12 @@ This call requires no Authorization header.
 
 **Parameters:**
 
-`{"token":{instance_id}}`
+`{"token":{instance_id},
+  "key": {vapidkey}}`
 
-> _**Note**_
->
-> If additional information is required for the bridge, it may be
+> _**Notes**_
+> * The VAPID key is optional
+> * If additional information is required for the bridge, it may be
 > included in the parameters as JSON elements. Currently, no additional
 > information is required.
 >
@@ -290,7 +299,7 @@ example:
 ``` http
  POST /v1/fcm/33clienttoken33/registration
 
- {"token": "11-instance-id-11"}
+ {"token": "11-instance-id-11", "key": "AbC12ef0"}
 ```
 
 ``` json
@@ -364,7 +373,10 @@ Acquire a new ChannelID for a given UAID. (See
 
 **Parameters:**
 
-`{}`
+`{key: {vapidKey}}`
+
+**Note**
+> VAPID key is optional
 
 **Reply:**
 
@@ -378,7 +390,7 @@ example:
  POST /v1/fcm/33clienttoken33/registration/abcdef012345/subscription
  Authorization: Bearer 00secret00
 
- {}
+ {"key": "AbCd01hk"}
 ```
 
 ``` json


### PR DESCRIPTION
Realized there was no documentation on the format of the VAPID key, read the source code and realized we call https://github.com/mozilla-services/autopush-rs/blob/6624a19ad97af90174cc7623b9b8683392c3aec9/autopush-common/src/util/mod.rs#L30-L32

(for reference, here's where we initiate the decoding while [making the endpoint](https://github.com/mozilla-services/autopush-rs/blob/6624a19ad97af90174cc7623b9b8683392c3aec9/autopush-common/src/endpoint.rs#L26)


cc @jrconlin 
