### PR TITLE
bug: filter by timestamp

### DIFF
--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -64,7 +64,7 @@ pub async fn register_uaid_route(
     trace!("🌍 Creating secret for UAID {}", user.uaid);
     let auth_keys = app_state.settings.auth_keys();
     let auth_key = auth_keys
-        .get(0)
+        .first()
         .expect("At least one auth key must be provided in the settings");
     let secret = AuthorizationCheck::generate_token(auth_key, &user.uaid)
         .map_err(ApiErrorKind::RegistrationSecretHash)?;

--- a/autopush-common/src/db/bigtable/bigtable_client/Bigtable_Learnings.md
+++ b/autopush-common/src/db/bigtable/bigtable_client/Bigtable_Learnings.md
@@ -1,0 +1,48 @@
+# Various things we learned while dealing with Bigtable
+
+This document contains tricks and traps that we've discovered while working with Bigtable.
+
+## Indicies
+
+* Bigtable uses a single key, which it uses to locate data as proximate to other values (e.g.
+"Foo-123" would be stored proximate to "Foo-456"). The suggested mechanism is to collapse significant values into a single key using well-known separator values and use regular-expression syntax for the key index to limit searches.
+
+* Regular expressions must match the entire key. A partial match is not considered for inclusion in the result set. (e.g. `Foo` will not match `Foo-123`, however `Foo.*` will)
+
+## Cells
+
+* Cell values are stored as Byte arrays, and library functions use field hints in order to store and retrieve values, but be mindful of storage differences. (e.g. a u64 value or search will not match a u128 byte array.)
+
+## Filters
+
+* Cell Filters are exclusive by default. This means that when you do a filter for a given cell value or qualifier, the result set will only contain the filtered results.
+This is a bit hard to explain without a proper example, but presume the following filter:
+
+```rust
+fn expiry_filter() -> Result<data::RowFilter, error::BigTableError> {
+    let mut expiry_filter = data::RowFilter::default();
+    let mut chain = data::RowFilter_Chain::default();
+    let mut filter_chain = RepeatedField::default();
+
+    let mut key_filter = data::RowFilter::default();
+    key_filter.set_column_qualifier_regex_filter("expiry".as_bytes().to_vec());
+    let bt_now: u128 = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(error::BigTableError::WriteTime)?
+        .as_millis();
+    let mut value_filter = data::RowFilter::default();
+    let mut range = data::ValueRange::default();
+
+    // Valid timestamps have not yet expired.
+    range.set_start_value_open(bt_now.to_be_bytes().to_vec());
+    value_filter.set_value_range_filter(range);
+    filter_chain.push(key_filter);
+    filter_chain.push(value_filter);
+    chain.set_filters(filter_chain);
+    expiry_filter.set_chain(chain);
+    Ok(expiry_filter)
+}
+
+```
+
+Adding this filter to a query will return a result that only includes the "expiry" cells which have a value that is greater than the current time. No other cells or values will be included in the return set, however each "row" will include the row meta information, including the key.

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -291,7 +291,6 @@ impl BigTableClientImpl {
         let mut req = DropRowRangeRequest::new();
         req.set_name(self.settings.table_name.clone());
         req.set_row_key_prefix(row_key.as_bytes().to_vec());
-        req.set_delete_all_data_from_table(true);
         admin
             .drop_row_range_async(&req)
             .map_err(|e| {

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -41,7 +41,7 @@ use crate::util::timing::{ms_since_epoch, sec_since_epoch};
 use models::{NotificationHeaders, RangeKey};
 
 const MAX_EXPIRY: u64 = 2_592_000;
-pub const USER_RECORD_VERSION: u8 = 1;
+pub const USER_RECORD_VERSION: u64 = 1;
 /// The maximum TTL for channels, 30 days
 pub const MAX_CHANNEL_TTL: u64 = 30 * 24 * 60 * 60;
 
@@ -166,7 +166,7 @@ pub struct User {
     pub node_id: Option<String>,
     /// Record version
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub record_version: Option<u8>,
+    pub record_version: Option<u64>,
     /// LEGACY: Current month table in the database the user is on
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_month: Option<String>,


### PR DESCRIPTION
This includes a filter by cell timestamp. This also includes a lot of inline comments pointing out potential hazards and pitfalls that I experienced working on this.

NOTE: There is a (hopefully remote) possiblity that a record could be returned with a specific cell missing if that cell's timestamp has expired. Timestamps are per cell, not per row.

Closes: SYNC-4060