### PR TITLE
bug: Use standard chidmessageid parser for remove_message

### DIFF
--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -254,7 +254,7 @@ pub struct NotificationRecord {
 
 impl NotificationRecord {
     /// read the custom sort_key and convert it into something the database can use.
-    fn parse_chidmessageid(key: &str) -> Result<RangeKey> {
+    pub(crate) fn parse_chidmessageid(key: &str) -> Result<RangeKey> {
         lazy_static! {
             static ref RE: RegexSet = RegexSet::new([
                 format!("^{}:\\S+:\\S+$", TOPIC_NOTIFICATION_PREFIX).as_str(),


### PR DESCRIPTION
Closes [SYNC-4065](https://mozilla-hub.atlassian.net/browse/SYNC-4065)

[SYNC-4065]: https://mozilla-hub.atlassian.net/browse/SYNC-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ