### PR TITLE
feat: run integration tests against Bigtable

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,5 @@ ignore = [
     "RUSTSEC-2023-0034", # Bound by Rusoto 0.42, Reqwest 0.9, a2 0.5 requiring Hyper 0.12
     "RUSTSEC-2023-0052", # Bound by Rusoto 0.47, Rustls 0.20, hyper-rustls 0.22, a2 0.8
     "RUSTSEC-2023-0065", # Bound by tokio-tungstenite
+    "RUSTSEC-2024-0003", # Bound by hyper 0.12
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,15 +155,22 @@ jobs:
           # instance. This may be causing rust to be overly greedy triggering the VM to OOM the process.)
           command: cargo test --features=emulator --jobs=2
       - run:
-          name: Integration tests (Autopush Legacy)
-          command: make integration-test-legacy
+          name: Integration tests (Bigtable)
+          command: make integration-test
           environment:
+            DB_DSN: grpc://localhost:8086
             TEST_RESULTS_DIR: workspace/test-results
       - run:
-          name: Integration tests (Autoconnect)
+          name: Integration tests (DynamoDB)
           command: make integration-test
           environment:
             TEST_RESULTS_DIR: workspace/test-results
+#      - run:
+#          name: Integration tests (Dual Bigtable/DynamoDB)
+#          command: make integration-test
+#          environment:
+#            DB_DSN: dual
+#            TEST_RESULTS_DIR: workspace/test-results
       - store_test_results:
           path: workspace/test-results
       - save_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "httparse",
  "httpdate",
@@ -876,7 +876,7 @@ dependencies = [
  "derive_more",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "itoa 1.0.10",
  "log",
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2347,14 +2347,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa 1.0.10",
  "pin-project-lite 0.2.13",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio 1.35.1",
  "tower-service",
  "tracing",
@@ -3805,7 +3805,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",

--- a/scripts/setup_bt.sh
+++ b/scripts/setup_bt.sh
@@ -18,5 +18,5 @@ cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $MESSAGE_FAMI
 cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $MESSAGE_TOPIC_FAMILY
 cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $ROUTER_FAMILY
 cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_FAMILY maxage=1s
-cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_TOPIC_FAMILY maxversions=1
+cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_TOPIC_FAMILY "maxage=1s or maxversions=1"
 cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $ROUTER_FAMILY maxversions=1


### PR DESCRIPTION
- kill no longer used columns in Bigtable
  - current_month: vestige of monthly table rotations
  - has_topic: superfluous w/ topic column/family/row key
  - last_connect: previously a secondary index used by a script to purge stale client records (but not really ever utilized?)

- fix message_topic_family's gcpolicy (enable TTLs)

Closes: SYNC-4070
Closes: SYNC-4064
Issue: SYNC-4062