### PR TITLE
fix: channel_ids should continue being represented in hyphenated format

### DIFF
--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -103,9 +103,9 @@ fn to_string(value: Vec<u8>, name: &str) -> Result<String, DbError> {
 /// Create a normalized index key.
 fn as_key(uaid: &Uuid, channel_id: Option<&Uuid>, chidmessageid: Option<&str>) -> String {
     let mut parts: Vec<String> = Vec::new();
-    parts.push(uaid.simple().to_string());
+    parts.push(uaid.as_simple().to_string());
     if let Some(channel_id) = channel_id {
-        parts.push(channel_id.simple().to_string());
+        parts.push(channel_id.as_hyphenated().to_string());
     } else if chidmessageid.is_some() {
         parts.push("".to_string())
     }
@@ -1303,7 +1303,7 @@ mod tests {
         let chid = Uuid::parse_str(TEST_CHID).unwrap();
         let chidmessageid = "01:decafbad-0000-0000-0000-0123456789ab:Inbox";
         let k = as_key(&uaid, Some(&chid), Some(chidmessageid));
-        assert_eq!(k, "deadbeef0000000000000123456789ab#decafbad0000000000000123456789ab#01:decafbad-0000-0000-0000-0123456789ab:Inbox");
+        assert_eq!(k, "deadbeef0000000000000123456789ab#decafbad-0000-0000-0000-0123456789ab#01:decafbad-0000-0000-0000-0123456789ab:Inbox");
     }
 
     #[actix_rt::test]

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -246,7 +246,7 @@ pub struct NotificationRecord {
     #[serde(skip_serializing_if = "Option::is_none")]
     headers: Option<NotificationHeaders>,
     /// This is the acknowledgement-id used for clients to ack that they have received the
-    /// message. Some Python code refers to this as a message_id. Endpoints generate this
+    /// message. Autoendpoint refers to this as a message_id. Endpoints generate this
     /// value before sending it to storage or a connection node.
     #[serde(skip_serializing_if = "Option::is_none")]
     updateid: Option<String>,

--- a/autopush-common/src/notification.rs
+++ b/autopush-common/src/notification.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::util::ms_since_epoch;
 
 #[derive(Serialize, Default, Deserialize, Clone, Debug)]
-/// A Publishable Notification record. Thi is a notofication that is either
+/// A Publishable Notification record. This is a notification that is either
 /// received from a third party or is outbound to a UserAgent. If the
 /// UserAgent is not currently available, it may be stored as a
 /// [crate::db::NotificationRecord]


### PR DESCRIPTION
as they already are in the channel_id column and in chidmessageid

Closes: SYNC-4076