### PR TITLE
fix: errors when deleting and provisioning load test clusters

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -234,7 +234,7 @@ Execute the `setup_k8s.sh` file from the root directory and select the **delete*
 [13]: https://docs.locust.io/en/stable/writing-a-locustfile.html#wait-time
 [14]: https://docs.locust.io/en/stable/writing-a-locustfile.html#task-decorator
 [15]: https://console.cloud.google.com/home/dashboard?q=search&referrer=search&project=spheric-keel-331521&cloudshell=false
-[16]: https://console.cloud.google.com/compute/instances?project=spheric-keel-331521
+[16]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-autopush?project=spheric-keel-331521
 [17]: https://earthangel-b40313e5.influxcloud.net/d/do4mmwcVz/autopush-gcp?orgId=1&refresh=1m
 
 

--- a/tests/load/kubernetes-config/locust-master-controller.yml
+++ b/tests/load/kubernetes-config/locust-master-controller.yml
@@ -44,8 +44,8 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 2
-              memory: 3Gi
+              cpu: 4
+              memory: 4Gi
             requests:
-              cpu: 1
-              memory: 2Gi
+              cpu: 3
+              memory: 3Gi

--- a/tests/load/kubernetes-config/locust-worker-controller.yml
+++ b/tests/load/kubernetes-config/locust-worker-controller.yml
@@ -30,8 +30,8 @@ spec:
               value:
           resources:
             limits:
-              cpu: 2
-              memory: 3Gi
+              cpu: 4
+              memory: 4Gi
             requests:
-              cpu: 1
-              memory: 2Gi
+              cpu: 3
+              memory: 3Gi

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -44,8 +44,8 @@ class AutopushLoadTestShape(LoadTestShape):
     """
 
     MAX_RUN_TIME: int = 600  # 10 minutes
-    WORKER_COUNT: int = 300  # Must match value defined in setup_k8s.sh
-    USERS_PER_WORKER: int = 500  # Number of users supported on a worker running on a n1-standard-2
+    WORKER_COUNT: int = 100  # Must match value defined in setup_k8s.sh
+    USERS_PER_WORKER: int = 1500  # Number of users supported on a c3d-standard-4 hosted worker
     MAX_USERS: int = WORKER_COUNT * USERS_PER_WORKER
     trend: QuadraticTrend
     user_classes: list[Type[User]] = [AutopushUser]

--- a/tests/load/setup_k8s.sh
+++ b/tests/load/setup_k8s.sh
@@ -10,8 +10,8 @@ CLUSTER='autopush-locust-load-test'
 TARGET='https://updates-autopush.stage.mozaws.net'
 SCOPE='https://www.googleapis.com/auth/cloud-platform'
 REGION='us-central1'
-WORKER_COUNT=300
-MACHINE_TYPE='n1-standard-2' # 2 CPUs + 7.50GB Memory
+WORKER_COUNT=100
+MACHINE_TYPE='c3d-standard-4' # 4 CPUs + 16GB Memory
 BOLD=$(tput bold)
 NORM=$(tput sgr0)
 DIRECTORY=$(pwd)
@@ -99,7 +99,7 @@ do
         create) #Setup Kubernetes Cluster
             echo -e "==================== Creating the GKE cluster "
             # The total-max-nodes = WORKER_COUNT + 1 (MASTER)
-            $GCLOUD container clusters create $CLUSTER --region $REGION --scopes $SCOPE --enable-autoscaling --total-min-nodes "1" --total-max-nodes "301" --scopes=logging-write,storage-ro --addons HorizontalPodAutoscaling,HttpLoadBalancing  --machine-type $MACHINE_TYPE
+            $GCLOUD container clusters create $CLUSTER --region $REGION --scopes $SCOPE --enable-autoscaling --total-min-nodes "1" --total-max-nodes "101" --scopes=logging-write,storage-ro --addons HorizontalPodAutoscaling,HttpLoadBalancing  --machine-type $MACHINE_TYPE
             SetupGksCluster
             break
             ;;


### PR DESCRIPTION
Replaced the load test configuration to use c3d-standard-4 instead of n1-standard-2 machine types increasing the user capacity per node 3-fold

Issue: [SYNC-4082](https://mozilla-hub.atlassian.net/browse/SYNC-4082)

[SYNC-4082]: https://mozilla-hub.atlassian.net/browse/SYNC-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ