### PR TITLE
feat: [SYNC-3835] pydocstyle implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             pip install --upgrade pip
             pip install poetry
       - run:
-          name: isort, black, flake8 and mypy
+          name: isort, black, flake8, pydocstyle and mypy
           command: make lint
 
   test:
@@ -84,7 +84,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-            RUST_BACKTRACE: 1
+          RUST_BACKTRACE: 1
       - image: amazon/dynamodb-local:latest
         auth:
           username: $DOCKER_USER

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .DS_Store
 .git
+.install.stamp
 .svn
 *.pyc
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ docs/old
 
 # circleCI
 workspace
+
+# For poetry install
+.install.stamp

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ lint:
 	$(POETRY) run isort --sp $(PYPROJECT_TOML) -c $(TESTS_DIR)
 	$(POETRY) run black --quiet --diff --config $(PYPROJECT_TOML) --check $(TESTS_DIR)
 	$(POETRY) run flake8 --config $(FLAKE8_CONFIG) $(TESTS_DIR)
+	$(POETRY) run pydocstyle --config=$(PYPROJECT_TOML)
 	$(POETRY) run mypy $(TESTS_DIR) --config-file=$(PYPROJECT_TOML)
 
 load:

--- a/scripts/fernet_key.py
+++ b/scripts/fernet_key.py
@@ -1,6 +1,4 @@
-"""
-A command-line utility that generates endpoint encryption keys.
-"""
+"""A command-line utility that generates endpoint encryption keys."""
 
 from __future__ import print_function
 from cryptography.fernet import Fernet

--- a/scripts/gendpoint.py
+++ b/scripts/gendpoint.py
@@ -1,5 +1,7 @@
+"""Module to process configuration from cli arguments and environment
+variables.
+"""
 #! env python3
-
 import argparse
 import os
 
@@ -35,6 +37,7 @@ def config(env_args: os._Environ) -> argparse.Namespace:
 
 
 def main():
+    """Process environment arguments/variables and set key."""
     args = config(os.environ)
     if isinstance(args.key, list):
         key = args.key[0]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""__init__.py for integration tests."""

--- a/tests/integration/db.py
+++ b/tests/integration/db.py
@@ -59,6 +59,8 @@ class ItemNotFound(Exception):
 
 
 class DynamoDBResource(threading.local):
+    """DynamoDBResource class subclassing threading.local"""
+
     def __init__(self, **kwargs):
         conf = kwargs
         if not conf.get("endpoint_url"):
@@ -87,7 +89,7 @@ class DynamoDBResource(threading.local):
     def get_latest_message_tablenames(
         self, prefix: str = "message", previous: int = 1
     ) -> list[str]:
-        """Fetches the name of the last message table"""
+        """Fetch the name of the last message table."""
         client = self._resource.meta.client
         paginator = client.get_paginator("list_tables")
         tables = []
@@ -102,11 +104,13 @@ class DynamoDBResource(threading.local):
         return tables[0 - previous :]
 
     def get_latest_message_tablename(self, prefix: str = "message") -> str:
-        """Fetches the name of the last message table"""
+        """Fetch the name of the last message table."""
         return self.get_latest_message_tablenames(prefix=prefix, previous=1)[0]
 
 
 class DynamoDBTable(threading.local):
+    """DynamoDBTable class."""
+
     def __init__(self, ddb_resource: DynamoDBResource, *args, **kwargs) -> None:
         self._table = ddb_resource.Table(*args, **kwargs)
 
@@ -118,13 +122,24 @@ class DynamoDBTable(threading.local):
 def generate_hash(key: bytes, payload: bytes) -> str:
     """Generate a HMAC for the uaid using the secret
 
-    :returns: HMAC hash and the nonce used as a tuple (nonce, hash).
+    :param key: key
+    :type: bytes
+    :param payload: payload
+    :type: bytes
+    :returns: A hexadecimal string of the HMAC hash and the nonce, used as a tuple (nonce, hash)
+    :rtype: str
     """
     h = hmac.new(key=key, msg=payload, digestmod=hashlib.sha256)
     return h.hexdigest()
 
 
 def normalize_id(ident: uuid.UUID | str) -> str:
+    """Normalize and return ID as string
+
+    :param ident: uuid.UUID or str identifier
+    :returns: string representation of UUID
+    :raises ValueError: raises an exception if UUID is invalid
+    """
     if isinstance(ident, uuid.UUID):
         return str(ident)
     try:
@@ -134,9 +149,10 @@ def normalize_id(ident: uuid.UUID | str) -> str:
 
 
 def base64url_encode(value: bytes | str) -> str:
+    """Encode an unpadded Base64 URL-encoded string per RFC 7515."""
     if isinstance(value, str):
         value = bytes(value, "utf-8")
-    """Encodes an unpadded Base64 URL-encoded string per RFC 7515."""
+
     return base64.urlsafe_b64encode(value).strip(b"=").decode("utf-8")
 
 
@@ -155,9 +171,7 @@ MAX_DDB_SESSIONS = 50  # constants.THREAD_POOL_SIZE
 
 
 def get_month(delta: int = 0) -> datetime.date:
-    """Basic helper function to get a datetime.date object iterations months
-    ahead/behind of now.
-    """
+    """Get a datetime.date object iterations months ahead/behind of now."""
     new = last = datetime.date.today()
     # Move until we hit a new month, this avoids having to manually
     # check year changes as we push forward or backward since the Python
@@ -308,7 +322,8 @@ def get_router_table(
 
 def track_provisioned(func: Callable[..., T]) -> Callable[..., T]:
     """Tracks provisioned exceptions and increments a metric for them named
-    after the function decorated"""
+    after the function decorated.
+    """
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -224,7 +224,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             return f
 
     def connect(self, connection_port: int | None = None):
-        """Connect."""
+        """Establish a websocket connection to localhost at the provided `connection_port`."""
         url = self.url
         if connection_port:  # pragma: nocover
             url = "ws://localhost:{}/".format(connection_port)
@@ -264,7 +264,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return result
 
     def broadcast_subscribe(self, services: list[str]):
-        """Broadcast subscribe."""
+        """Broadcast WebSocket subscribe."""
         if not self.ws:
             raise Exception("WebSocket client not available as expected")
 
@@ -432,7 +432,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         self.ws.send(msg)
 
     def disconnect(self):
-        """Disconnect"""
+        """Disconnect from the application websocket."""
         self.ws.close()
 
     def sleep(self, duration: int):  # pragma: nocover
@@ -480,7 +480,12 @@ def _get_vapid(
 
 
 def enqueue_output(out, queue):
+<<<<<<< HEAD
     for line in iter(out.readline, ""):
+=======
+    """Add lines from the out buffer to the provided queue."""
+    for line in iter(out.readline, b""):
+>>>>>>> f775454 (review comments for clearer test functions)
         queue.put(line)
     out.close()
 
@@ -532,7 +537,7 @@ def max_logs(endpoint=None, conn=None):
     """
 
     def max_logs_decorator(func):
-        """Decorate max_logs."""
+        """Overwrite `max_endpoint_logs` with a given endpoint if it is specified."""
 
         def wrapper(self, *args, **kwargs):
             if endpoint is not None:
@@ -566,7 +571,7 @@ class CustomClient(Client):
     """Custom Client for testing."""
 
     def send_bad_data(self):
-        """Set `bad-data`"""
+        """Send an invalid data message via websocket to the autoconnect client."""
         self.ws.send("bad-data")
 
 
@@ -583,7 +588,9 @@ def kill_process(process):
 
 
 def get_rust_binary_path(binary):
-    """Get Rust binary path."""
+    """Get path to pre-built Rust binary.
+    This presumes that the application has already been built with proper features.
+    """
     global STRICT_LOG_COUNTS
 
     rust_bin = root_dir + "/target/release/{}".format(binary)
@@ -603,7 +610,7 @@ def get_rust_binary_path(binary):
 
 
 def write_config_to_env(config, prefix):
-    """Write configurations to env."""
+    """Write configurations to application read environment variables."""
     for key, val in config.items():
         new_key = prefix + key
         log.debug("✍ config {} => {}".format(new_key, val))
@@ -958,7 +965,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_hello_with_bad_prior_uaid(self):
-        """Test hello with bard prior uaid."""
+        """Test hello with bad prior uaid."""
         non_uaid = uuid.uuid4().hex
         client = Client(self._ws_url)
         yield client.connect()
@@ -970,7 +977,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery(self):
-        """Test basic delivery."""
+        """Test basic regular push message delivery."""
         data = str(uuid.uuid4())
         client: Client = yield self.quick_register()
         result = yield client.send_notification(data=data)
@@ -983,7 +990,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_topic_basic_delivery(self):
-        """Test topic basic delivery."""
+        """Test basic topic push message delivery."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         result = yield client.send_notification(data=data, topic="Inbox")
@@ -996,7 +1003,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_topic_replacement_delivery(self):
-        """Test topic replacement delivery."""
+        """Test that a topic push message replaces it's prior version."""
         data = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
         client = yield self.quick_register()
@@ -1045,7 +1052,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_vapid(self):
-        """Test basic delivery with vapid."""
+        """Test delivery of a basic push message with a VAPID header."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(payload=self.vapid_payload)
@@ -1059,7 +1066,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid(self):
-        """Test basic delivery with invalid vapid."""
+        """Test basic delivery with invalid VAPID header."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(payload=self.vapid_payload, endpoint=self.host_endpoint(client))
@@ -1069,7 +1076,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid_exp(self):
-        """Test basic delivery with invalid vapid exp."""
+        """Test basic delivery of a push message with invalid VAPID `exp` assertion."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(
@@ -1520,7 +1527,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_with_key(self):
-        """Test with key."""
+        """Test getting a locked subscription with a valid VAPID public key."""
         private_key = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
         claims = {
             "aud": "http://localhost:{}".format(ENDPOINT_PORT),

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -1,6 +1,4 @@
-"""
-Rust Connection and Endpoint Node Integration Tests
-"""
+"""Rust Connection and Endpoint Node Integration Tests."""
 
 import base64
 import copy
@@ -95,6 +93,7 @@ RUST_LOG = ",".join(log_string) + ",error"
 
 
 def get_free_port() -> int:
+    """Get free port."""
     port: int
     s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
     s.bind(("localhost", 0))
@@ -110,6 +109,7 @@ If that points to a file, read the settings from that file.
 
 
 def get_db_settings() -> str | dict[str, str | int | float] | None:
+    """Get database settings."""
     env_var = os.environ.get("DB_SETTINGS")
     if env_var:
         if os.path.isfile(env_var):
@@ -212,6 +212,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         }
 
     def __getattribute__(self, name: str):
+        """Turn functions into deferToThread functions."""
         # Python fun to turn all functions into deferToThread functions
         f = object.__getattribute__(self, name)
         if name.startswith("__"):
@@ -223,6 +224,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             return f
 
     def connect(self, connection_port: int | None = None):
+        """Connect."""
         url = self.url
         if connection_port:  # pragma: nocover
             url = "ws://localhost:{}/".format(connection_port)
@@ -230,6 +232,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return self.ws.connected if self.ws else None
 
     def hello(self, uaid: str | None = None, services: list[str] | None = None):
+        """Hello verification."""
         if not self.ws:
             raise Exception("WebSocket client not available as expected")
 
@@ -261,6 +264,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return result
 
     def broadcast_subscribe(self, services: list[str]):
+        """Broadcast subscribe."""
         if not self.ws:
             raise Exception("WebSocket client not available as expected")
 
@@ -269,6 +273,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         self.ws.send(msg)
 
     def register(self, chid: str | None = None, key=None, status=200):
+        """Register."""
         if not self.ws:
             raise Exception("WebSocket client not available as expected")
 
@@ -286,6 +291,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return result
 
     def unregister(self, chid):
+        """Unregister."""
         msg = json.dumps(dict(messageType="unregister", channelID=chid))
         log.debug("Send: %s", msg)
         self.ws.send(msg)
@@ -294,6 +300,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return result
 
     def delete_notification(self, channel, message=None, status=204):
+        """Delete notification."""
         messages = self.messages[channel]
         if not message:
             message = random.choice(messages)
@@ -317,6 +324,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         topic=None,
         headers=None,
     ):
+        """Send notification."""
         if not channel:
             channel = random.choice(list(self.channels.keys()))
 
@@ -375,6 +383,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             return resp
 
     def get_notification(self, timeout=1):
+        """Get notification."""
         orig_timeout = self.ws.gettimeout()
         self.ws.settimeout(timeout)
         try:
@@ -387,6 +396,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             self.ws.settimeout(orig_timeout)
 
     def get_broadcast(self, timeout=1):  # pragma: nocover
+        """Get broadcast."""
         orig_timeout = self.ws.gettimeout()
         self.ws.settimeout(timeout)
         try:
@@ -402,6 +412,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             self.ws.settimeout(orig_timeout)
 
     def ping(self):
+        """Test ping."""
         log.debug("Send: %s", "{}")
         self.ws.send("{}")
         result = self.ws.recv()
@@ -410,6 +421,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         return result
 
     def ack(self, channel, version):
+        """Acknowledge message send."""
         msg = json.dumps(
             dict(
                 messageType="ack",
@@ -420,13 +432,15 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         self.ws.send(msg)
 
     def disconnect(self):
+        """Disconnect"""
         self.ws.close()
 
     def sleep(self, duration: int):  # pragma: nocover
+        """Sleep wrapper function."""
         time.sleep(duration)
 
     def wait_for(self, func):
-        """Waits several seconds for a function to return True"""
+        """Wait several seconds for a function to return True"""
         times = 0
         while not func():  # pragma: nocover
             time.sleep(1)
@@ -440,6 +454,7 @@ def _get_vapid(
     payload: dict[str, str | int] | None = None,
     endpoint: str | None = None,
 ) -> dict[str, str | bytes]:
+    """Get vapid key."""
     global CONNECTION_CONFIG
 
     if endpoint is None:
@@ -471,6 +486,7 @@ def enqueue_output(out, queue):
 
 
 def print_lines_in_queues(queues, prefix):
+    """Print lines in queues to stdout."""
     for queue in queues:
         is_empty = False
         while not is_empty:
@@ -516,6 +532,8 @@ def max_logs(endpoint=None, conn=None):
     """
 
     def max_logs_decorator(func):
+        """Decorate max_logs."""
+
         def wrapper(self, *args, **kwargs):
             if endpoint is not None:
                 self.max_endpoint_logs = endpoint
@@ -530,24 +548,30 @@ def max_logs(endpoint=None, conn=None):
 
 @app.get("/v1/broadcasts")
 def broadcast_handler():
+    """Broadcast handler setup."""
     assert bottle.request.headers["Authorization"] == MOCK_MP_TOKEN
     MOCK_MP_POLLED.set()
     return dict(broadcasts=MOCK_MP_SERVICES)
 
 
 @app.post("/api/1/envelope/")
-def sentry_handler():
+def sentry_handler() -> dict[str, str]:
+    """Sentry handler configuration."""
     headers, item_headers, payload = bottle.request.body.read().splitlines()
     MOCK_SENTRY_QUEUE.put(json.loads(payload))
     return {"id": "fc6d8c0c43fc4630ad850ee518f1b9d0"}
 
 
 class CustomClient(Client):
+    """Custom Client for testing."""
+
     def send_bad_data(self):
+        """Set `bad-data`"""
         self.ws.send("bad-data")
 
 
 def kill_process(process):
+    """Kill child processes."""
     # This kinda sucks, but its the only way to nuke the child procs
     if process is None:
         return
@@ -559,6 +583,7 @@ def kill_process(process):
 
 
 def get_rust_binary_path(binary):
+    """Get Rust binary path."""
     global STRICT_LOG_COUNTS
 
     rust_bin = root_dir + "/target/release/{}".format(binary)
@@ -578,6 +603,7 @@ def get_rust_binary_path(binary):
 
 
 def write_config_to_env(config, prefix):
+    """Write configurations to env."""
     for key, val in config.items():
         new_key = prefix + key
         log.debug("✍ config {} => {}".format(new_key, val))
@@ -585,6 +611,7 @@ def write_config_to_env(config, prefix):
 
 
 def capture_output_to_queue(output_stream):
+    """Capture output to log queue."""
     log_queue = Queue()
     t = Thread(target=enqueue_output, args=(output_stream, log_queue))
     t.daemon = True  # thread dies with the program
@@ -593,6 +620,7 @@ def capture_output_to_queue(output_stream):
 
 
 def setup_bt():
+    """Set up BigTable emulator."""
     global BT_PROCESS, BT_DB_SETTINGS
     log.debug("🐍🟢 Starting bigtable emulator")
     BT_PROCESS = subprocess.Popen("gcloud beta emulators bigtable start".split(" "))
@@ -617,6 +645,7 @@ def setup_bt():
 
 
 def setup_dynamodb():
+    """Set up DynamoDB."""
     global DDB_PROCESS
 
     log.debug("🐍🟢 Starting dynamodb")
@@ -643,6 +672,7 @@ def setup_dynamodb():
 
 
 def setup_mock_server():
+    """Set up mock server."""
     global MOCK_SERVER_THREAD
 
     MOCK_SERVER_THREAD = Thread(target=app.run, kwargs=dict(port=MOCK_SERVER_PORT, debug=True))
@@ -654,6 +684,7 @@ def setup_mock_server():
 
 
 def setup_connection_server(connection_binary):
+    """Set up connection server from config."""
     global CN_SERVER, BT_PROCESS, DDB_PROCESS
 
     # NOTE:
@@ -692,6 +723,7 @@ def setup_connection_server(connection_binary):
 
 
 def setup_megaphone_server(connection_binary):
+    """Set up megaphone server from configuration."""
     global CN_MP_SERVER
 
     url = os.getenv("AUTOPUSH_MP_SERVER")
@@ -715,6 +747,7 @@ def setup_megaphone_server(connection_binary):
 
 
 def setup_endpoint_server():
+    """Set up endpoint server from configuration."""
     global CONNECTION_CONFIG, EP_SERVER, BT_PROCESS
 
     # Set up environment
@@ -755,6 +788,9 @@ def setup_endpoint_server():
 
 
 def setup_module():
+    """Set up module including BigTable or Dynamo
+    and connection, endpoint and megaphone servers.
+    """
     global CN_SERVER, CN_QUEUES, CN_MP_SERVER, MOCK_SERVER_THREAD, STRICT_LOG_COUNTS, RUST_LOG
 
     if "SKIP_INTEGRATION" in os.environ:  # pragma: nocover
@@ -787,6 +823,7 @@ def setup_module():
 
 
 def teardown_module():
+    """Teardown module for dynamo, bigtable, and servers."""
     if DDB_PROCESS:
         os.unsetenv("AWS_LOCAL_DYNAMODB")
         log.debug("🐍🔴 Stopping dynamodb")
@@ -804,6 +841,8 @@ def teardown_module():
 
 
 class TestRustWebPush(unittest.TestCase):
+    """Test class for Rust Web Push."""
+
     # Max log lines allowed to be emitted by each node type
     max_endpoint_logs = 8
     max_conn_logs = 3
@@ -813,16 +852,19 @@ class TestRustWebPush(unittest.TestCase):
     }
 
     def tearDown(self):
+        """Tear down and log processing."""
         process_logs(self)
         while not MOCK_SENTRY_QUEUE.empty():
             MOCK_SENTRY_QUEUE.get_nowait()
 
     def host_endpoint(self, client):
+        """Return host endpoint."""
         parsed = urlparse(list(client.channels.values())[0])
         return "{}://{}".format(parsed.scheme, parsed.netloc)
 
     @inlineCallbacks
     def quick_register(self):
+        """Quick register."""
         log.debug("🐍#### Connecting to ws://localhost:{}/".format(CONNECTION_PORT))
         client = Client("ws://localhost:{}/".format(CONNECTION_PORT))
         yield client.connect()
@@ -833,6 +875,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def shut_down(self, client=None):
+        """Shut down client."""
         if client:
             yield client.disconnect()
 
@@ -843,6 +886,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(conn=4)
     def test_sentry_output_autoconnect(self):
+        """Test sentry output for autoconnect."""
         if os.getenv("SKIP_SENTRY"):
             SkipTest("Skipping sentry test")
             return
@@ -866,6 +910,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(endpoint=1)
     def test_sentry_output_autoendpoint(self):
+        """Test sentry output for autoendpoint."""
         if os.getenv("SKIP_SENTRY"):
             SkipTest("Skipping sentry test")
             return
@@ -886,6 +931,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @max_logs(conn=4)
     def test_no_sentry_output(self):
+        """Test for no Sentry output."""
         if os.getenv("SKIP_SENTRY"):
             SkipTest("Skipping sentry test")
             return
@@ -902,6 +948,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_hello_echo(self):
+        """Test hello echo."""
         client = Client(self._ws_url)
         yield client.connect()
         result = yield client.hello()
@@ -911,6 +958,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_hello_with_bad_prior_uaid(self):
+        """Test hello with bard prior uaid."""
         non_uaid = uuid.uuid4().hex
         client = Client(self._ws_url)
         yield client.connect()
@@ -922,6 +970,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery(self):
+        """Test basic delivery."""
         data = str(uuid.uuid4())
         client: Client = yield self.quick_register()
         result = yield client.send_notification(data=data)
@@ -934,6 +983,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_topic_basic_delivery(self):
+        """Test topic basic delivery."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         result = yield client.send_notification(data=data, topic="Inbox")
@@ -946,6 +996,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_topic_replacement_delivery(self):
+        """Test topic replacement delivery."""
         data = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
         client = yield self.quick_register()
@@ -968,6 +1019,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(conn=4)
     def test_topic_no_delivery_on_reconnect(self):
+        """Test topic no delivery on reconnect."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
@@ -993,6 +1045,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_vapid(self):
+        """Test basic delivery with vapid."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(payload=self.vapid_payload)
@@ -1006,6 +1059,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid(self):
+        """Test basic delivery with invalid vapid."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(payload=self.vapid_payload, endpoint=self.host_endpoint(client))
@@ -1015,6 +1069,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid_exp(self):
+        """Test basic delivery with invalid vapid exp."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(
@@ -1030,6 +1085,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid_auth(self):
+        """Test basic delivery with invalid vapid auth."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(
@@ -1042,6 +1098,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_signature(self):
+        """Test basic delivery with invalid signature."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(
@@ -1056,6 +1113,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_basic_delivery_with_invalid_vapid_ckey(self):
+        """Test basic delivery with invalid vapid ckey."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         vapid_info = _get_vapid(payload=self.vapid_payload, endpoint=self.host_endpoint(client))
@@ -1065,6 +1123,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_delivery_repeat_without_ack(self):
+        """Test delivery repeat without ack."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
@@ -1086,6 +1145,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_repeat_delivery_with_disconnect_without_ack(self):
+        """Test repeat delivery with disconnect without ack."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         result = yield client.send_notification(data=data)
@@ -1101,6 +1161,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_multiple_delivery_repeat_without_ack(self):
+        """Test multiple delivery repeat without ack."""
         data = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
         client = yield self.quick_register()
@@ -1130,6 +1191,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_topic_expired(self):
+        """Test topic expired."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
@@ -1148,6 +1210,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(conn=4)
     def test_multiple_delivery_with_single_ack(self):
+        """Test multiple delivery with single ack."""
         data = b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
         data2 = b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
         client = yield self.quick_register()
@@ -1188,6 +1251,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_multiple_delivery_with_multiple_ack(self):
+        """Test multiple delivery with multiple ack."""
         data = b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()  # "FirstMessage"
         data2 = b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()  # "OtherMessage"
         client = yield self.quick_register()
@@ -1216,6 +1280,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_no_delivery_to_unregistered(self):
+        """Test no delivery to unregistered."""
         data = str(uuid.uuid4())
         client: Client = yield self.quick_register()
         assert client.channels
@@ -1237,6 +1302,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_ttl_0_connected(self):
+        """Test TTL 0 connected."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         result = yield client.send_notification(data=data, ttl=0)
@@ -1250,6 +1316,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_ttl_0_not_connected(self):
+        """Test TTL 0 not connected."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
@@ -1262,6 +1329,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_ttl_expired(self):
+        """Test TTL expired."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         yield client.disconnect()
@@ -1276,6 +1344,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(endpoint=28)
     def test_ttl_batch_expired_and_good_one(self):
+        """Test TTL batch expired with one good result."""
         data = str(uuid.uuid4()).encode()
         data2 = base64.urlsafe_b64decode("0012") + str(uuid.uuid4()).encode()
         print(data2)
@@ -1303,6 +1372,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(endpoint=28)
     def test_ttl_batch_partly_expired_and_good_one(self):
+        """Test TTL batch partly expired with one good result."""
         data = str(uuid.uuid4())
         data1 = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
@@ -1339,6 +1409,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_message_without_crypto_headers(self):
+        """Test message without crypto headers."""
         data = str(uuid.uuid4())
         client = yield self.quick_register()
         result = yield client.send_notification(data=data, use_header=False, status=400)
@@ -1347,6 +1418,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_empty_message_without_crypto_headers(self):
+        """Test empty message without crypto headers."""
         client = yield self.quick_register()
         result = yield client.send_notification(use_header=False)
         assert result is not None
@@ -1369,6 +1441,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_empty_message_with_crypto_headers(self):
+        """Test empty message with crypto headers."""
         client = yield self.quick_register()
         result = yield client.send_notification()
         assert result is not None
@@ -1447,6 +1520,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_with_key(self):
+        """Test with key."""
         private_key = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
         claims = {
             "aud": "http://localhost:{}".format(ENDPOINT_PORT),
@@ -1474,6 +1548,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_with_bad_key(self):
+        """Test with bad key."""
         chid = str(uuid.uuid4())
         client = Client("ws://localhost:{}/".format(CONNECTION_PORT))
         yield client.connect()
@@ -1486,6 +1561,7 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(endpoint=44)
     def test_msg_limit(self):
+        """Test message limit."""
         client = yield self.quick_register()
         uaid = client.uaid
         yield client.disconnect()
@@ -1506,6 +1582,7 @@ class TestRustWebPush(unittest.TestCase):
 
     @inlineCallbacks
     def test_can_ping(self):
+        """Test can ping."""
         client = yield self.quick_register()
         yield client.ping()
         assert client.ws.connected
@@ -1544,14 +1621,18 @@ class TestRustWebPush(unittest.TestCase):
 
 
 class TestRustWebPushBroadcast(unittest.TestCase):
+    """Test class for Rust Web Push Broadcast."""
+
     max_endpoint_logs = 4
     max_conn_logs = 1
 
     def tearDown(self):
+        """Tear down."""
         process_logs(self)
 
     @inlineCallbacks
     def quick_register(self, connection_port=None):
+        """Connect and register client."""
         conn_port = connection_port or MP_CONNECTION_PORT
         client = Client("ws://localhost:{}/".format(conn_port))
         yield client.connect()
@@ -1561,6 +1642,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def shut_down(self, client=None):
+        """Shut down client connection."""
         if client:
             yield client.disconnect()
 
@@ -1570,6 +1652,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def test_broadcast_update_on_connect(self):
+        """Test broadcast update on connect."""
         global MOCK_MP_SERVICES
         MOCK_MP_SERVICES = {"kinto:123": "ver1"}
         MOCK_MP_POLLED.clear()
@@ -1594,6 +1677,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def test_broadcast_update_on_connect_with_errors(self):
+        """Test broadcast update on connect with errors."""
         global MOCK_MP_SERVICES
         MOCK_MP_SERVICES = {"kinto:123": "ver1"}
         MOCK_MP_POLLED.clear()
@@ -1611,6 +1695,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def test_broadcast_subscribe(self):
+        """Test broadcast subscribe."""
         global MOCK_MP_SERVICES
         MOCK_MP_SERVICES = {"kinto:123": "ver1"}
         MOCK_MP_POLLED.clear()
@@ -1639,6 +1724,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def test_broadcast_subscribe_with_errors(self):
+        """Test that broadcast returns expected errors."""
         global MOCK_MP_SERVICES
         MOCK_MP_SERVICES = {"kinto:123": "ver1"}
         MOCK_MP_POLLED.clear()
@@ -1661,6 +1747,7 @@ class TestRustWebPushBroadcast(unittest.TestCase):
 
     @inlineCallbacks
     def test_broadcast_no_changes(self):
+        """Test to ensure there are no changes from broadcast."""
         global MOCK_MP_SERVICES
         MOCK_MP_SERVICES = {"kinto:123": "ver1"}
         MOCK_MP_POLLED.clear()

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -480,12 +480,8 @@ def _get_vapid(
 
 
 def enqueue_output(out, queue):
-<<<<<<< HEAD
-    for line in iter(out.readline, ""):
-=======
     """Add lines from the out buffer to the provided queue."""
-    for line in iter(out.readline, b""):
->>>>>>> f775454 (review comments for clearer test functions)
+    for line in iter(out.readline, ""):
         queue.put(line)
     out.close()
 

--- a/tests/load/locustfiles/args.py
+++ b/tests/load/locustfiles/args.py
@@ -1,3 +1,4 @@
+"""Load test arguments."""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -19,6 +20,7 @@ def parse_wait_time(val: str):
             raise ValueError("Invalid wait_time")
 
 
-def float_or_int(val: str):
+def float_or_int(val: str) -> int | float:
+    """Parse string value into float or integer."""
     float_val: float = float(val)
     return int(float_val) if float_val.is_integer() else float_val

--- a/tests/load/locustfiles/args.py
+++ b/tests/load/locustfiles/args.py
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from locust import between, constant
 
 

--- a/tests/load/locustfiles/exceptions.py
+++ b/tests/load/locustfiles/exceptions.py
@@ -7,7 +7,7 @@
 class ZeroStatusRequestError(Exception):
     """Custom exception for when a Locust request fails with a '0' status code."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         error_message: str = (
             "A connection, timeout or similar error happened while sending a request "
             "from Locust. Status Code: 0"

--- a/tests/load/locustfiles/exceptions.py
+++ b/tests/load/locustfiles/exceptions.py
@@ -1,3 +1,4 @@
+"""Custom exceptions for load tests."""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -68,13 +68,13 @@ class AutopushLoadTestShape(LoadTestShape):
         -------
         TickTuple | None
 
-        Distribution Parameters
-        -----------------------
-        user_count : Total user count
-        spawn_rate : Number of users to start/stop per second when changing
-            number of users
-        user_classes : None or a List of user classes to be spawned
-        None : Instruction to stop the load test
+        TickTuple Contained Parameters
+            user_count: Total user count
+            spawn_rate: Number of users to start/stop per second when changing
+                        number of users
+            user_classes: None or a List of user classes to be spawned
+
+        None: Instruction to stop the load test
         """
         run_time: int = self.get_run_time()
         if run_time > self.MAX_RUN_TIME:

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -29,8 +29,15 @@ class QuadraticTrend:
     def calculate_users(self, run_time: int) -> int:
         """Determine the number of active users given a run time.
 
-        Returns:
-            int: The number of users
+        Parameters
+        ----------
+        run_time : int
+            Run time in seconds
+
+        Returns
+        -------
+        run_time : int
+            The number of users
         """
         return int(round((self.a * math.pow(run_time, 2)) + (self.b * run_time) + self.c))
 
@@ -57,13 +64,17 @@ class AutopushLoadTestShape(LoadTestShape):
     def tick(self) -> TickTuple | None:
         """Override defining the desired distribution for Autopush load testing.
 
-        Returns:
-            TickTuple: Distribution parameters
-                user_count: Total user count
-                spawn_rate: Number of users to start/stop per second when changing
-                            number of users
-                user_classes: None or a List of user classes to be spawned
-            None: Instruction to stop the load test
+        Returns
+        -------
+        TickTuple | None
+
+        Distribution Parameters
+        -----------------------
+        user_count : Total user count
+        spawn_rate : Number of users to start/stop per second when changing
+            number of users
+        user_classes : None or a List of user classes to be spawned
+        None : Instruction to stop the load test
         """
         run_time: int = self.get_run_time()
         if run_time > self.MAX_RUN_TIME:

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -27,7 +27,7 @@ class QuadraticTrend:
         )
 
     def calculate_users(self, run_time: int) -> int:
-        """Determined the number of active users given a run time.
+        """Determine the number of active users given a run time.
 
         Returns:
             int: The number of users

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -1,8 +1,7 @@
+"""Performance test module."""
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""Performance test module."""
 
 import base64
 import json
@@ -61,6 +60,8 @@ def _(environment, **kwargs):
 
 
 class AutopushUser(FastHttpUser):
+    """AutopushUser class."""
+
     REST_HEADERS: dict[str, str] = {"TTL": "60", "Content-Encoding": "aes128gcm"}
     WEBSOCKET_HEADERS: dict[str, str] = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) "
@@ -79,14 +80,15 @@ class AutopushUser(FastHttpUser):
         self.ws_greenlet: Greenlet | None = None
 
     def wait_time(self):
+        """Return the autopush wait time."""
         return self.environment.autopush_wait_time(self)
 
     def on_start(self) -> Any:
-        """Called when a User starts running."""
+        """Call when a User starts running."""
         self.ws_greenlet = gevent.spawn(self.connect)
 
     def on_stop(self) -> Any:
-        """Called when a User stops running."""
+        """Call when a User stops running."""
         if self.ws:
             for channel_id in self.channels.keys():
                 self.send_unregister(self.ws, channel_id)
@@ -96,7 +98,7 @@ class AutopushUser(FastHttpUser):
             gevent.kill(self.ws_greenlet)
 
     def on_ws_open(self, ws: WebSocket) -> None:
-        """Called when opening a WebSocket.
+        """Call when opening a WebSocket.
 
         Args:
             ws: WebSocket class object
@@ -104,7 +106,7 @@ class AutopushUser(FastHttpUser):
         self.send_hello(ws)
 
     def on_ws_message(self, ws: WebSocket, data: str) -> None:
-        """Called when received data from a WebSocket.
+        """Call when received data from a WebSocket.
 
         Args:
             ws: WebSocket class object
@@ -121,7 +123,7 @@ class AutopushUser(FastHttpUser):
             del self.channels[message.channelID]
 
     def on_ws_error(self, ws: WebSocket, error: Exception) -> None:
-        """Called when there is a WebSocket error or if an exception is raised in a WebSocket
+        """Call when there is a WebSocket error or if an exception is raised in a WebSocket
         callback function.
 
         Args:
@@ -141,7 +143,7 @@ class AutopushUser(FastHttpUser):
     def on_ws_close(
         self, ws: WebSocket, close_status_code: int | None, close_msg: str | None
     ) -> None:
-        """Called when closing a WebSocket.
+        """Call when closing a WebSocket.
 
         Args:
             ws: WebSocket class object
@@ -153,7 +155,7 @@ class AutopushUser(FastHttpUser):
 
     @task(weight=98)
     def send_notification(self):
-        """Sends a notification to a registered endpoint while connected to Autopush."""
+        """Send a notification to a registered endpoint while connected to Autopush."""
         if not self.ws or not self.channels:
             logger.debug("Task 'send_notification' skipped.")
             return
@@ -163,7 +165,7 @@ class AutopushUser(FastHttpUser):
 
     @task(weight=1)
     def subscribe(self):
-        """Subscribes a user to an Autopush channel."""
+        """Subscribe a user to an Autopush channel."""
         if not self.ws:
             logger.debug("Task 'subscribe' skipped.")
             return
@@ -173,7 +175,7 @@ class AutopushUser(FastHttpUser):
 
     @task(weight=1)
     def unsubscribe(self):
-        """Unsubscribes a user from an Autopush channel."""
+        """Unsubscribe a user from an Autopush channel."""
         if not self.ws or not self.channels:
             logger.debug("Task 'unsubscribe' skipped.")
             return
@@ -182,7 +184,7 @@ class AutopushUser(FastHttpUser):
         self.send_unregister(self.ws, channel_id)
 
     def connect(self) -> None:
-        """Creates the WebSocketApp that will run indefinitely."""
+        """Create the WebSocketApp that will run indefinitely."""
         if not self.host:
             raise LocustError("'host' value is unavailable.")
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -84,11 +84,11 @@ class AutopushUser(FastHttpUser):
         return self.environment.autopush_wait_time(self)
 
     def on_start(self) -> Any:
-        """Call when a websocket starts running."""
+        """Call when a User starts running."""
         self.ws_greenlet = gevent.spawn(self.connect)
 
     def on_stop(self) -> Any:
-        """Call when a websocket stops running."""
+        """Call when a User stops running."""
         if self.ws:
             for channel_id in self.channels.keys():
                 self.send_unregister(self.ws, channel_id)

--- a/tests/load/locustfiles/models.py
+++ b/tests/load/locustfiles/models.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 """Load test models module."""
 
 from typing import Any, Literal

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -1496,6 +1496,23 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydocstyle"
+version = "6.3.0"
+description = "Python docstring style checker"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
+    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
+]
+
+[package.dependencies]
+snowballstemmer = ">=2.2.0"
+
+[package.extras]
+toml = ["tomli (>=1.2.3)"]
+
+[[package]]
 name = "pyflakes"
 version = "3.1.0"
 description = "passive checker of Python programs"
@@ -1781,6 +1798,17 @@ files = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+optional = false
+python-versions = "*"
+files = [
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -2004,4 +2032,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cd8fe171c1c1c7a930658a902148a91f392c4ee6e5b8c48551a5d2a863e1dc71"
+content-hash = "1d3d73e1e2d6e6995149fad8969a05c985db1dd404551ea7c89a7c12ddc7c8d0"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -30,6 +30,7 @@ license = "Mozilla Public License Version 2.0"
 [tool.poetry.dependencies]
 python = "^3.10"
 websocket-client = "^1.7.0"
+pydocstyle = "^6.3.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.0"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -20,6 +20,19 @@ warn_return_any = true
 warn_unused_ignores = true
 warn_unreachable = true
 
+[tool.pydocstyle]
+match = ".*\\.py"
+convention = "pep257"
+# Error Code Ref: https://www.pydocstyle.org/en/stable/error_codes.html
+# D212 Multi-line docstring summary should start at the first line
+add-select = ["D212"]
+# D105 Docstrings for magic methods
+# D107 Docstrings for __init__
+# D203 as it conflicts with D211 https://github.com/PyCQA/pydocstyle/issues/141
+# D205 1 blank line required between summary line and description, awkward spacing
+# D400 First line should end with a period, doesn't work when sentence spans 2 lines
+add-ignore = ["D105","D107","D203", "D205", "D400"]
+
 [tool.poetry]
 name = "tests"
 version = "0.1.0"


### PR DESCRIPTION
## References

JIRA: [SYNC-3835](https://mozilla-hub.atlassian.net/browse/SYNC-3835)

## Description
Addition of [pydocstyle](https://www.pydocstyle.org/en/stable/) to python testing section of autopush.

Acceptance Criteria
-     pydocstyle is added and applied as a dev dependency for the Python test solutions
-     Configurations can be set in the pyproject.toml
-     The CI is updated to execute pydocstyle
-     Documentation is updated accordingly

The following has been implemented:
- Added `pydocstyle` to the `lint` command and also implemented a `make pydocstyle` command that can be called on its own for a richer output on recommendations.
- Added pydocstyle to run as part of CI flow.
- Added `.install.stamp` to manage poetry dependency installation whenever commands invoked. This was then added to `.gitignore` and `.dockerignore`
- Integration tests have docstring annotations describing the test functions. Note that this was done rather simply, mimicking the name of the test function. Given we will modernize and refactor the integration tests, it didn't seem prudent  to waste too much time on this. 
- Load test docstrings updated. Since it seemed the those were hedging towards the NumPy standard of docstrings, I made the decision to follow that convention over reStructuredText, since it is a bit more readable.  Both are official implementations supported by Sphinx. If someone prefers reStructuredText, that can be used instead.
## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/autopush-rs/blob/master/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[SYNC-####]`, and has the same title (if applicable)
- [x] Documentation has been updated (if applicable
- [x] Functional and performance test coverage has been expanded and maintained (if applicable)

[SYNC-3835]: https://mozilla-hub.atlassian.net/browse/SYNC-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ