### PR TITLE
fix: fix remove_node_id's condition check to be more reliable

### DIFF
--- a/autoendpoint/src/routers/webpush.rs
+++ b/autoendpoint/src/routers/webpush.rs
@@ -197,7 +197,7 @@ impl WebPushRouter {
         self.metrics.incr("updates.client.host_gone").ok();
         let removed = self
             .db
-            .remove_node_id(&user.uaid, node_id, user.connected_at)
+            .remove_node_id(&user.uaid, node_id, user.connected_at, &user.version)
             .await?;
         if !removed {
             debug!("✉ The node id was not removed");

--- a/autopush-common/src/db/client.rs
+++ b/autopush-common/src/db/client.rs
@@ -53,8 +53,13 @@ pub trait DbClient: Send + Sync {
     /// Remove the node ID from a user in the router table. Returns whether the
     /// removal occurred. The node ID will only be removed if `connected_at`
     /// matches up with the item's `connected_at`.
-    async fn remove_node_id(&self, uaid: &Uuid, node_id: &str, connected_at: u64)
-        -> DbResult<bool>;
+    async fn remove_node_id(
+        &self,
+        uaid: &Uuid,
+        node_id: &str,
+        connected_at: u64,
+        version: &Option<Uuid>,
+    ) -> DbResult<bool>;
 
     /// Save a message to the message table
     async fn save_message(&self, uaid: &Uuid, message: Notification) -> DbResult<()>;

--- a/autopush-common/src/db/dual/mod.rs
+++ b/autopush-common/src/db/dual/mod.rs
@@ -206,13 +206,16 @@ impl DbClient for DualClientImpl {
         uaid: &Uuid,
         node_id: &str,
         connected_at: u64,
+        version: &Option<Uuid>,
     ) -> DbResult<bool> {
         let (target, is_primary) = self.allot(uaid).await?;
-        let mut result = target.remove_node_id(uaid, node_id, connected_at).await?;
+        let mut result = target
+            .remove_node_id(uaid, node_id, connected_at, version)
+            .await?;
         if is_primary {
             result = self
                 .secondary
-                .remove_node_id(uaid, node_id, connected_at)
+                .remove_node_id(uaid, node_id, connected_at, version)
                 .await?
                 || result;
         }

--- a/autopush-common/src/db/dynamodb/mod.rs
+++ b/autopush-common/src/db/dynamodb/mod.rs
@@ -353,6 +353,7 @@ impl DbClient for DdbClientImpl {
         uaid: &Uuid,
         node_id: &str,
         connected_at: u64,
+        _version: &Option<Uuid>,
     ) -> DbResult<bool> {
         let input = UpdateItemInput {
             key: ddb_item! { uaid: s => uaid.simple().to_string() },

--- a/autopush-common/src/db/mock.rs
+++ b/autopush-common/src/db/mock.rs
@@ -53,9 +53,10 @@ impl DbClient for Arc<MockDbClient> {
         uaid: &Uuid,
         node_id: &str,
         connected_at: u64,
+        version: &Option<Uuid>,
     ) -> DbResult<bool> {
         Arc::as_ref(self)
-            .remove_node_id(uaid, node_id, connected_at)
+            .remove_node_id(uaid, node_id, connected_at, version)
             .await
     }
 

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -182,6 +182,7 @@ pub struct User {
     //TODO: rename this to `last_notification_timestamp`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_timestamp: Option<u64>,
+    pub version: Option<Uuid>,
 }
 
 impl Default for User {
@@ -198,6 +199,7 @@ impl Default for User {
             record_version: Some(USER_RECORD_VERSION),
             current_month: None,
             current_timestamp: None,
+            version: Some(Uuid::new_v4()),
         }
     }
 }

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -182,6 +182,7 @@ pub struct User {
     //TODO: rename this to `last_notification_timestamp`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_timestamp: Option<u64>,
+    /// UUID4 version number for optimistic locking of updates on Bigtable
     pub version: Option<Uuid>,
 }
 

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -1486,7 +1486,6 @@ class TestRustWebPush(unittest.TestCase):
     @inlineCallbacks
     @max_logs(endpoint=44)
     def test_msg_limit(self):
-        self.skipTest("known broken")
         client = yield self.quick_register()
         uaid = client.uaid
         yield client.disconnect()


### PR DESCRIPTION
this adds a "version" column to the router CF to act as an optimistic locking version number which the majority of writes reset the value of.

whether version has changed since the router record was read becomes the condition for update_user/remove_node_id

Closes: SYNC-4115