### PR TITLE
fix: fix add/update_user version field handling on migrations

### DIFF
--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
@@ -136,7 +136,7 @@ impl UnidentifiedClient {
                     }
                     user.connected_at = connected_at;
                     user.set_last_connect();
-                    if !self.app_state.db.update_user(&user).await? {
+                    if !self.app_state.db.update_user(&mut user).await? {
                         let _ = self.app_state.metrics.incr("ua.already_connected");
                         return Err(SMErrorKind::AlreadyConnected.into());
                     }

--- a/autoendpoint/src/routers/adm/router.rs
+++ b/autoendpoint/src/routers/adm/router.rs
@@ -148,7 +148,7 @@ impl Router for AdmRouter {
             );
             user.router_data = Some(router_data);
 
-            if !self.db.update_user(&user).await? {
+            if !self.db.update_user(&mut user).await? {
                 // Unlikely to occur on mobile records
                 return Err(ApiErrorKind::General("Conditional update failed".to_owned()).into());
             }

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -107,7 +107,7 @@ pub async fn update_token_route(
     let router_data = router.register(&router_data_input, &path_args.app_id)?;
 
     // Update the user in the database
-    let user = User {
+    let mut user = User {
         uaid: path_args.uaid,
         router_type: path_args.router_type.to_string(),
         router_data: Some(router_data),
@@ -115,7 +115,7 @@ pub async fn update_token_route(
     };
     trace!("🌍 Updating user with UAID {}", user.uaid);
     trace!("🌍 user = {:?}", user);
-    if !app_state.db.update_user(&user).await? {
+    if !app_state.db.update_user(&mut user).await? {
         // Unlikely to occur on mobile records
         return Err(ApiErrorKind::General("Conditional update failed".to_owned()).into());
     }

--- a/autopush-common/src/db/client.rs
+++ b/autopush-common/src/db/client.rs
@@ -30,7 +30,7 @@ pub trait DbClient: Send + Sync {
     /// update will not occur if the user does not already exist, has a
     /// different router type, or has a newer `connected_at` timestamp.
     // TODO: make the bool a #[must_use]
-    async fn update_user(&self, user: &User) -> DbResult<bool>;
+    async fn update_user(&self, user: &mut User) -> DbResult<bool>;
 
     /// Read a user from the database
     async fn get_user(&self, uaid: &Uuid) -> DbResult<Option<User>>;

--- a/autopush-common/src/db/dynamodb/mod.rs
+++ b/autopush-common/src/db/dynamodb/mod.rs
@@ -159,7 +159,7 @@ impl DbClient for DdbClientImpl {
         Ok(())
     }
 
-    async fn update_user(&self, user: &User) -> DbResult<bool> {
+    async fn update_user(&self, user: &mut User) -> DbResult<bool> {
         let mut user_map = serde_dynamodb::to_hashmap(&user)?;
         user_map.remove("uaid");
         let input = UpdateItemInput {

--- a/autopush-common/src/db/mock.rs
+++ b/autopush-common/src/db/mock.rs
@@ -20,7 +20,7 @@ impl DbClient for Arc<MockDbClient> {
         Arc::as_ref(self).add_user(user).await
     }
 
-    async fn update_user(&self, user: &User) -> DbResult<bool> {
+    async fn update_user(&self, user: &mut User) -> DbResult<bool> {
         Arc::as_ref(self).update_user(user).await
     }
 


### PR DESCRIPTION
- explicitly add a version (which there is None from DynamoDB) in dual mode migration
- Bigtable::add_user now writes the initial version passed in
- Bigtable::update_user continues always writing a new version but now modifies the &mut User upon success

Closes: SYNC-4147