### PR TITLE
docs: update path to push architecture schema

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-![image](assets/push_architecture2.svg)
+![image](assets/push_architecture.svg)
 
 ## Overview
 


### PR DESCRIPTION
Fixes 404 for push architecture schema at docs 

<img width="1072" alt="image" src="https://github.com/mozilla-services/autopush-rs/assets/44056222/771431e9-8dc6-4f57-839a-5aeaefc0b298">
