### PR TITLE
feat: Add `profile_app_id` routing hint to bigtable requests

### DIFF
--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -44,6 +44,10 @@ pub struct BigTableDbSettings {
     /// bigtable.
     #[serde(default)]
     pub table_name: String,
+    /// Routing replication profile id.
+    /// Should be used everywhere we set `table_name` when creating requests
+    #[serde(default)]
+    pub profile_id: String,
     #[serde(default)]
     pub router_family: String,
     #[serde(default)]
@@ -98,7 +102,7 @@ impl BigTableDbSettings {
 impl TryFrom<&str> for BigTableDbSettings {
     type Error = DbError;
     fn try_from(setting_string: &str) -> Result<Self, Self::Error> {
-        let me: Self = serde_json::from_str(setting_string)
+        let mut me: Self = serde_json::from_str(setting_string)
             .map_err(|e| DbError::General(format!("Could not parse DdbSettings: {:?}", e)))?;
 
         if me.table_name.starts_with('/') {
@@ -106,6 +110,13 @@ impl TryFrom<&str> for BigTableDbSettings {
                 "Table name path begins with a '/'".to_owned(),
             ));
         };
+
+        // specify the default string "default" if it's not specified.
+        // There's a small chance that this could be reported as "unspecified", so this
+        // removes that confusion.
+        if me.profile_id.is_empty() {
+            me.profile_id = "default".to_owned();
+        }
 
         Ok(me)
     }

--- a/autopush-common/src/db/bigtable/pool.rs
+++ b/autopush-common/src/db/bigtable/pool.rs
@@ -184,7 +184,7 @@ impl Manager for BigtableClientManager {
         // note, this changes to `blocks_in_conditions` for 1.76+
         #[allow(clippy::blocks_in_conditions)]
         if !client
-            .health_check(&self.settings.table_name)
+            .health_check(&self.settings.table_name, &self.settings.profile_id)
             .await
             .map_err(|e| {
                 debug!("🏊 Recycle requested (health). {:?}", e);


### PR DESCRIPTION
Based on [what I found](https://github.com/googleapis/google-cloud-python/blob/6838a4f11162544c0654f3ce99fac5a7c510237a/bigtable/google/cloud/bigtable_v2/proto/bigtable_pb2.py#L1245) in th e python lib.

Closes: SYNC-4153