### PR TITLE
feat: Attempt retry for Bigtable read row.

### DIFF
--- a/autopush-common/src/db/bigtable/bigtable_client/error.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/error.rs
@@ -115,6 +115,10 @@ pub enum BigTableError {
     /// General Pool builder errors.
     #[error("Pool Error: {0}")]
     Pool(String),
+
+    /// Retryable error
+    #[error("Retry")]
+    Retry(grpcio::RpcStatusCode),
 }
 
 impl ReportableError for BigTableError {
@@ -144,6 +148,7 @@ impl ReportableError for BigTableError {
             BigTableError::Recycle => "storage.bigtable.error.recycle",
             BigTableError::Pool(_) => "storage.bigtable.error.pool",
             BigTableError::GRPC(_) => "storage.bigtable.error.grpc",
+            BigTableError::Retry(_) => return None,
         };
         Some(err)
     }

--- a/autopush-common/src/db/bigtable/bigtable_client/merge.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/merge.rs
@@ -387,6 +387,13 @@ impl RowMerger {
             stream = s;
             let row = match row_resp_res {
                 Ok(v) => v,
+                Err(grpcio::Error::RpcFailure(status))
+                    if status
+                        .message()
+                        .contains("Error occurred when fetching oauth2 token") =>
+                {
+                    return Err(BigTableError::Retry(status.code()));
+                }
                 Err(e) => return Err(BigTableError::InvalidRowResponse(e)),
             };
             /*


### PR DESCRIPTION
This is an exploritory patch to see if we should retry read operations if we get a Bigtable oauth2 token request error.

Issue: SYNC-4157