### PR TITLE
feat: include tags/extras across the exception chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio 0.8.10",
+ "mio 0.8.11",
  "socket2",
  "tokio 1.36.0",
  "tracing",
@@ -2456,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -4231,7 +4231,7 @@ dependencies = [
  "backtrace",
  "bytes 1.5.0",
  "libc",
- "mio 0.8.10",
+ "mio 0.8.11",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.13",

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/error.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/error.rs
@@ -56,6 +56,7 @@ impl ReportableError for SMError {
     fn reportable_source(&self) -> Option<&(dyn ReportableError + 'static)> {
         match &self.kind {
             SMErrorKind::MakeEndpoint(e) => Some(e),
+            SMErrorKind::Database(e) => Some(e),
             _ => None,
         }
     }

--- a/autopush-common/src/db/bigtable/bigtable_client/row.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/row.rs
@@ -47,7 +47,7 @@ impl Row {
     /// Like [take_cell] but returns an Error when no cell is present
     pub fn take_required_cell(&mut self, column: &str) -> DbResult<Cell> {
         self.take_cell(column)
-            .ok_or_else(|| DbError::Integrity(format!("Expected column: {column}")))
+            .ok_or_else(|| DbError::Integrity(format!("Expected column: {column}"), None))
     }
 
     /// Add cells to a given family

--- a/autopush-common/src/db/error.rs
+++ b/autopush-common/src/db/error.rs
@@ -75,7 +75,7 @@ pub enum DbError {
     Conditional,
 
     #[error("Database integrity error: {}", _0)]
-    Integrity(String),
+    Integrity(String, Option<String>),
 
     #[error("Unknown Database Error {0}")]
     General(String),
@@ -122,6 +122,7 @@ impl ReportableError for DbError {
             DbError::Backoff(e) => {
                 vec![("raw", e.to_string())]
             }
+            DbError::Integrity(_, Some(row)) => vec![("row", row.clone())],
             _ => vec![],
         }
     }

--- a/autopush-common/src/middleware/sentry.rs
+++ b/autopush-common/src/middleware/sentry.rs
@@ -8,7 +8,6 @@ use cadence::{CountedExt, StatsdClient};
 use futures::{future::LocalBoxFuture, FutureExt};
 use futures_util::future::{ok, Ready};
 use sentry::{protocol::Event, Hub};
-use serde_json::value::Value;
 
 use crate::{errors::ReportableError, tags::Tags};
 
@@ -114,17 +113,7 @@ where
                         }
                     };
                     debug!("Reporting error to Sentry (service error): {}", error);
-                    let mut event = event_from_actix_error::<E>(&error);
-                    event.extra.append(&mut tags.clone().extra_tree());
-                    event.tags.append(&mut tags.clone().tag_tree());
-                    if let Some(reportable_err) = error.as_error::<E>() {
-                        for (key, val) in reportable_err.extras() {
-                            event.extra.insert(key.to_owned(), Value::from(val));
-                        }
-                        for (key, val) in reportable_err.tags() {
-                            event.tags.insert(key.to_owned(), val);
-                        }
-                    }
+                    let event = event_from_actix_error::<E>(&error);
                     let event_id = hub.capture_event(event);
                     trace!("event_id = {}", event_id);
                     return Err(error);
@@ -143,17 +132,7 @@ where
                     }
                 }
                 debug!("Reporting error to Sentry (response error): {}", error);
-                let mut event = event_from_actix_error::<E>(error);
-                event.extra.append(&mut tags.clone().extra_tree());
-                event.tags.append(&mut tags.clone().tag_tree());
-                if let Some(reportable_err) = error.as_error::<E>() {
-                    for (key, val) in reportable_err.extras() {
-                        event.extra.insert(key.to_owned(), Value::from(val));
-                    }
-                    for (key, val) in reportable_err.tags() {
-                        event.tags.insert(key.to_owned(), val);
-                    }
-                }
+                let event = event_from_actix_error::<E>(error);
                 let event_id = hub.capture_event(event);
                 trace!("event_id = {}", event_id);
             }


### PR DESCRIPTION
- add extras for diagnosing db errors in SYNC-4172
- update mio per RUSTSEC-2024-0019

Closes: SYNC-4145
Issue: SYNC-4172