### PR TITLE
feat: Add backstage info 

### DIFF
--- a/autoconnect/catalog-info.yaml
+++ b/autoconnect/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: autoconnect
+  description: Mozilla's Web Push User Agent Client
+spec:
+  type: service
+  lifecycle: production
+  owner: push-admin@mozilla.com
+  system: sync-ecosystem
+  dependsOn:
+    - google-cloud-rust/googleapis-raw/gcp-bigtable
+

--- a/autoendpoint/catalog-info.yaml
+++ b/autoendpoint/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: autoendpoint
+  description: Mozilla's Web Push HTTPS Endpoint server
+spec:
+  type: service
+  lifecycle: production
+  owner: push-admin@mozilla.com
+  system: sync-ecosystem
+  dependsOn:
+    - google-cloud-rust/googleapis-raw/gcp-bigtable
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,13 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Location
 metadata:
   name: autopush
   description: Mozilla's Web Push server
 spec:
-  type: service
+  type: url
   lifecycle: production
   owner: push-admin@mozilla.com
   system: sync-ecosystem
-  dependsOn:
-    - Component:google-cloud-rust/googleapis-raw
+  targets:
+    - ./autoconnect/catalog-info.yaml
+    - ./autoendpoint/catalog-info.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: autopush
+  description: Mozilla's Web Push server
+spec:
+  type: service
+  lifecycle: production
+  owner: push-admin@mozilla.com
+  system: sync-ecosystem
+  dependsOn:
+    - Component:google-cloud-rust/googleapis-raw


### PR DESCRIPTION
Add [Backstage](https://backstage.io/docs/features/software-catalog/) compatible information. 

Backstage is used by similar systems [like FxA](https://github.com/mozilla/fxa/blob/main/catalog-info.yaml) in order to provide an easy overview of systems inter-relationships. This can allow us to graph dependencies as well as predict the impacts of system outages. It may also help us easily identify customers and dependencies. 

This is currently a work in progress. 