### PR TITLE
chore: update per RUSTSEC-2024-0336

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,4 +8,6 @@ ignore = [
     "RUSTSEC-2023-0052", # Bound by Rusoto 0.47, Rustls 0.20, hyper-rustls 0.22, a2 0.8
     "RUSTSEC-2023-0065", # Bound by tokio-tungstenite
     "RUSTSEC-2024-0006", # Bound by Rusoto 0.42
+    "RUSTSEC-2024-0336", # Bound by hyper-alpn 0.4.1, hyper-rustls 0.22.0/0.23.4,
+                         # tokio-rustls 0.22.0/0.23.4 (not affected)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-native-certs 0.6.3",
  "tokio 1.37.0",
  "tokio-rustls 0.24.1",
@@ -2505,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3680,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -4672,7 +4672,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio 1.37.0",
 ]
 
@@ -5476,7 +5476,7 @@ dependencies = [
  "itertools",
  "log",
  "percent-encoding",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-pemfile",
  "seahash",
  "serde",


### PR DESCRIPTION
also ignore it because our rustls 0.19/0.20 is only used by tokio-rustls (not affected per the RUSTSEC) and http client lib usage (hyper-alpn and hyper-rustls 0.22)