### PR TITLE
feat: fixturize pytest

### DIFF
--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -82,7 +82,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         parsed = urlparse(list(self.channels.values())[0])
         return f"{parsed.scheme}://{parsed.netloc}"
 
-    async def hello(self, uaid: str | None = None, services: list[str] | None = None):
+    async def hello(self, uaid: str | None = None, services: dict[str, str] | None = None):
         """Hello verification."""
         if not self.ws:
             raise WebSocketException("WebSocket client not available as expected.")
@@ -114,7 +114,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         self.uaid = result["uaid"]
         return result
 
-    async def broadcast_subscribe(self, services: list[str]) -> None:
+    async def broadcast_subscribe(self, services: dict[str, str]) -> None:
         """Broadcast WebSocket subscribe."""
         if not self.ws:
             raise WebSocketException("WebSocket client not available as expected.")
@@ -175,7 +175,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         self,
         channel=None,
         version=None,
-        data: str | None = None,
+        data: str | bytes | None = None,
         use_header: bool = True,
         status: int = 201,
         # 202 status reserved for yet to be implemented push w/ reciept.
@@ -215,9 +215,9 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             headers.update({"Crypto-Key": f"{headers.get('Crypto-Key', '')};{ckey}"})
         if topic:
             headers["Topic"] = topic
-        body: str = data or ""
+        body: str | bytes = data or ""
         method: str = "POST"
-        log.debug(f"{method} body: {body}")
+        log.debug(f"{method} body: {body!r}")
         log.debug(f"  headers: {headers}")
         async with httpx.AsyncClient() as httpx_client:
             resp = await httpx_client.request(

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -77,6 +77,11 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         log.debug(f"Send: {payload}")
         await self.ws.send(payload)
 
+    def get_host_client_endpoint(self) -> str:
+        """Return host endpoint from client."""
+        parsed = urlparse(list(self.channels.values())[0])
+        return f"{parsed.scheme}://{parsed.netloc}"
+
     async def hello(self, uaid: str | None = None, services: list[str] | None = None):
         """Hello verification."""
         if not self.ws:

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -272,7 +272,6 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             d = await asyncio.wait_for(self.ws.recv(), timeout)
             log.debug(f"Recv: {d}")
             result = json.loads(d)
-            assert result.get("messageType") == ClientMessageType.BROADCAST.value
             return result
         except WebSocketException as ex:  # pragma: no cover
             log.error(f"Error: {ex}")

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -703,7 +703,6 @@ class TestRustWebPush:
     def _ws_url(self):
         return f"ws://127.0.0.1:{CONNECTION_PORT}/"
 
-    @pytest.mark.asyncio
     @max_logs(conn=4)
     async def test_sentry_output_autoconnect(self):
         """Test sentry output for autoconnect."""
@@ -735,7 +734,6 @@ class TestRustWebPush:
             pass
         assert event1["exception"]["values"][0]["value"] == "LogCheck"
 
-    @pytest.mark.asyncio
     @max_logs(endpoint=1)
     async def test_sentry_output_autoendpoint(self):
         """Test sentry output for autoendpoint."""
@@ -763,7 +761,6 @@ class TestRustWebPush:
         assert "LogCheck" in values
         assert sorted(values) == ["ERROR:Success", "LogCheck"]
 
-    @pytest.mark.asyncio
     @max_logs(conn=4)
     async def test_no_sentry_output(self):
         """Test for no Sentry output."""
@@ -783,7 +780,6 @@ class TestRustWebPush:
         except Empty:
             pass
 
-    @pytest.mark.asyncio
     async def test_hello_echo(self, test_client):
         """Test hello echo."""
         await test_client.connect()
@@ -792,7 +788,6 @@ class TestRustWebPush:
         assert result["use_webpush"] is True
         await test_client.disconnect()
 
-    @pytest.mark.asyncio
     async def test_hello_with_bad_prior_uaid(self, test_client):
         """Test hello with bad prior uaid."""
         non_uaid = uuid.uuid4().hex
@@ -803,7 +798,6 @@ class TestRustWebPush:
         assert result["use_webpush"] is True
         await test_client.disconnect()
 
-    @pytest.mark.asyncio
     async def test_basic_delivery(self, registered_test_client):
         """Test basic regular push message delivery."""
         data = str(uuid.uuid4())
@@ -814,7 +808,6 @@ class TestRustWebPush:
         assert result["data"] == base64url_encode(bytes(data, "utf-8"))
         assert result["messageType"] == "notification"
 
-    @pytest.mark.asyncio
     async def test_topic_basic_delivery(self, registered_test_client):
         """Test basic topic push message delivery."""
         data = str(uuid.uuid4())
@@ -825,7 +818,6 @@ class TestRustWebPush:
         assert result["data"] == base64url_encode(data)
         assert result["messageType"] == "notification"
 
-    @pytest.mark.asyncio
     async def test_topic_replacement_delivery(self, registered_test_client):
         """Test that a topic push message replaces it's prior version."""
         data = str(uuid.uuid4())
@@ -845,7 +837,6 @@ class TestRustWebPush:
         result = await registered_test_client.get_notification()
         assert result is None
 
-    @pytest.mark.asyncio
     @max_logs(conn=4)
     async def test_topic_no_delivery_on_reconnect(self):
         """Test that a topic message does not attempt to redeliver on reconnect."""
@@ -872,7 +863,6 @@ class TestRustWebPush:
         await client.hello()
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_vapid(self, registered_test_client, vapid_payload):
         """Test delivery of a basic push message with a VAPID header."""
         data = str(uuid.uuid4())
@@ -884,7 +874,6 @@ class TestRustWebPush:
         assert result["data"] == base64url_encode(data)
         assert result["messageType"] == "notification"
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_invalid_vapid(self, registered_test_client, vapid_payload):
         """Test basic delivery with invalid VAPID header."""
         data = str(uuid.uuid4())
@@ -894,7 +883,6 @@ class TestRustWebPush:
         vapid_info["crypto-key"] = "invalid"
         await registered_test_client.send_notification(data=data, vapid=vapid_info, status=401)
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_invalid_vapid_exp(self, registered_test_client):
         """Test basic delivery of a push message with invalid VAPID `exp` assertion."""
         data = str(uuid.uuid4())
@@ -908,7 +896,6 @@ class TestRustWebPush:
         vapid_info["crypto-key"] = "invalid"
         await registered_test_client.send_notification(data=data, vapid=vapid_info, status=401)
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_invalid_vapid_auth(
         self, registered_test_client, vapid_payload
     ):
@@ -921,7 +908,6 @@ class TestRustWebPush:
         vapid_info["auth"] = ""
         await registered_test_client.send_notification(data=data, vapid=vapid_info, status=401)
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_invalid_signature(self, registered_test_client):
         """Test that a basic delivery with invalid VAPID signature fails."""
         data = str(uuid.uuid4())
@@ -934,7 +920,6 @@ class TestRustWebPush:
         vapid_info["auth"] = f"{vapid_info['auth'][:-3]}bad"
         await registered_test_client.send_notification(data=data, vapid=vapid_info, status=401)
 
-    @pytest.mark.asyncio
     async def test_basic_delivery_with_invalid_vapid_ckey(
         self, registered_test_client, vapid_payload
     ):
@@ -946,7 +931,6 @@ class TestRustWebPush:
         vapid_info["crypto-key"] = "invalid|"
         await registered_test_client.send_notification(data=data, vapid=vapid_info, status=401)
 
-    @pytest.mark.asyncio
     async def test_delivery_repeat_without_ack(self, registered_test_client):
         """Test that message delivery repeats if the client does not acknowledge messages."""
         data = str(uuid.uuid4())
@@ -966,7 +950,6 @@ class TestRustWebPush:
         assert result != {}
         assert result["data"] == base64url_encode(data)
 
-    @pytest.mark.asyncio
     async def test_repeat_delivery_with_disconnect_without_ack(self, registered_test_client):
         """Test that message delivery repeats if the client disconnects
         without acknowledging the message.
@@ -982,7 +965,6 @@ class TestRustWebPush:
         assert result != {}
         assert result["data"] == base64url_encode(data)
 
-    @pytest.mark.asyncio
     async def test_multiple_delivery_repeat_without_ack(self, registered_test_client):
         """Test that the server will always try to deliver messages
         until the client acknowledges them.
@@ -1012,7 +994,6 @@ class TestRustWebPush:
         assert result != {}
         assert result["data"] in map(base64url_encode, [data, data2])
 
-    @pytest.mark.asyncio
     async def test_topic_expired(self, registered_test_client):
         """Test that the server will not deliver a message topic that has expired."""
         data = str(uuid.uuid4())
@@ -1028,7 +1009,6 @@ class TestRustWebPush:
         assert result != {}
         assert result["data"] == base64url_encode(data)
 
-    @pytest.mark.asyncio
     @max_logs(conn=4)
     async def test_multiple_delivery_with_single_ack(self):
         """Test that the server provides the right unacknowledged messages
@@ -1074,7 +1054,6 @@ class TestRustWebPush:
         assert result is None
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_multiple_delivery_with_multiple_ack(self, registered_test_client):
         """Test that the server provides the no additional unacknowledged messages
         if the client acknowledges both of the received messages.
@@ -1105,7 +1084,6 @@ class TestRustWebPush:
         result = await registered_test_client.get_notification(timeout=0.5)
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_no_delivery_to_unregistered(self, registered_test_client):
         """Test that the server does not try to deliver to unregistered channel IDs."""
         data = str(uuid.uuid4())
@@ -1126,7 +1104,6 @@ class TestRustWebPush:
         )
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_ttl_0_connected(self, registered_test_client):
         """Test that a message with a TTL=0 is delivered to a client that is actively connected."""
         data = str(uuid.uuid4())
@@ -1138,7 +1115,6 @@ class TestRustWebPush:
         assert result["data"] == base64url_encode(data)
         assert result["messageType"] == "notification"
 
-    @pytest.mark.asyncio
     async def test_ttl_0_not_connected(self, registered_test_client):
         """Test that a message with a TTL=0 and a recipient client that is not connected,
         is not delivered when the client reconnects.
@@ -1151,7 +1127,6 @@ class TestRustWebPush:
         result = await registered_test_client.get_notification(timeout=0.5)
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_ttl_expired(self, registered_test_client):
         """Test that messages with a TTL that has expired are not delivered
         to a recipient client.
@@ -1165,7 +1140,6 @@ class TestRustWebPush:
         result = await registered_test_client.get_notification(timeout=0.5)
         assert result is None
 
-    @pytest.mark.asyncio
     @max_logs(endpoint=28)
     async def test_ttl_batch_expired_and_good_one(self):
         """Test that if a batch of messages are received while the recipient is offline,
@@ -1196,7 +1170,6 @@ class TestRustWebPush:
         assert result is None
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     @max_logs(endpoint=28)
     async def test_ttl_batch_partly_expired_and_good_one(self):
         """Test that if a batch of messages are received while the recipient is offline,
@@ -1237,7 +1210,6 @@ class TestRustWebPush:
         assert result is None
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_message_without_crypto_headers(self):
         """Test that a message without crypto headers, but has data is not accepted."""
         data = str(uuid.uuid4())
@@ -1246,7 +1218,6 @@ class TestRustWebPush:
         assert result is None
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_empty_message_without_crypto_headers(self):
         """Test that a message without crypto headers, and does not have data, is accepted."""
         client = await self.quick_register()
@@ -1269,7 +1240,6 @@ class TestRustWebPush:
 
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_empty_message_with_crypto_headers(self):
         """Test that an empty message with crypto headers does not send either `headers`
         or `data` as part of the incoming websocket `notification` message.
@@ -1303,7 +1273,6 @@ class TestRustWebPush:
 
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_big_message(self):
         """Test that we accept a large message.
 
@@ -1335,7 +1304,6 @@ class TestRustWebPush:
 
     # Skipping test for now.
     # Note: dict_keys obj was not iterable, corrected by converting to iterable.
-    @pytest.mark.asyncio
     async def test_delete_saved_notification(self, registered_test_client):
         """Test deleting a saved notification in client server."""
         await registered_test_client.disconnect()
@@ -1350,7 +1318,6 @@ class TestRustWebPush:
         result = await registered_test_client.get_notification()
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_with_key(self, test_client):
         """Test getting a locked subscription with a valid VAPID public key."""
         private_key = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
@@ -1375,7 +1342,6 @@ class TestRustWebPush:
 
         await test_client.send_notification(vapid=vapid, status=401)
 
-    @pytest.mark.asyncio
     async def test_with_bad_key(self, test_client):
         """Test that a message registration request with bad VAPID public key is rejected."""
         chid = str(uuid.uuid4())
@@ -1384,7 +1350,6 @@ class TestRustWebPush:
         result = await test_client.register(channel_id=chid, key="af1883%&!@#*(", status=400)
         assert result["status"] == 400
 
-    @pytest.mark.asyncio
     @max_logs(endpoint=44)
     async def test_msg_limit(self):
         """Test that sent messages that are larger than our size limit are rejected."""
@@ -1406,7 +1371,6 @@ class TestRustWebPush:
         assert client.uaid != uaid
         await self.shut_down(client)
 
-    @pytest.mark.asyncio
     async def test_can_moz_ping(self, registered_test_client):
         """Test that the client can send a small ping message and get a valid response."""
         result = await registered_test_client.moz_ping()
@@ -1420,7 +1384,6 @@ class TestRustWebPush:
             pass
         assert not registered_test_client.ws.open
 
-    @pytest.mark.asyncio
     async def test_internal_endpoints(self, registered_test_client):
         """Ensure an internal router endpoint isn't exposed on the public CONNECTION_PORT"""
         parsed = (
@@ -1461,7 +1424,6 @@ class TestRustWebPushBroadcast:
         """Tear down."""
         process_logs(self)
 
-    @pytest.mark.asyncio
     async def test_broadcast_update_on_connect(self, test_client_broadcast):
         """Test that the client receives any pending broadcast updates on connect."""
         global MOCK_MP_SERVICES
@@ -1483,7 +1445,6 @@ class TestRustWebPushBroadcast:
         assert result.get("messageType") == ClientMessageType.BROADCAST.value
         assert result["broadcasts"]["kinto:123"] == "ver2"
 
-    @pytest.mark.asyncio
     async def test_broadcast_update_on_connect_with_errors(self, test_client_broadcast):
         """Test that the client can receive broadcast updates on connect
         that may have produced internal errors.
@@ -1501,7 +1462,6 @@ class TestRustWebPushBroadcast:
         assert result["broadcasts"]["kinto:123"] == "ver1"
         assert result["broadcasts"]["errors"]["kinto:456"] == "Broadcast not found"
 
-    @pytest.mark.asyncio
     async def test_broadcast_subscribe(self, test_client_broadcast):
         """Test that the client can subscribe to new broadcasts."""
         global MOCK_MP_SERVICES
@@ -1529,7 +1489,6 @@ class TestRustWebPushBroadcast:
         assert result.get("messageType") == ClientMessageType.BROADCAST.value
         assert result["broadcasts"]["kinto:123"] == "ver2"
 
-    @pytest.mark.asyncio
     async def test_broadcast_subscribe_with_errors(self, test_client_broadcast):
         """Test that broadcast returns expected errors."""
         global MOCK_MP_SERVICES
@@ -1550,7 +1509,6 @@ class TestRustWebPushBroadcast:
         assert result["broadcasts"]["kinto:123"] == "ver1"
         assert result["broadcasts"]["errors"]["kinto:456"] == "Broadcast not found"
 
-    @pytest.mark.asyncio
     async def test_broadcast_no_changes(self, test_client_broadcast):
         """Test to ensure there are no changes from broadcast."""
         global MOCK_MP_SERVICES

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -580,13 +580,13 @@ def setup_teardown() -> Generator:
     kill_process(EP_SERVER)
 
 
-@pytest.fixture(name="ws_url")
+@pytest.fixture(name="ws_url", scope="session")
 def fixture_ws_url() -> str:
     """Return defined url for websocket connection."""
     return f"ws://localhost:{CONNECTION_PORT}/"
 
 
-@pytest.fixture(name="broadcast_ws_url")
+@pytest.fixture(name="broadcast_ws_url", scope="session")
 def fixture_broadcast_ws_url() -> str:
     """Return websocket url for megaphone broadcast testing."""
     return f"ws://localhost:{MP_CONNECTION_PORT}/"
@@ -611,7 +611,7 @@ def fixture_clear_sentry_queue():
         MOCK_SENTRY_QUEUE.get_nowait()
 
 
-@pytest.fixture(name="ws_config")
+@pytest.fixture(name="ws_config", scope="session")
 def fixture_ws_config():
     """Return collection of configuration values."""
     return {"connection_port": 9150}

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -17,7 +17,6 @@ import uuid
 from queue import Empty, Queue
 from threading import Event, Thread
 from typing import Any, Generator
-from unittest import SkipTest
 from urllib.parse import urlparse
 
 import ecdsa
@@ -534,7 +533,8 @@ def setup_teardown() -> Generator:
     global CN_SERVER, CN_QUEUES, CN_MP_SERVER, MOCK_SERVER_THREAD, STRICT_LOG_COUNTS, RUST_LOG
 
     if "SKIP_INTEGRATION" in os.environ:  # pragma: nocover
-        raise SkipTest("Skipping integration tests")
+        log.debug("Skipping integration tests")
+        pytest.skip("Skipping integration tests", allow_module_level=True)
 
     for name in ("boto", "boto3", "botocore"):
         logging.getLogger(name).setLevel(logging.CRITICAL)
@@ -659,8 +659,8 @@ async def test_sentry_output_autoconnect(
 ) -> None:
     """Test sentry output for autoconnect."""
     if os.getenv("SKIP_SENTRY"):
-        SkipTest("Skipping sentry test")
-        return
+        log.debug("Skipping test_sentry_output_autoconnect")
+        pytest.skip("Skipping test_sentry_output_autoconnect")
     # Ensure bad data doesn't throw errors
     await test_client.connect()
     await test_client.hello()
@@ -693,8 +693,8 @@ async def test_sentry_output_autoendpoint(
 ) -> None:
     """Test sentry output for autoendpoint."""
     if os.getenv("SKIP_SENTRY"):
-        SkipTest("Skipping sentry test")
-        return
+        log.debug("Skipping test_sentry_output_autoendpoint")
+        pytest.skip("Skipping test_sentry_output_autoendpoint")
     endpoint = registered_test_client.get_host_client_endpoint()
     await registered_test_client.disconnect()
     async with httpx.AsyncClient() as httpx_client:
@@ -720,8 +720,8 @@ async def test_sentry_output_autoendpoint(
 async def test_no_sentry_output(ws_url: str, process_logs_autouse) -> None:
     """Test for no Sentry output."""
     if os.getenv("SKIP_SENTRY"):
-        SkipTest("Skipping sentry test")
-        return
+        log.debug("Skipping test_no_sentry_output")
+        pytest.skip("Skipping test_no_sentry_output")
 
     ws_url = urlparse(ws_url)._replace(scheme="http").geturl()
 

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -587,6 +587,50 @@ def teardown_module():
     kill_process(EP_SERVER)
 
 
+@pytest.fixture(name="ws_url")
+def fixture_ws_url() -> str:
+    """Return defined url for websocket connection."""
+    return f"ws://localhost:{CONNECTION_PORT}/"
+
+
+@pytest.fixture(name="megaphone_ws_url")
+def fixture_megaphone_ws_url() -> str:
+    """Return websocket url for megaphone broadcast testing."""
+    return f"ws://localhost:{MP_CONNECTION_PORT}/"
+
+
+@pytest.fixture(name="test_client")
+def fixture_test_client(ws_url) -> AsyncPushTestClient:
+    """Return a push test client for use within tests."""
+    return AsyncPushTestClient(ws_url)
+
+
+@pytest.fixture(name="vapid_payload", scope="function")
+def fixture_vapid_payload() -> dict[str, int | str]:
+    """Return a test fixture of a vapid payload."""
+    return {
+        "exp": int(time.time()) + 86400,
+        "sub": "mailto:admin@example.com",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.fixture(name="initialized_test_client")
+async def fixture_initialized_test_client():
+    """Perform a connection initialization, which includes a new connection,
+    `hello`, and channel registration.
+    """
+    log.debug(f"🐍#### Connecting to ws://localhost:{CONNECTION_PORT}/")
+    client = AsyncPushTestClient(f"ws://localhost:{CONNECTION_PORT}/")
+    await client.connect()
+    await client.hello()
+    await client.register()
+    log.debug("🐍 Test Client Connected")
+    yield client
+    await client.disconnect()
+    log.debug("🐍 Test Client Disconnected")
+
+
 class TestRustWebPush:
     """Test class for Rust Web Push."""
 

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -280,8 +280,7 @@ def fixture_process_logs_autouse():
         # allowed to be emitted by each node type
         conn_count = sum(queue.qsize() for queue in CN_QUEUES)
         endpoint_count = sum(queue.qsize() for queue in EP_QUEUES)
-        import pdb
-        pdb.set_trace()
+
         print_lines_in_queues(CN_QUEUES, f"{CONNECTION_BINARY.upper()}: ")
         print_lines_in_queues(EP_QUEUES, "AUTOENDPOINT: ")
 
@@ -699,45 +698,6 @@ async def fixture_registered_test_client(ws_config):
     print("🐍 Test Client Disconnected")
 
 
-# @pytest.mark.usefixtures("registered_test_client", "test_client", "process_logs_autouse")
-# class TestRustWebPush:
-#     """Test class for Rust Web Push."""
-
-
-# max_endpoint_logs = 8
-# max_conn_logs = 3
-# vapid_payload = {
-#     "exp": int(time.time()) + 86400,
-#     "sub": "mailto:admin@example.com",
-# }
-
-# def tearDown(self):
-#     """Tear down and log processing."""
-#     process_logs(self)
-
-# async def quick_register(self):
-#     """Perform a connection initialization, which includes a new connection,
-#     `hello`, and channel registration.
-#     """
-#     log.debug(f"🐍#### Connecting to ws://127.0.0.1:{CONNECTION_PORT}/")
-#     client = AsyncPushTestClient(f"ws://127.0.0.1:{CONNECTION_PORT}/")
-#     await client.connect()
-#     await client.hello()
-#     await client.register()
-#     log.debug("🐍 Connected")
-#     return client
-
-# async def shut_down(self, client=None):
-#     """Shut down client."""
-#     if client:
-#         await client.disconnect()
-
-# @property
-# def _ws_url(self):
-#     return f"ws://127.0.0.1:{CONNECTION_PORT}/"
-
-
-# @max_logs(conn=4)
 async def test_sentry_output_autoconnect(
     test_client: AsyncPushTestClient, process_logs_autouse
 ) -> None:
@@ -772,7 +732,6 @@ async def test_sentry_output_autoconnect(
     process_logs_autouse(max_conn_logs=4)
 
 
-# @max_logs(endpoint=1)
 async def test_sentry_output_autoendpoint(
     registered_test_client: AsyncPushTestClient, process_logs_autouse
 ) -> None:
@@ -802,7 +761,6 @@ async def test_sentry_output_autoendpoint(
     process_logs_autouse(max_endpoint_logs=1)
 
 
-# @max_logs(conn=4)
 async def test_no_sentry_output(ws_url: str, process_logs_autouse) -> None:
     """Test for no Sentry output."""
     if os.getenv("SKIP_SENTRY"):
@@ -888,7 +846,6 @@ async def test_topic_replacement_delivery(
     assert result is None
 
 
-# @max_logs(conn=4)
 @pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_topic_no_delivery_on_reconnect(
     registered_test_client: AsyncPushTestClient,
@@ -1098,7 +1055,6 @@ async def test_topic_expired(registered_test_client: AsyncPushTestClient, uuid_d
     assert result["data"] == base64url_encode(uuid_data)
 
 
-# @max_logs(conn=4)
 @pytest.mark.parametrize(
     ["uuid_data_1", "uuid_data_2"],
     [
@@ -1300,7 +1256,6 @@ async def test_ttl_batch_expired_and_good_one(
     process_logs_autouse(max_endpoint_logs=28)
 
 
-# @max_logs(endpoint=28)
 @pytest.mark.parametrize(
     ["uuid_data_1", "uuid_data_2", "uuid_data_3"],
     [(str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4()))],
@@ -1492,7 +1447,6 @@ async def test_with_bad_key(test_client: AsyncPushTestClient, chid: str):
     assert result["status"] == 400
 
 
-# @max_logs(endpoint=44)
 async def test_msg_limit(registered_test_client: AsyncPushTestClient, process_logs_autouse):
     """Test that sent messages that are larger than our size limit are rejected."""
     uaid = registered_test_client.uaid
@@ -1556,18 +1510,6 @@ async def test_internal_endpoints(
         assert e.response.status_code == 404
     else:
         assert False
-
-
-# @pytest.mark.usefixtures("test_client_broadcast")
-# class TestRustWebPushBroadcast:
-#     """Test class for Rust Web Push Broadcast."""
-
-#     max_endpoint_logs = 4
-#     max_conn_logs = 1
-
-#     def tearDown(self):
-#         """Tear down."""
-#         process_logs(self)
 
 
 async def test_broadcast_update_on_connect(test_client_broadcast, process_logs_autouse) -> None:

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -743,9 +743,9 @@ async def test_hello_echo(test_client: AsyncPushTestClient) -> None:
     assert result["use_webpush"] is True
 
 
-@pytest.mark.parametrize("non_uaid", [uuid.uuid4().hex])
-async def test_hello_with_bad_prior_uaid(test_client: AsyncPushTestClient, non_uaid: str) -> None:
+async def test_hello_with_bad_prior_uaid(test_client: AsyncPushTestClient) -> None:
     """Test hello with bad prior uaid."""
+    non_uaid: str = uuid.uuid4().hex
     await test_client.connect()
     result = await test_client.hello(uaid=non_uaid)
     assert result != {}
@@ -753,9 +753,9 @@ async def test_hello_with_bad_prior_uaid(test_client: AsyncPushTestClient, non_u
     assert result["use_webpush"] is True
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_basic_delivery(registered_test_client: AsyncPushTestClient, uuid_data: str) -> None:
+async def test_basic_delivery(registered_test_client: AsyncPushTestClient) -> None:
     """Test basic regular push message delivery."""
+    uuid_data: str = str(uuid.uuid4())
     result = await registered_test_client.send_notification(data=uuid_data)
     # the following presumes that only `salt` is padded.
     clean_header = registered_test_client._crypto_key.replace('"', "").rstrip("=")
@@ -764,11 +764,9 @@ async def test_basic_delivery(registered_test_client: AsyncPushTestClient, uuid_
     assert result["messageType"] == "notification"
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_topic_basic_delivery(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
-) -> None:
+async def test_topic_basic_delivery(registered_test_client: AsyncPushTestClient) -> None:
     """Test basic topic push message delivery."""
+    uuid_data: str = str(uuid.uuid4())
     result = await registered_test_client.send_notification(data=uuid_data, topic="Inbox")
     # the following presumes that only `salt` is padded.
     clean_header = registered_test_client._crypto_key.replace('"', "").rstrip("=")
@@ -777,11 +775,12 @@ async def test_topic_basic_delivery(
     assert result["messageType"] == "notification"
 
 
-@pytest.mark.parametrize(["uuid_data_1", "uuid_data_2"], [(str(uuid.uuid4()), str(uuid.uuid4()))])
 async def test_topic_replacement_delivery(
-    registered_test_client: AsyncPushTestClient, uuid_data_1: str, uuid_data_2: str
+    registered_test_client: AsyncPushTestClient,
 ) -> None:
     """Test that a topic push message replaces it's prior version."""
+    uuid_data_1: str = str(uuid.uuid4())
+    uuid_data_2: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     await registered_test_client.send_notification(data=uuid_data_1, topic="Inbox", status=201)
     await registered_test_client.send_notification(data=uuid_data_2, topic="Inbox", status=201)
@@ -798,13 +797,12 @@ async def test_topic_replacement_delivery(
     assert result is None
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_topic_no_delivery_on_reconnect(
     registered_test_client: AsyncPushTestClient,
-    uuid_data: str,
     process_logs_autouse,
 ) -> None:
     """Test that a topic message does not attempt to redeliver on reconnect."""
+    uuid_data: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     await registered_test_client.send_notification(data=uuid_data, topic="Inbox", status=201)
     await registered_test_client.connect()
@@ -827,13 +825,12 @@ async def test_topic_no_delivery_on_reconnect(
     process_logs_autouse(max_conn_logs=4)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_vapid(
     registered_test_client: AsyncPushTestClient,
     vapid_payload: dict[str, int | str],
-    uuid_data: str,
 ) -> None:
     """Test delivery of a basic push message with a VAPID header."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(payload=vapid_payload)
     result = await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info)
     # the following presumes that only `salt` is padded.
@@ -843,13 +840,12 @@ async def test_basic_delivery_with_vapid(
     assert result["messageType"] == "notification"
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_invalid_vapid(
     registered_test_client: AsyncPushTestClient,
     vapid_payload: dict[str, int | str],
-    uuid_data: str,
 ) -> None:
     """Test basic delivery with invalid VAPID header."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(
         payload=vapid_payload, endpoint=registered_test_client.get_host_client_endpoint()
     )
@@ -857,12 +853,11 @@ async def test_basic_delivery_with_invalid_vapid(
     await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info, status=401)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_invalid_vapid_exp(
     registered_test_client: AsyncPushTestClient,
-    uuid_data: str,
 ) -> None:
     """Test basic delivery of a push message with invalid VAPID `exp` assertion."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(
         payload={
             "aud": registered_test_client.get_host_client_endpoint(),
@@ -874,13 +869,12 @@ async def test_basic_delivery_with_invalid_vapid_exp(
     await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info, status=401)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_invalid_vapid_auth(
     registered_test_client: AsyncPushTestClient,
     vapid_payload: dict[str, int | str],
-    uuid_data: str,
 ) -> None:
     """Test basic delivery with invalid VAPID auth."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(
         payload=vapid_payload,
         endpoint=registered_test_client.get_host_client_endpoint(),
@@ -889,12 +883,11 @@ async def test_basic_delivery_with_invalid_vapid_auth(
     await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info, status=401)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_invalid_signature(
     registered_test_client: AsyncPushTestClient,
-    uuid_data: str,
 ) -> None:
     """Test that a basic delivery with invalid VAPID signature fails."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(
         payload={
             "aud": registered_test_client.get_host_client_endpoint(),
@@ -905,13 +898,12 @@ async def test_basic_delivery_with_invalid_signature(
     await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info, status=401)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_basic_delivery_with_invalid_vapid_ckey(
     registered_test_client: AsyncPushTestClient,
     vapid_payload: dict[str, int | str],
-    uuid_data: str,
 ) -> None:
     """Test that basic delivery with invalid VAPID crypto-key fails."""
+    uuid_data: str = str(uuid.uuid4())
     vapid_info = _get_vapid(
         payload=vapid_payload, endpoint=registered_test_client.get_host_client_endpoint()
     )
@@ -919,12 +911,11 @@ async def test_basic_delivery_with_invalid_vapid_ckey(
     await registered_test_client.send_notification(data=uuid_data, vapid=vapid_info, status=401)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_delivery_repeat_without_ack(
     registered_test_client: AsyncPushTestClient,
-    uuid_data: str,
 ) -> None:
     """Test that message delivery repeats if the client does not acknowledge messages."""
+    uuid_data: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     assert registered_test_client.channels
     await registered_test_client.send_notification(data=uuid_data, status=201)
@@ -942,13 +933,13 @@ async def test_delivery_repeat_without_ack(
     assert result["data"] == base64url_encode(uuid_data)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
 async def test_repeat_delivery_with_disconnect_without_ack(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
+    registered_test_client: AsyncPushTestClient,
 ) -> None:
     """Test that message delivery repeats if the client disconnects
     without acknowledging the message.
     """
+    uuid_data: str = str(uuid.uuid4())
     result = await registered_test_client.send_notification(data=uuid_data)
     assert result != {}
     assert result["data"] == base64url_encode(uuid_data)
@@ -960,13 +951,14 @@ async def test_repeat_delivery_with_disconnect_without_ack(
     assert result["data"] == base64url_encode(uuid_data)
 
 
-@pytest.mark.parametrize(["uuid_data_1", "uuid_data_2"], [(str(uuid.uuid4()), str(uuid.uuid4()))])
 async def test_multiple_delivery_repeat_without_ack(
-    registered_test_client: AsyncPushTestClient, uuid_data_1: str, uuid_data_2: str
+    registered_test_client: AsyncPushTestClient,
 ) -> None:
     """Test that the server will always try to deliver messages
     until the client acknowledges them.
     """
+    uuid_data_1: str = str(uuid.uuid4())
+    uuid_data_2: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     assert registered_test_client.channels
     await registered_test_client.send_notification(data=uuid_data_1, status=201)
@@ -991,9 +983,9 @@ async def test_multiple_delivery_repeat_without_ack(
     assert result["data"] in map(base64url_encode, [uuid_data_1, uuid_data_2])
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_topic_expired(registered_test_client: AsyncPushTestClient, uuid_data: str) -> None:
+async def test_topic_expired(registered_test_client: AsyncPushTestClient) -> None:
     """Test that the server will not deliver a message topic that has expired."""
+    uuid_data: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     assert registered_test_client.channels
     await registered_test_client.send_notification(data=uuid_data, ttl=1, topic="test", status=201)
@@ -1007,19 +999,8 @@ async def test_topic_expired(registered_test_client: AsyncPushTestClient, uuid_d
     assert result["data"] == base64url_encode(uuid_data)
 
 
-@pytest.mark.parametrize(
-    ["uuid_data_1", "uuid_data_2"],
-    [
-        (
-            b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode(),  # FirstMessage
-            b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode(),  # OtherMessage
-        )
-    ],
-)
 async def test_multiple_delivery_with_single_ack(
     registered_test_client: AsyncPushTestClient,
-    uuid_data_1: str,
-    uuid_data_2: str,
     process_logs_autouse,
 ) -> None:
     """Test that the server provides the right unacknowledged messages
@@ -1027,6 +1008,12 @@ async def test_multiple_delivery_with_single_ack(
     Note: the `data` fields are constructed so that they return
     `FirstMessage` and `OtherMessage`, which may be useful for debugging.
     """
+    uuid_data_1: bytes = (
+        b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
+    )  # FirstMessage
+    uuid_data_2: bytes = (
+        b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
+    )  # OtherMessage
     await registered_test_client.disconnect()
     assert registered_test_client.channels
     await registered_test_client.send_notification(data=uuid_data_1, status=201)
@@ -1064,23 +1051,20 @@ async def test_multiple_delivery_with_single_ack(
     process_logs_autouse(max_conn_logs=4)
 
 
-@pytest.mark.parametrize(
-    ["uuid_data_1", "uuid_data_2"],
-    [
-        (
-            b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode(),  # FirstMessage
-            b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode(),  # OtherMessage
-        )
-    ],
-)
 async def test_multiple_delivery_with_multiple_ack(
-    registered_test_client: AsyncPushTestClient, uuid_data_1: str, uuid_data_2: str
+    registered_test_client: AsyncPushTestClient,
 ) -> None:
     """Test that the server provides the no additional unacknowledged messages
     if the client acknowledges both of the received messages.
     Note: the `data` fields are constructed so that they return
     `FirstMessage` and `OtherMessage`, which may be useful for debugging.
     """
+    uuid_data_1: bytes = (
+        b"\x16*\xec\xb4\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
+    )  # FirstMessage
+    uuid_data_2: bytes = (
+        b":\xd8^\xac\xc7\xac\xb1\xa8\x1e" + str(uuid.uuid4()).encode()
+    )  # OtherMessage
     await registered_test_client.disconnect()
     assert registered_test_client.channels
     await registered_test_client.send_notification(data=uuid_data_1, status=201)
@@ -1104,11 +1088,9 @@ async def test_multiple_delivery_with_multiple_ack(
     assert result is None
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_no_delivery_to_unregistered(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
-) -> None:
+async def test_no_delivery_to_unregistered(registered_test_client: AsyncPushTestClient) -> None:
     """Test that the server does not try to deliver to unregistered channel IDs."""
+    uuid_data: str = str(uuid.uuid4())
     assert registered_test_client.channels
     chan = list(registered_test_client.channels.keys())[0]
 
@@ -1127,11 +1109,9 @@ async def test_no_delivery_to_unregistered(
     assert result is None
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_ttl_0_connected(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
-) -> None:
+async def test_ttl_0_connected(registered_test_client: AsyncPushTestClient) -> None:
     """Test that a message with a TTL=0 is delivered to a client that is actively connected."""
+    uuid_data: str = str(uuid.uuid4())
     result = await registered_test_client.send_notification(data=uuid_data, ttl=0)
     assert result is not None
     # the following presumes that only `salt` is padded.
@@ -1141,13 +1121,11 @@ async def test_ttl_0_connected(
     assert result["messageType"] == "notification"
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_ttl_0_not_connected(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
-) -> None:
+async def test_ttl_0_not_connected(registered_test_client: AsyncPushTestClient) -> None:
     """Test that a message with a TTL=0 and a recipient client that is not connected,
     is not delivered when the client reconnects.
     """
+    uuid_data: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     await registered_test_client.send_notification(data=uuid_data, ttl=0, status=201)
     await registered_test_client.connect()
@@ -1156,11 +1134,11 @@ async def test_ttl_0_not_connected(
     assert result is None
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_ttl_expired(registered_test_client: AsyncPushTestClient, uuid_data: str) -> None:
+async def test_ttl_expired(registered_test_client: AsyncPushTestClient) -> None:
     """Test that messages with a TTL that has expired are not delivered
     to a recipient client.
     """
+    uuid_data: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     await registered_test_client.send_notification(data=uuid_data, ttl=1, status=201)
     await asyncio.sleep(1)
@@ -1170,25 +1148,16 @@ async def test_ttl_expired(registered_test_client: AsyncPushTestClient, uuid_dat
     assert result is None
 
 
-@pytest.mark.parametrize(
-    ["uuid_data_1", "uuid_data_2"],
-    [
-        (
-            str(uuid.uuid4()).encode(),
-            base64.urlsafe_b64decode("0012") + str(uuid.uuid4()).encode(),
-        )
-    ],
-)
 async def test_ttl_batch_expired_and_good_one(
     registered_test_client: AsyncPushTestClient,
-    uuid_data_1: bytes,
-    uuid_data_2: bytes,
     process_logs_autouse,
 ) -> None:
     """Test that if a batch of messages are received while the recipient is offline,
     only messages that have not expired are sent to the recipient.
     This test checks if the latest pending message is not expired.
     """
+    uuid_data_1: bytes = str(uuid.uuid4()).encode()
+    uuid_data_2: bytes = base64.urlsafe_b64decode("0012") + str(uuid.uuid4()).encode()
     await registered_test_client.disconnect()
     for x in range(0, 12):
         prefix = base64.urlsafe_b64decode(f"{x:04d}")
@@ -1212,21 +1181,17 @@ async def test_ttl_batch_expired_and_good_one(
     process_logs_autouse(max_endpoint_logs=28)
 
 
-@pytest.mark.parametrize(
-    ["uuid_data_1", "uuid_data_2", "uuid_data_3"],
-    [(str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4()))],
-)
 async def test_ttl_batch_partly_expired_and_good_one(
     registered_test_client: AsyncPushTestClient,
-    uuid_data_1: str,
-    uuid_data_2: str,
-    uuid_data_3: str,
     process_logs_autouse,
 ) -> None:
     """Test that if a batch of messages are received while the recipient is offline,
     only messages that have not expired are sent to the recipient.
     This test checks if there is an equal mix of expired and unexpired messages.
     """
+    uuid_data_1: str = str(uuid.uuid4())
+    uuid_data_2: str = str(uuid.uuid4())
+    uuid_data_3: str = str(uuid.uuid4())
     await registered_test_client.disconnect()
     for x in range(0, 6):
         await registered_test_client.send_notification(data=uuid_data_1, status=201)
@@ -1258,11 +1223,9 @@ async def test_ttl_batch_partly_expired_and_good_one(
     process_logs_autouse(max_endpoint_logs=28)
 
 
-@pytest.mark.parametrize("uuid_data", [str(uuid.uuid4())])
-async def test_message_without_crypto_headers(
-    registered_test_client: AsyncPushTestClient, uuid_data: str
-) -> None:
+async def test_message_without_crypto_headers(registered_test_client: AsyncPushTestClient) -> None:
     """Test that a message without crypto headers, but has data is not accepted."""
+    uuid_data: str = str(uuid.uuid4())
     result = await registered_test_client.send_notification(
         data=uuid_data, use_header=False, status=400
     )
@@ -1396,9 +1359,10 @@ async def test_with_key(test_client: AsyncPushTestClient) -> None:
     await test_client.send_notification(vapid=vapid, status=401)
 
 
-@pytest.mark.parametrize(["chid", "bad_key"], [(str(uuid.uuid4()), "af1883%&!@#*(")])
-async def test_with_bad_key(test_client: AsyncPushTestClient, chid: str, bad_key: str):
+async def test_with_bad_key(test_client: AsyncPushTestClient):
     """Test that a message registration request with bad VAPID public key is rejected."""
+    chid: str = str(uuid.uuid4())
+    bad_key: str = "af1883%&!@#*("
     await test_client.connect()
     await test_client.hello()
     result = await test_client.register(channel_id=chid, key=bad_key, status=400)

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -1,5 +1,6 @@
 """Rust Connection and Endpoint Node Integration Tests."""
 
+import asyncio
 import base64
 import copy
 import json
@@ -1138,7 +1139,7 @@ class TestRustWebPush:
         data = str(uuid.uuid4())
         await registered_test_client.disconnect()
         await registered_test_client.send_notification(data=data, ttl=1, status=201)
-        time.sleep(1)
+        await asyncio.sleep(1)
         await registered_test_client.connect()
         await registered_test_client.hello()
         result = await registered_test_client.get_notification(timeout=0.5)
@@ -1161,7 +1162,7 @@ class TestRustWebPush:
             await client.send_notification(data=prefix + data, ttl=1, status=201)
 
         await client.send_notification(data=data2, status=201)
-        time.sleep(1)
+        await asyncio.sleep(1)
         await client.connect()
         await client.hello()
         result = await client.get_notification(timeout=4)
@@ -1194,7 +1195,7 @@ class TestRustWebPush:
             await client.send_notification(data=data1, ttl=1, status=201)
 
         await client.send_notification(data=data2, status=201)
-        time.sleep(1)
+        await asyncio.sleep(1)
         await client.connect()
         await client.hello()
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -85,3 +85,6 @@ pydantic = "^2.7.1"
 [build-system]
 requires = ["poetry-core>=1.8.1"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
Closes [SYNC-4116](https://mozilla-hub.atlassian.net/browse/SYNC-4116)

Summary & Acceptance Criteria Met:
- `unittest` fully removed.
- All tests pulled out of classes and into individual test classes, all references to duplicated class boilerplate in normal tests and broadcast tests moved into their own fixtures.
- Some setup and teardown logic moved into autouse fixtures.
- Test data is injected into individual tests through `pytest.mark.parameterize`. This removes internal test setup and also provides the injected values in the test output, for easier debugging.
- `max_logs` decorator removed and `process_logs` are now implemented though an autouse fixture that runs at the end of each test, allowing the endpoint and connection values to be passed in.
- 🎉 Bonus: resolved the `[   ERROR] Task was destroyed but it is pending!` problem by moving the `test_client` and `registered_test_client` into async fixtures that `yield` the client and then automatically disconnect after each test function.
- 🎉 Bonus: tests run faster! Cut the execution time in half: `65.22s` -> `36.29s`

Note: 
- potential move into conftest would be covered in scope of another task. May not get much benefit from this presently. Also, moving scope of some of the setup would be too much in a single PR given the changes in design here.
- Given UUID data is created as params passed to each test function, I opted for this over a fixture since we assume the push connections are frequently receiving unique UAIDs. Plus annotated above each test function makes it easier to see the input, as there are several test cases that involve a bit of variation. 

[SYNC-4116]: https://mozilla-hub.atlassian.net/browse/SYNC-4116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ