### PR TITLE
fix: jsonwebtoken validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,8 +1728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2235,13 +2237,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
+ "js-sys",
  "pem",
- "ring 0.16.20",
+ "ring 0.17.8",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2278,7 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2696,11 +2699,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.0",
+ "serde",
 ]
 
 [[package]]

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -50,7 +50,7 @@ again = { version = "0.1.2", default-features = false, features = [
 ] }
 async-trait = "0.1"
 autopush_common = { path = "../autopush-common" }
-jsonwebtoken = "8.0" # v9.0 breaks vapid aud tests. https://mozilla-hub.atlassian.net/browse/SYNC-4201
+jsonwebtoken = "9.3.0"
 validator = "0.17"
 validator_derive = "0.17"
 yup-oauth2 = "8.1"

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -266,7 +266,7 @@ fn validate_vapid_jwt(
 
     let public_key = decode_public_key(public_key)?;
     let mut validation = Validation::new(Algorithm::ES256);
-    validation.set_audience(&["https://push.services.mozilla.org"]);
+    validation.set_audience(&["https://push.services.mozilla.org", "http://127.0.0.1:9160"]);
     validation.set_required_spec_claims(&["exp", "aud", "sub"]);
 
     let token_data = match jsonwebtoken::decode::<VapidClaims>(

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -265,10 +265,14 @@ fn validate_vapid_jwt(
     let VapidHeaderWithKey { vapid, public_key } = vapid;
 
     let public_key = decode_public_key(public_key)?;
+    let mut validation = Validation::new(Algorithm::ES256);
+    validation.set_audience(&["https://push.services.mozilla.org"]);
+    validation.set_required_spec_claims(&["exp", "aud", "sub"]);
+
     let token_data = match jsonwebtoken::decode::<VapidClaims>(
         &vapid.token,
         &DecodingKey::from_ec_der(&public_key),
-        &Validation::new(Algorithm::ES256),
+        &validation,
     ) {
         Ok(v) => v,
         Err(e) => match e.kind() {

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     pub router_table_name: String,
     pub message_table_name: String,
 
+    pub vapid_aud: Vec<String>,
+
     pub max_data_bytes: usize,
     pub crypto_keys: String,
     pub auth_keys: String,
@@ -58,6 +60,10 @@ impl Default for Settings {
             db_settings: "".to_owned(),
             router_table_name: "router".to_string(),
             message_table_name: "message".to_string(),
+            vapid_aud: vec![
+                "https://push.services.mozilla.org".to_string(),
+                "http://127.0.0.1:9160".to_string(),
+            ],
             // max data is a bit hard to figure out, due to encryption. Using something
             // like pywebpush, if you encode a block of 4096 bytes, you'll get a
             // 4216 byte data block. Since we're going to be receiving this, we have to

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -217,15 +217,15 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             headers["Topic"] = topic
         body: str | bytes = data or ""
         method: str = "POST"
-        print("#"*20)
+        print("#" * 20)
         print(f"VAPID {vapid}")
 
         print(f"method: {method} body: {body!r}")
         print(f"url {url}")
         print(f"url.geturl() {url.geturl()}")
-        print(f"body content {body}")
+        print(f"body content {body!r}")
         print(f"Headers {headers}")
-        print("#"*20)
+        print("#" * 20)
         log.debug(f"{method} body: {body!r}")
         log.debug(f"  headers: {headers}")
         async with httpx.AsyncClient() as httpx_client:

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -217,15 +217,6 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             headers["Topic"] = topic
         body: str | bytes = data or ""
         method: str = "POST"
-        print("#" * 20)
-        print(f"VAPID {vapid}")
-
-        print(f"method: {method} body: {body!r}")
-        print(f"url {url}")
-        print(f"url.geturl() {url.geturl()}")
-        print(f"body content {body!r}")
-        print(f"Headers {headers}")
-        print("#" * 20)
         log.debug(f"{method} body: {body!r}")
         log.debug(f"  headers: {headers}")
         async with httpx.AsyncClient() as httpx_client:

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -217,6 +217,15 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             headers["Topic"] = topic
         body: str | bytes = data or ""
         method: str = "POST"
+        print("#"*20)
+        print(f"VAPID {vapid}")
+
+        print(f"method: {method} body: {body!r}")
+        print(f"url {url}")
+        print(f"url.geturl() {url.geturl()}")
+        print(f"body content {body}")
+        print(f"Headers {headers}")
+        print("#"*20)
         log.debug(f"{method} body: {body!r}")
         log.debug(f"  headers: {headers}")
         async with httpx.AsyncClient() as httpx_client:


### PR DESCRIPTION
Explanation of why this error condition occurred, from looking at the `jsonwebtoken` changelog and source:

v 9.0.0 - _Rejects JWTs containing audiences when the Validation doesn't contain any._ 
- Note: therefore, required to set in`set_required_spec_claims` [source](https://github.com/Keats/jsonwebtoken/blob/afbb44e34dbd721c35dedb68ec13a86ff6db6d8b/src/validation.rs#L152) and explicit `aud` value needs to be set via `set_audience` [source](https://github.com/Keats/jsonwebtoken/blob/afbb44e34dbd721c35dedb68ec13a86ff6db6d8b/src/validation.rs#L137)

v 9.2.0 - _Add an option to not validate aud in the Validation struct_ [source](https://github.com/Keats/jsonwebtoken/blob/afbb44e34dbd721c35dedb68ec13a86ff6db6d8b/src/validation.rs#L74). 
- Note: this could optionally emulate the previous state by setting `validate_aud` to `false`.

From the [docs](https://crates.io/crates/jsonwebtoken/9.3.0): 
_Validation: This library automatically validates the exp claim, and nbf is validated if present. You can also validate the sub, iss, and aud but those require setting the expected values in the Validation struct. **In the case of aud, if there is a value set in the token but not in the Validation, the token will be rejected.**_

After adding the explicit `aud` value and setting the required spec claims, this left a lingering issue with the integration tests where `test_basic_delivery_with_vapid` failed due to a `401 Unauthorized` response during the `send_notification` call.

Solution: setting explicit audience value' only caveat being we need to set the value in the test env as well that is not the push service endpoint:
Ex. validation.set_audience(&["https://push.services.mozilla.org", "http://127.0.0.1:9160"]);
It's probably better then to set the audience value within a configuration variable that can be altered based on context.

Alternatively, `validation.validate_aud = false` would bypass explicit validation of aud, though not sure we'd want that. 

Closes [SYNC-2401](https://mozilla-hub.atlassian.net/browse/SYNC-4201)

[SYNC-2401]: https://mozilla-hub.atlassian.net/browse/SYNC-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ