### PR TITLE
refactor: remove aws feature flag for logging aws ec2

### DIFF
--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -79,7 +79,6 @@ bigtable = [
     "dep:form_urlencoded",
 ]
 dynamodb = ["dep:rusoto_core", "dep:rusoto_dynamodb"]
-aws = []
 emulator = [
     "bigtable",
 ] # used for testing big table, requires an external bigtable emulator running.


### PR DESCRIPTION
Given Push is no longer deployed using an Amazon EC2 instance, we no longer need this feature flag implementation. 

See https://github.com/mozilla-services/autopush-rs/commit/04df79e5df9899fc0563d116187fbd59e0a53eee 

Closes [SYNC-4337](https://mozilla-hub.atlassian.net/browse/SYNC-4337)