### PR TITLE
feat: Add ability to track messages based on known VAPID keys

### DIFF
--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -38,7 +38,7 @@ pub struct Subscription {
     /// Should this subscription update be tracked internally?
     /// (This should ONLY be applied for messages that match known
     /// Mozilla provided VAPID public keys.)
-    pub trackable: bool,
+    pub tracking_id: Option<String>,
 }
 
 impl FromRequest for Subscription {
@@ -136,7 +136,13 @@ impl FromRequest for Subscription {
                 user,
                 channel_id,
                 vapid,
-                trackable,
+                // Eventually this will be replaced by the generated, opaque
+                // tracking ID, for now, just use a simple UUID4 string.
+                tracking_id: if trackable {
+                    Some(uuid::Uuid::new_v4().as_simple().to_string())
+                } else {
+                    None
+                },
             })
         }
         .boxed_local()

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -74,7 +74,7 @@ impl FromRequest for Subscription {
 
             trace!("raw vapid: {:?}", &vapid);
             let trackable = if let Some(vapid) = &vapid {
-                app_state.settings.is_trackable(&vapid)
+                app_state.settings.is_trackable(vapid)
             } else {
                 false
             };

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -239,7 +239,7 @@ pub mod tests {
                 user,
                 channel_id: channel_id(),
                 vapid: None,
-                trackable: false,
+                tracking_id: None,
             },
             headers: NotificationHeaders {
                 ttl: 0,

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -239,6 +239,7 @@ pub mod tests {
                 user,
                 channel_id: channel_id(),
                 vapid: None,
+                trackable: false,
             },
             headers: NotificationHeaders {
                 ttl: 0,

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -225,13 +225,9 @@ impl VapidTracker {
 
 #[cfg(test)]
 mod tests {
-<<<<<<< HEAD
     use actix_http::header::{HeaderMap, HeaderName, HeaderValue};
 
     use super::{Settings, VapidTracker};
-=======
-    use super::Settings;
->>>>>>> 0f8c0292a677104bdcb71226601d31b11dd1979c
     use crate::{
         error::ApiResult,
         headers::vapid::{VapidHeader, VapidHeaderWithKey},
@@ -258,32 +254,6 @@ mod tests {
         };
         let result = settings.auth_keys();
         assert_eq!(result, success);
-        Ok(())
-    }
-
-    #[test]
-    fn test_tracking_keys() -> ApiResult<()> {
-        let mut settings = Settings{
-            tracking_keys: r#"["BLMymkOqvT6OZ1o9etCqV4jGPkvOXNz5FdBjsAR9zR5oeCV1x5CBKuSLTlHon-H_boHTzMtMoNHsAGDlDB6X7vI"]"#.to_owned(),
-            ..Default::default()
-        };
-
-        let test_header = VapidHeaderWithKey {
-            vapid: VapidHeader {
-                scheme: "".to_owned(),
-                token: "".to_owned(),
-                version_data: crate::headers::vapid::VapidVersionData::Version1,
-            },
-            public_key: "BLMymkOqvT6OZ1o9etCqV4jGPkvOXNz5FdBjsAR9zR5oeCV1x5CBKuSLTlHon-H_boHTzMtMoNHsAGDlDB6X7vI".to_owned()
-        };
-
-        let result = settings.tracking_keys();
-        assert!(!result.is_empty());
-
-        // emulate Settings.with_env_and_config_file()
-        settings.tracking_vapid_pubs = result;
-
-        assert!(settings.is_trackable(&test_header));
         Ok(())
     }
 

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -34,8 +34,13 @@ pub struct Settings {
 
     /// A stringified JSON list of VAPID public keys which should be tracked internally.
     /// This should ONLY include Mozilla generated and consumed messages (e.g. "SendToTab", etc.)
+    /// These keys should be specified in stripped, b64encoded, X962 format (e.g. a single line of
+    /// base64 encoded data without padding).
+    /// You can use `scripts/convert_pem_to_x962.py` to easily convert EC Public keys stored in
+    /// PEM format into appropriate x962 format.
     pub tracking_keys: String,
     /// Cached, parsed tracking keys.
+    //TODO: convert to decoded Vec<u8>?
     pub tracking_vapid_pubs: Vec<String>,
 
     pub max_data_bytes: usize,
@@ -182,8 +187,12 @@ impl Settings {
             .collect()
     }
 
+    /// Very simple string check to see if the Public Key specified in the Vapid header
+    /// matches the set of trackable keys.
     pub fn is_trackable(&self, vapid: &VapidHeaderWithKey) -> bool {
-        self.tracking_vapid_pubs.contains(&vapid.public_key)
+        // ideally, [Settings.with_env_and_config_file()] does the work of pre-populating
+        // the Settings.tracking_vapid_pubs cache, but we can't rely on that.
+        self.tracking_keys().contains(&vapid.public_key)
     }
 
     /// Get the URL for this endpoint server
@@ -200,7 +209,10 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::Settings;
-    use crate::error::ApiResult;
+    use crate::{
+        error::ApiResult,
+        headers::vapid::{VapidHeader, VapidHeaderWithKey},
+    };
 
     #[test]
     fn test_auth_keys() -> ApiResult<()> {
@@ -229,11 +241,27 @@ mod tests {
     #[test]
     fn test_tracking_keys() -> ApiResult<()> {
         let mut settings = Settings{
-            tracking_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB=", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC="]"#.to_owned(),
+            tracking_keys: r#"["BLMymkOqvT6OZ1o9etCqV4jGPkvOXNz5FdBjsAR9zR5oeCV1x5CBKuSLTlHon-H_boHTzMtMoNHsAGDlDB6X7vI"]"#.to_owned(),
             ..Default::default()
         };
 
+        let test_header = VapidHeaderWithKey {
+            vapid: VapidHeader {
+                scheme: "".to_owned(),
+                token: "".to_owned(),
+                version_data: crate::headers::vapid::VapidVersionData::Version1,
+            },
+            public_key: "BLMymkOqvT6OZ1o9etCqV4jGPkvOXNz5FdBjsAR9zR5oeCV1x5CBKuSLTlHon-H_boHTzMtMoNHsAGDlDB6X7vI".to_owned()
+        };
+
         let result = settings.tracking_keys();
+        assert!(!result.is_empty());
+
+        // emulate Settings.with_env_and_config_file()
+        settings.tracking_vapid_pubs = result;
+
+        assert!(settings.is_trackable(&test_header));
+        Ok(())
     }
 
     #[test]

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -5,6 +5,7 @@ use fernet::{Fernet, MultiFernet};
 use serde::Deserialize;
 use url::Url;
 
+use crate::headers::vapid::VapidHeaderWithKey;
 use crate::routers::apns::settings::ApnsSettings;
 use crate::routers::fcm::settings::FcmSettings;
 #[cfg(feature = "stub")]
@@ -30,6 +31,12 @@ pub struct Settings {
     pub message_table_name: String,
 
     pub vapid_aud: Vec<String>,
+
+    /// A stringified JSON list of VAPID public keys which should be tracked internally.
+    /// This should ONLY include Mozilla generated and consumed messages (e.g. "SendToTab", etc.)
+    pub tracking_keys: String,
+    /// Cached, parsed tracking keys.
+    pub tracking_vapid_pubs: Vec<String>,
 
     pub max_data_bytes: usize,
     pub crypto_keys: String,
@@ -64,6 +71,7 @@ impl Default for Settings {
                 "https://push.services.mozilla.org".to_string(),
                 "http://127.0.0.1:9160".to_string(),
             ],
+            tracking_vapid_pubs: vec![],
             // max data is a bit hard to figure out, due to encryption. Using something
             // like pywebpush, if you encode a block of 4096 bytes, you'll get a
             // 4216 byte data block. Since we're going to be receiving this, we have to
@@ -71,6 +79,7 @@ impl Default for Settings {
             max_data_bytes: 5630,
             crypto_keys: format!("[{}]", Fernet::generate_key()),
             auth_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]"#.to_string(),
+            tracking_keys: r#"[]"#.to_string(),
             human_logs: false,
             connection_timeout_millis: 1000,
             request_timeout_millis: 3000,
@@ -100,9 +109,7 @@ impl Settings {
         // down to the sub structures.
         config = config.add_source(Environment::with_prefix(ENV_PREFIX).separator("__"));
 
-        let built = config.build()?;
-
-        built.try_deserialize::<Self>().map_err(|error| {
+        let mut built: Self = config.build()?.try_deserialize::<Self>().map_err(|error| {
             match error {
                 // Configuration errors are not very sysop friendly, Try to make them
                 // a bit more 3AM useful.
@@ -121,7 +128,12 @@ impl Settings {
                     error
                 }
             }
-        })
+        })?;
+
+        // cache the tracking keys we've built.
+        built.tracking_vapid_pubs = built.tracking_keys();
+
+        Ok(built)
     }
 
     /// Convert a string like `[item1,item2]` into a iterator over `item1` and `item2`.
@@ -156,6 +168,22 @@ impl Settings {
         Self::read_list_from_str(keys, "Invalid AUTOEND_AUTH_KEYS")
             .map(|v| v.to_owned())
             .collect()
+    }
+
+    /// Get the list of tracking public keys
+    pub fn tracking_keys(&self) -> Vec<String> {
+        // return the cached version if present.
+        if !self.tracking_vapid_pubs.is_empty() {
+            return self.tracking_vapid_pubs.clone();
+        };
+        let keys = &self.tracking_keys.replace(['"', ' '], "");
+        Self::read_list_from_str(keys, "Invalid AUTOEND_TRACKING_KEYS")
+            .map(|v| v.to_owned())
+            .collect()
+    }
+
+    pub fn is_trackable(&self, vapid: &VapidHeaderWithKey) -> bool {
+        self.tracking_vapid_pubs.contains(&vapid.public_key)
     }
 
     /// Get the URL for this endpoint server
@@ -196,6 +224,16 @@ mod tests {
         let result = settings.auth_keys();
         assert_eq!(result, success);
         Ok(())
+    }
+
+    #[test]
+    fn test_tracking_keys() -> ApiResult<()> {
+        let mut settings = Settings{
+            tracking_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB=", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC="]"#.to_owned(),
+            ..Default::default()
+        };
+
+        let result = settings.tracking_keys();
     }
 
     #[test]

--- a/scripts/convert_pem_to_x962.py
+++ b/scripts/convert_pem_to_x962.py
@@ -11,12 +11,13 @@ import base64
 import sys
 
 from typing import cast
-from cryptography.hazmat.primitives.asymmetric import ec, utils as ec_utils
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import serialization
 
 try:
-    content = open(sys.argv[1], "rb").read()
-    pubkey = serialization.load_pem_public_key(content)
+    with open(sys.argv[1], "rb") as fp:
+        content = fp.read()
+        pubkey = serialization.load_pem_public_key(content)
 except IndexError:
     print ("Please specify a public key PEM file to convert.")
     exit()

--- a/scripts/convert_pem_to_x962.py
+++ b/scripts/convert_pem_to_x962.py
@@ -1,0 +1,31 @@
+"""
+Convert a EC Public key in PEM format into an b64 x962 string.
+
+Autopush will try to scan for known VAPID public keys to track. These keys
+are specified in the header as x962 formatted strings. X962 is effectively
+"raw" format and contains the two longs that are the coordinates for the
+public key.
+
+"""
+import base64
+import sys
+
+from typing import cast
+from cryptography.hazmat.primitives.asymmetric import ec, utils as ec_utils
+from cryptography.hazmat.primitives import serialization
+
+try:
+    content = open(sys.argv[1], "rb").read()
+    pubkey = serialization.load_pem_public_key(content)
+except IndexError:
+    print ("Please specify a public key PEM file to convert.")
+    exit()
+
+pk_string = cast(ec.EllipticCurvePublicKey, pubkey).public_bytes(
+    serialization.Encoding.X962,
+    serialization.PublicFormat.UncompressedPoint
+)
+
+pk_string = base64.urlsafe_b64encode(pk_string).strip(b'=')
+
+print(f"{pk_string.decode()}")


### PR DESCRIPTION
_*Note*_: This introduces a new setting for autoendpoint: `tracking_keys`
This is a JSON formatted list of the "raw"/x962 formatted VAPID public keys that should be monitored for Push tracking and follows the same format as other key data fields. 

The newly added `script/convert_pem_to_x962.py` script aids by reading a VAPID public key PEM file and outputing a x962 formatted string. 

Closes: [SYNC-4349](https://mozilla-hub.atlassian.net/browse/SYNC-4349)

[SYNC-4349]: https://mozilla-hub.atlassian.net/browse/SYNC-4349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ