### PR TITLE
feat: add APNS timeouts for a2

### DIFF
--- a/autoendpoint/src/routers/apns/router.rs
+++ b/autoendpoint/src/routers/apns/router.rs
@@ -9,7 +9,6 @@ use crate::routers::common::{
     build_message_data, incr_error_metric, incr_success_metrics, message_size_check,
 };
 use crate::routers::{Router, RouterError, RouterResponse};
-use crate::settings::Settings;
 use a2::{
     self,
     request::payload::{Payload, PayloadLike},
@@ -154,15 +153,15 @@ impl ApnsRouter {
         } else {
             settings.key.as_bytes().to_vec()
         };
-        // Timeouts defined in autoendpoint settings.rs config and can be modified.
+        // Timeouts defined in ApnsSettings settings.rs config and can be modified.
         // We define them to prevent possible a2 library changes that could
         // create unexpected behavior if timeouts are altered.
         // They currently map to values matching the detaults in the a2 lib v0.10.
-        let autoendpoint_settings = Settings::default();
+        let apns_settings = ApnsSettings::default();
         let config = a2::ClientConfig {
             endpoint,
-            request_timeout_secs: autoendpoint_settings.request_timeout_secs,
-            pool_idle_timeout_secs: autoendpoint_settings.pool_idle_timeout_secs,
+            request_timeout_secs: apns_settings.request_timeout_secs,
+            pool_idle_timeout_secs: apns_settings.pool_idle_timeout_secs,
         };
         let client = ApnsClientData {
             client: Box::new(

--- a/autoendpoint/src/routers/apns/settings.rs
+++ b/autoendpoint/src/routers/apns/settings.rs
@@ -10,6 +10,11 @@ pub struct ApnsSettings {
     pub channels: String,
     /// The max size of notification data in bytes
     pub max_data: usize,
+    // These values correspond to the a2 library ClientConfig struct.
+    // https://github.com/WalletConnect/a2/blob/master/src/client.rs#L65-L71.
+    // Utilized by apns router config in creating the client.
+    pub request_timeout_secs: Option<u64>,
+    pub pool_idle_timeout_secs: Option<u64>,
 }
 
 /// Settings for a specific APNS release channel
@@ -27,10 +32,12 @@ pub struct ApnsChannel {
 }
 
 impl Default for ApnsSettings {
-    fn default() -> Self {
-        Self {
+    fn default() -> ApnsSettings {
+        ApnsSettings {
             channels: "{}".to_string(),
             max_data: 4096,
+            request_timeout_secs: Some(20),
+            pool_idle_timeout_secs: Some(600),
         }
     }
 }

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -46,6 +46,12 @@ pub struct Settings {
     pub fcm: FcmSettings,
     pub apns: ApnsSettings,
 
+    // These values correspond to the a2 library ClientConfig struct.
+    // https://github.com/WalletConnect/a2/blob/master/src/client.rs#L65-L71.
+    // Utilized by autoendpoint router config in creating the client.
+    pub request_timeout_secs: Option<u64>,
+    pub pool_idle_timeout_secs: Option<u64>,
+
     #[cfg(feature = "stub")]
     pub stub: StubSettings,
 }
@@ -80,6 +86,8 @@ impl Default for Settings {
             statsd_label: "autoendpoint".to_string(),
             fcm: FcmSettings::default(),
             apns: ApnsSettings::default(),
+            request_timeout_secs: Some(20),
+            pool_idle_timeout_secs: Some(600),
             #[cfg(feature = "stub")]
             stub: StubSettings::default(),
         }

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -45,13 +45,6 @@ pub struct Settings {
 
     pub fcm: FcmSettings,
     pub apns: ApnsSettings,
-
-    // These values correspond to the a2 library ClientConfig struct.
-    // https://github.com/WalletConnect/a2/blob/master/src/client.rs#L65-L71.
-    // Utilized by autoendpoint router config in creating the client.
-    pub request_timeout_secs: Option<u64>,
-    pub pool_idle_timeout_secs: Option<u64>,
-
     #[cfg(feature = "stub")]
     pub stub: StubSettings,
 }
@@ -86,8 +79,6 @@ impl Default for Settings {
             statsd_label: "autoendpoint".to_string(),
             fcm: FcmSettings::default(),
             apns: ApnsSettings::default(),
-            request_timeout_secs: Some(20),
-            pool_idle_timeout_secs: Some(600),
             #[cfg(feature = "stub")]
             stub: StubSettings::default(),
         }


### PR DESCRIPTION
Per [`ClientConfig`](https://github.com/WalletConnect/a2/blob/master/src/client.rs#L78) struct in a2 library, updated autoconnect Settings struct to hold `request_timeout_secs` and `pool_idle_timeout_secs`, define `default()` struct to pass into `ClientConfig`, with defaults set to what are the current defaults in a2. We can of course change them going forward. This way the settings are untethered from whatever a2 may change them to.

Some contextual comments are included for clarity.

Closes [SYNC-4307](https://mozilla-hub.atlassian.net/browse/SYNC-4307)

[SYNC-4307]: https://mozilla-hub.atlassian.net/browse/SYNC-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ