### PR TITLE
feat: [SYNC-4365]: Report test results and coverage on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
             else
               echo "${PASS}" | docker login -u="${USER}" --password-stdin
             fi
-  setup-rust:
+  setup_rust:
     steps:
       - run:
           name: Set up Rust and build applications
@@ -47,6 +47,52 @@ commands:
             echo 'export PATH=$PATH:$HOME/.cargo/bin' >> $BASH_ENV
             rustc --version
             cargo build --features=emulator
+  setup_bigtable:
+    steps:
+      - run:
+          name: Setup Bigtable
+          command: scripts/setup_bt.sh
+  setup_cbt:
+    steps:
+      - run:
+          name: Set up cbt
+          command: |
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            apt-get update -y
+            apt install google-cloud-cli-cbt -y
+  create_test_result_workspace:
+    steps:
+      - run:
+          name: Create Workspace
+          command: mkdir -p workspace/test-results
+  restore_test_cache:
+    parameters:
+      cache_key:
+        type: string
+    steps:
+      - restore_cache:
+          name: Restoring Rust cache
+          key: <<parameters.cache_key>>
+  save_test_cache:
+    parameters:
+      cache_key:
+        type: string
+    steps:
+      - save_cache:
+          name: Save Rust cache
+          key: <<parameters.cache_key>>
+          paths:
+            - target
+            - ~/.cargo/registry
+            - ~/.cargo/git
+  setup_python:
+    steps:
+      - run:
+          name: Set up Python
+          command: |
+            pip install --upgrade pip
+            pip install poetry
 
 jobs:
   audit:
@@ -104,38 +150,23 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
-    resource_class: xlarge
+    resource_class: medium
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
-      - restore_cache:
-          name: Restoring Rust cache
-          key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Create Workspace
-          command: mkdir -p workspace
-      - setup-rust
+      - restore_test_cache:
+          cache_key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - create_test_result_workspace
+      - setup_rust
       - run:
           name: Set up system
           command: |
             apt update
             apt install libssl-dev apt-transport-https ca-certificates gnupg curl cmake -y
-      - run:
-          name: Set up cbt
-          command: |
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-            apt-get update -y
-            apt install google-cloud-cli-cbt -y
-      - run:
-          name: Set up Python
-          command: |
-            pip install --upgrade pip
-            pip install poetry
-      - run:
-          name: Setup Bigtable
-          command: scripts/setup_bt.sh
+      - setup_cbt
+      - setup_python
+      - setup_bigtable
       - run:
           name: Integration tests (Bigtable)
           command: make integration-test
@@ -146,15 +177,10 @@ jobs:
             TEST_RESULTS_DIR: workspace/test-results
       - store_test_results:
           path: workspace/test-results
-      - save_cache:
-          name: Save Rust cache
-          key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-          paths:
-            - target
-            - ~/.cargo/registry
-            - ~/.cargo/git
+      - save_test_cache:
+          cache_key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 
-  test-rust:
+  test-unit:
     docker:
       - image: python:3.12-slim-bookworm
         auth:
@@ -168,37 +194,31 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
-    resource_class: xlarge
+    resource_class: medium
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
       # Need to download the poetry.lock files so we can use their
       # checksums in restore_cache.
-      - restore_cache:
-          name: Restoring Rust cache
-          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - restore_test_cache:
+          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - create_test_result_workspace
+      - setup_rust
+      - setup_cbt
+      - setup_bigtable
       - run:
-          name: Create Workspace
-          command: mkdir -p workspace/test-results
-      - setup-rust
-      - run:
-          name: Set up cbt
-          command: |
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-            apt-get update -y
-            apt install google-cloud-cli-cbt -y
-      - run:
-          name: Set up Rust
+          name: Echo Rust version
           command: |
             rustc --version
       - run:
-          name: Setup Bigtable
-          command: scripts/setup_bt.sh
-      - run:
           name: Install cargo-llvm-cov
           command: cargo install cargo-llvm-cov
+      # Note: This build can potentially exceed the amount of memory availble to the CircleCI instance.
+      # We've seen that limiting the number of jobs helps reduce the frequency of this. (Note that
+      # when doing discovery, we found that the docker image `meminfo` and `cpuinfo` often report
+      # the machine level memory and CPU which are far higher than the memory allocated to the docker
+      # instance. This may be causing rust to be overly greedy triggering the VM to OOM the process.)
       - run:
           name: Report tests and coverage
           command: |
@@ -206,15 +226,10 @@ jobs:
       - store_artifacts:
           path: ~/project/workspace/test-results/cov.json
           destination: cov.json
-      - save_cache:
-          name: Save Rust cache
-          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-          paths:
-            - target
-            - ~/.cargo/registry
-            - ~/.cargo/git
+      - save_test_cache:
+          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 
-  check-rust-formatting:
+  rust-checks:
     docker:
       - image: python:3.12-slim-bookworm
         auth:
@@ -223,19 +238,18 @@ jobs:
         environment:
           RUST_BACKTRACE: 1
           RUST_TEST_THREADS: 1
-    resource_class: xlarge
+    resource_class: medium
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
       # Need to download the poetry.lock files so we can use their
       # checksums in restore_cache.
-      - restore_cache:
-          name: Restoring Rust cache
-          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-      - setup-rust
+      - restore_test_cache:
+          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - setup_rust
       - run:
-          name: Set up Rust
+          name: Echo Rust Version
           command: |
             rustc --version
       - run:
@@ -388,12 +402,12 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-rust:
-          name: Rust Tests
+      - test-unit:
+          name: Rust Unit Tests
           filters:
             tags:
               only: /.*/
-      - check-rust-formatting:
+      - rust-checks:
           name: Rust Formatting Check
           filters:
             tags:
@@ -430,7 +444,7 @@ workflows:
           requires:
             - build-autoconnect
             - Integration Tests
-            - Rust Tests
+            - Rust Unit Tests
             - Rust Formatting Check
           filters:
             tags:
@@ -445,7 +459,7 @@ workflows:
           requires:
             - build-autoendpoint
             - Integration Tests
-            - Rust Tests
+            - Rust Unit Tests
             - Rust Formatting Check
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
-    resource_class: medium
+    resource_class: large
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
@@ -194,7 +194,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
-    resource_class: medium
+    resource_class: large
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
@@ -238,7 +238,7 @@ jobs:
         environment:
           RUST_BACKTRACE: 1
           RUST_TEST_THREADS: 1
-    resource_class: medium
+    resource_class: large
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,20 @@ commands:
             else
               echo "${PASS}" | docker login -u="${USER}" --password-stdin
             fi
+  setup-rust:
+    steps:
+      - run:
+          name: Set up Rust and build applications
+          command: |
+            apt update
+            apt install build-essential curl libstdc++6 libstdc++-12-dev libssl-dev pkg-config -y
+            apt install cmake -y
+            # RUST_VER
+            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.80 -y
+            export PATH=$PATH:$HOME/.cargo/bin
+            echo 'export PATH=$PATH:$HOME/.cargo/bin' >> $BASH_ENV
+            rustc --version
+            cargo build --features=emulator
 
 jobs:
   audit:
@@ -77,7 +91,7 @@ jobs:
           name: isort, black, flake8, pydocstyle and mypy
           command: make lint
 
-  test:
+  test-integration:
     docker:
       - image: python:3.12-slim-bookworm
         auth:
@@ -95,19 +109,18 @@ jobs:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
-      # Need to download the poetry.lock files so we can use their
-      # checksums in restore_cache.
       - restore_cache:
           name: Restoring Rust cache
-          key: rust-v1-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Create Workspace
           command: mkdir -p workspace
+      - setup-rust
       - run:
           name: Set up system
           command: |
             apt update
-            apt install libssl-dev apt-transport-https ca-certificates gnupg curl -y
+            apt install libssl-dev apt-transport-https ca-certificates gnupg curl cmake -y
       - run:
           name: Set up cbt
           command: |
@@ -121,33 +134,8 @@ jobs:
             pip install --upgrade pip
             pip install poetry
       - run:
-          name: Set up Rust
-          command: |
-            apt update
-            apt install build-essential curl libstdc++6 libstdc++-12-dev libssl-dev pkg-config -y
-            apt install cmake -y
-            # RUST_VER
-            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.80 -y
-            export PATH=$PATH:$HOME/.cargo/bin
-            echo 'export PATH=$PATH:$HOME/.cargo/bin' >> $BASH_ENV
-            rustc --version
-            cargo build --features=emulator
-      - run:
-          name: Check formatting
-          command: |
-            cargo fmt -- --check
-            cargo clippy --all --all-targets --all-features -- -D warnings --deny=clippy::dbg_macro
-      - run:
           name: Setup Bigtable
           command: scripts/setup_bt.sh
-      - run:
-          name: Rust tests
-          # Note: This build can potentially exceed the amount of memory availble to the CircleCI instance.
-          # We've seen that limiting the number of jobs helps reduce the frequency of this. (Note that
-          # when doing discovery, we found that the docker image `meminfo` and `cpuinfo` often report
-          # the machine level memory and CPU which are far higher than the memory allocated to the docker
-          # instance. This may be causing rust to be overly greedy triggering the VM to OOM the process.)
-          command: cargo test --features=emulator --features=bigtable --jobs=2
       - run:
           name: Integration tests (Bigtable)
           command: make integration-test
@@ -160,11 +148,101 @@ jobs:
           path: workspace/test-results
       - save_cache:
           name: Save Rust cache
-          key: rust-v1-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
           paths:
             - target
             - ~/.cargo/registry
             - ~/.cargo/git
+
+  test-rust:
+    docker:
+      - image: python:3.12-slim-bookworm
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          RUST_BACKTRACE: 1
+          RUST_TEST_THREADS: 1
+      - image: google/cloud-sdk:latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        command: gcloud beta emulators bigtable start --host-port=localhost:8086
+    resource_class: xlarge
+    environment:
+      BIGTABLE_EMULATOR_HOST: localhost:8086
+    steps:
+      - checkout
+      # Need to download the poetry.lock files so we can use their
+      # checksums in restore_cache.
+      - restore_cache:
+          name: Restoring Rust cache
+          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Create Workspace
+          command: mkdir -p workspace/test-results
+      - setup-rust
+      - run:
+          name: Set up cbt
+          command: |
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            apt-get update -y
+            apt install google-cloud-cli-cbt -y
+      - run:
+          name: Set up Rust
+          command: |
+            rustc --version
+      - run:
+          name: Setup Bigtable
+          command: scripts/setup_bt.sh
+      - run:
+          name: Install cargo-llvm-cov
+          command: cargo install cargo-llvm-cov
+      - run:
+          name: Report tests and coverage
+          command: |
+            cargo llvm-cov --json --output-path workspace/test-results/cov.json test --features=emulator --features=bigtable --jobs=2
+      - store_artifacts:
+          path: ~/project/workspace/test-results/cov.json
+          destination: cov.json
+      - save_cache:
+          name: Save Rust cache
+          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - target
+            - ~/.cargo/registry
+            - ~/.cargo/git
+
+  check-rust-formatting:
+    docker:
+      - image: python:3.12-slim-bookworm
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          RUST_BACKTRACE: 1
+          RUST_TEST_THREADS: 1
+    resource_class: xlarge
+    environment:
+      BIGTABLE_EMULATOR_HOST: localhost:8086
+    steps:
+      - checkout
+      # Need to download the poetry.lock files so we can use their
+      # checksums in restore_cache.
+      - restore_cache:
+          name: Restoring Rust cache
+          key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      - setup-rust
+      - run:
+          name: Set up Rust
+          command: |
+            rustc --version
+      - run:
+          name: Check formatting
+          command: |
+            cargo fmt -- --check
+            cargo clippy --all --all-targets --all-features -- -D warnings --deny=clippy::dbg_macro
 
   build:
     docker:
@@ -305,7 +383,18 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test:
+      - test-integration:
+          name: Integration Tests
+          filters:
+            tags:
+              only: /.*/
+      - test-rust:
+          name: Rust Tests
+          filters:
+            tags:
+              only: /.*/
+      - check-rust-formatting:
+          name: Rust Formatting Check
           filters:
             tags:
               only: /.*/
@@ -340,7 +429,9 @@ workflows:
           repo: ${DOCKERHUB_CONNECT_REPO}
           requires:
             - build-autoconnect
-            - test
+            - Integration Tests
+            - Rust Tests
+            - Rust Formatting Check
           filters:
             tags:
               only: /.*/
@@ -353,7 +444,9 @@ workflows:
           repo: ${DOCKERHUB_ENDPOINT_REPO}
           requires:
             - build-autoendpoint
-            - test
+            - Integration Tests
+            - Rust Tests
+            - Rust Formatting Check
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This PR splits the current `test` job, which runs both rust and integration-tests, to 2 individual jobs. I have also added a job just for the `cargo format` step. The 2 new jobs use a new cache which will need to be generated on the first run so the builds will seem long but should shorten down significantly once the cache is built.

The `Rust Test` job now reports code coverage. The file is quite large but it is JSON and is uploaded as an artifact. This is done via [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov). The Integration test job also reports its test results but it is stored using `store_test_results`. I can also add this as an artifact if needed.

This should get us the test metrics we want and also shorten our overall test time on CI a bit.