### PR TITLE
Add junit reporter for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
   setup_rust:
     steps:
       - run:
-          name: Set up Rust and build applications
+          name: Set up Rust
           command: |
             apt update
             apt install build-essential curl libstdc++6 libstdc++-12-dev libssl-dev pkg-config -y
@@ -46,7 +46,11 @@ commands:
             export PATH=$PATH:$HOME/.cargo/bin
             echo 'export PATH=$PATH:$HOME/.cargo/bin' >> $BASH_ENV
             rustc --version
-            cargo build --features=emulator
+  build_applications:
+    steps:
+      - run:
+          name: Build Applicatins
+          command: cargo build --features=emulator
   setup_bigtable:
     steps:
       - run:
@@ -159,6 +163,7 @@ jobs:
           cache_key: rust-v1-integration-test-{{ checksum "Cargo.lock" }}
       - create_test_result_workspace
       - setup_rust
+      - build_applications
       - run:
           name: Set up system
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,9 @@ jobs:
             # PYTEST_ARGS: -sv
             DB_DSN: grpc://localhost:8086
             TEST_RESULTS_DIR: workspace/test-results
+      - store_artifacts:
+          path: ~/project/workspace/test-results/integration_test_results.xml
+          destination: integration_test_results.xml
       - store_test_results:
           path: workspace/test-results
       - save_test_cache:
@@ -234,6 +237,9 @@ jobs:
       - store_artifacts:
           path: ~/project/workspace/test-results/cov.json
           destination: cov.json
+      - store_artifacts:
+          path: ~/project/target/nextest/ci/junit.xml
+          destination: junit.xml
       - store_test_results:
           path: target/nextest/ci
       - save_test_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,9 @@ jobs:
       - setup_cbt
       - setup_bigtable
       - run:
+          name: Install cargo-nextest
+          command: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - run:
           name: Echo Rust version
           command: |
             rustc --version
@@ -222,10 +225,12 @@ jobs:
       - run:
           name: Report tests and coverage
           command: |
-            cargo llvm-cov --json --output-path workspace/test-results/cov.json test --features=emulator --features=bigtable --jobs=2
+            cargo llvm-cov --json --output-path workspace/test-results/cov.json nextest --features=emulator --features=bigtable --jobs=2 --profile=ci
       - store_artifacts:
           path: ~/project/workspace/test-results/cov.json
           destination: cov.json
+      - store_test_results:
+          path: target/nextest/ci
       - save_test_cache:
           cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
-    resource_class: large
+    resource_class: 2xlarge
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - checkout
       - restore_test_cache:
-          cache_key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          cache_key: rust-v1-integration-test-{{ checksum "Cargo.lock" }}
       - create_test_result_workspace
       - setup_rust
       - run:
@@ -178,7 +178,7 @@ jobs:
       - store_test_results:
           path: workspace/test-results
       - save_test_cache:
-          cache_key: rust-v1-integration-test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          cache_key: rust-v1-integration-test-cache-{{ checksum "Cargo.lock" }}
 
   test-unit:
     docker:
@@ -202,7 +202,7 @@ jobs:
       # Need to download the poetry.lock files so we can use their
       # checksums in restore_cache.
       - restore_test_cache:
-          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
       - create_test_result_workspace
       - setup_rust
       - setup_cbt
@@ -232,7 +232,7 @@ jobs:
       - store_test_results:
           path: target/nextest/ci
       - save_test_cache:
-          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
 
   rust-checks:
     docker:
@@ -251,7 +251,7 @@ jobs:
       # Need to download the poetry.lock files so we can use their
       # checksums in restore_cache.
       - restore_test_cache:
-          cache_key: rust-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+          cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
       - setup_rust
       - run:
           name: Echo Rust Version

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,23 @@
+[store]
+dir = "target/nextest"
+
+[profile.default]
+retries = 0
+test-threads = "num-cpus"
+threads-required = 1
+status-level = "pass"
+final-status-level = "flaky"
+failure-output = "immediate"
+success-output = "never"
+fail-fast = false
+slow-timeout = { period = "300s" }
+
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"
+
+report-name = "autopush-unit-tests"
+store-success-output = false
+store-failure-output = true


### PR DESCRIPTION
This adds Junit XML reporting for the unit tests on circleci, and it uploads them to `test_artifacts`. This allows us to see a report of any failures on circleci in the `Tests` tab.

I needed to increase the circleci `resource_class` as it seems to be running out of memory more often now, but I also reduced the amount of builds a job does, and even removed a build for the `rust_checks` job. This should result in faster jobs too (just by a little).

I also changed the cache key as it was using the branch as a part of the key and this won't really help us as each PR will be on a different branch, so it is now setup to just use a checksum of  `Cargo.lock`.

Fixes https://mozilla-hub.atlassian.net/browse/SYNC-4369