### PR TITLE
fix: change logic for image build triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${{ github.event.inputs.git_tag }}" != "" ]]; then
             echo "tag=${{ github.event.inputs.git_tag }}" >> $GITHUB_OUTPUT
           # successful check_run from tag
-          elif [[ "${{ startsWith(github.event.check_run.check_suite.head_branch, 'release/') }}" == "true" ]]; then
+          elif [[ "${{ github.event.check_run.check_suite.head_branch }}" =~ ^release\/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "tag=$(cut -d \/ -f2 <(echo '${{ github.event.check_run.check_suite.head_branch }}'))" >> $GITHUB_OUTPUT
           else
             echo "Cannot determine tag"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
       (github.event_name == 'check_run' &&
       github.event.check_run.name == 'build-test-deploy' &&
       github.event.check_run.conclusion == 'success' &&
-      github.ref_type == 'tag')
+      startsWith(github.event.check_run.check_suite.head_branch, 'release/'))
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -28,9 +28,8 @@ jobs:
           if [[ "${{ github.event.inputs.git_tag }}" != "" ]]; then
             echo "tag=${{ github.event.inputs.git_tag }}" >> $GITHUB_OUTPUT
           # successful check_run from tag
-          elif [[ "${{ github.ref }}" != "" ]] && \
-               [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "tag=$(cut -d \/ -f3 <(echo '${{ github.ref }}'))" >> $GITHUB_OUTPUT
+          elif [[ "${{ startsWith(github.event.check_run.check_suite.head_branch, 'release/') }}" == "true" ]]; then
+            echo "tag=$(cut -d \/ -f2 <(echo '${{ github.event.check_run.check_suite.head_branch }}'))" >> $GITHUB_OUTPUT
           else
             echo "Cannot determine tag"
             exit 1


### PR DESCRIPTION
It turns out `check_run` and `check_suite` events only occur on the default branch, so I can't verify tags the way I was before. In this case, I can leverage the `release/<tag>` branch name in `.check_suite.branch_name` to determine that tagging should occur and to identify the tag name.

In the future, we will probably want to create a workflow that initiates a tagging event, runs tests, and then builds/pushes the image.