### PR TITLE
fix(circleci): now using correct project IDs, cleaned up env var names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,12 @@
 # DOCKER_LOAD_TEST_USER - Docker Hub load test repo user
 #
 # These environment variables are necessary to authenticate with GCP and upload images to GAR
+# GCP_GAR_PROJECT_ID - GCP project ID for GAR repo
 # GCP_GAR_REPO - Name of GAR repo
-# GCP_PROJECT_ID - GCP project ID
-# GCP_SERVICE_ACCOUNT_EMAIL - GCP service account email
-# GCP_WIP_ID - GCP Workload Identity Pool ID
-# GCP_WIP_PROVIDER_ID - GCP Workload Identity Pool Provider ID
+# GCP_OIDC_PROJECT_ID - GCP project ID for Workload Identity Pool/Provider
+# GCP_OIDC_SERVICE_ACCOUNT_EMAIL - GCP service account email
+# GCP_OIDC_WIP_ID - GCP Workload Identity Pool ID
+# GCP_OIDC_WIP_PROVIDER_ID - GCP Workload Identity Pool Provider ID
 
 version: 2.1
 
@@ -428,12 +429,12 @@ jobs:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-gcr-auth
       - gcp-gcr/gcr-auth:
           gcp_cred_config_file_path: ~/gcp_cred_config.json
-          google-project-id: GCP_PROJECT_ID
+          google-project-id: GCP_OIDC_PROJECT_ID
           registry-url: <<parameters.registry-url>>
-          service_account_email: GCP_SERVICE_ACCOUNT_EMAIL
+          service_account_email: GCP_OIDC_SERVICE_ACCOUNT_EMAIL
           use_oidc: true
-          workload_identity_pool_id: GCP_WIP_ID
-          workload_identity_pool_provider_id: GCP_WIP_PROVIDER_ID
+          workload_identity_pool_id: GCP_OIDC_WIP_ID
+          workload_identity_pool_provider_id: GCP_OIDC_WIP_PROVIDER_ID
       - run:
           name: Tag image
           command: |
@@ -442,7 +443,7 @@ jobs:
             elif [ ! -z "${CIRCLE_TAG}" ]; then
               echo "export GAR_TAG=$CIRCLE_TAG" >> $BASH_ENV
             fi
-              echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
+              echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_GAR_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
               source $BASH_ENV
               docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:$GAR_TAG
               docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:latest
@@ -450,7 +451,7 @@ jobs:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:
           image: $GAR_IMAGE
-          google-project-id: GCP_PROJECT_ID
+          google-project-id: GCP_GAR_PROJECT_ID
           registry-url: <<parameters.registry-url>>
           tag: $GAR_TAG,latest
 


### PR DESCRIPTION
I was accidentally using the GAR project ID for both OIDC and GAR. I updated this workflow to:

- Use the correct values for each respective project ID
- Rename the environment variables so their scopes are clearer (GAR vs OIDC)

I already updated the corresponding environment variables on CircleCI.