### PR TITLE
fix: minor fixes for GAR deploy CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,6 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo 'export GAR_TAG=master' >> $BASH_ENV
-            elif [ "${CIRCLE_BRANCH}" == "RRM-181" ]; then
-              echo 'export GAR_TAG=debug' >> $BASH_ENV
             elif [ ! -z "${CIRCLE_TAG}" ]; then
               echo "export GAR_TAG=$CIRCLE_TAG" >> $BASH_ENV
             fi
@@ -556,9 +554,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only:
-                - master
-                - RRM-181
+              only: master
 
       - deploy-to-gar:
           name: deploy-autoendpoint-gar
@@ -572,9 +568,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only:
-                - master
-                - RRM-181
+              only: master
 
       - deploy-load-test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,6 +436,11 @@ jobs:
           use_oidc: true
           workload_identity_pool_id: GCP_OIDC_WIP_ID
           workload_identity_pool_provider_id: GCP_OIDC_WIP_PROVIDER_ID
+      - attach_workspace:
+          at: /cache
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /cache/docker.tar
       - run:
           name: Tag image
           command: |
@@ -448,8 +453,8 @@ jobs:
             fi
               echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_GAR_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
               source $BASH_ENV
-              docker tag <<parameters.image>> $GAR_IMAGE:$GAR_TAG
-              docker tag <<parameters.image>> $GAR_IMAGE:latest
+              docker tag <<parameters.image>>:build $GAR_IMAGE:$GAR_TAG
+              docker tag <<parameters.image>>:build $GAR_IMAGE:latest
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:
@@ -542,11 +547,11 @@ workflows:
       - deploy-to-gar:
           name: deploy-autoconnect-gar
           image: autoconnect
-          #requires:
-          #  - build-autoconnect
-          #  - Integration Tests
-          #  - Rust Unit Tests
-          #  - Rust Formatting Check
+          requires:
+            - build-autoconnect
+            - Integration Tests
+            - Rust Unit Tests
+            - Rust Formatting Check
           filters:
             tags:
               only: /.*/
@@ -558,11 +563,11 @@ workflows:
       - deploy-to-gar:
           name: deploy-autoendpoint-gar
           image: autoendpoint
-          #requires:
-          #  - build-autoendpoint
-          #  - Integration Tests
-          #  - Rust Unit Tests
-          #  - Rust Formatting Check
+          requires:
+            - build-autoendpoint
+            - Integration Tests
+            - Rust Unit Tests
+            - Rust Formatting Check
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,9 +328,9 @@ jobs:
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save <<parameters.image>>
-          command: mkdir -p /cache; docker save -o /cache/docker.tar "<<parameters.image>>"
+          command: mkdir -p /tmp/cache; docker save -o /tmp/cache/docker.tar "<<parameters.image>>"
       - persist_to_workspace:
-          root: /cache
+          root: /tmp/cache
           paths:
             - docker.tar
 
@@ -369,10 +369,10 @@ jobs:
       - setup_remote_docker
       - docker_login
       - attach_workspace:
-          at: /cache
+          at: /tmp/cache
       - run:
           name: Restore Docker image cache
-          command: docker load -i /cache/docker.tar
+          command: docker load -i /tmp/cache/docker.tar
       - run:
           name: Deploy to Dockerhub
           command: |
@@ -437,10 +437,10 @@ jobs:
           workload_identity_pool_id: GCP_OIDC_WIP_ID
           workload_identity_pool_provider_id: GCP_OIDC_WIP_PROVIDER_ID
       - attach_workspace:
-          at: /cache
+          at: /tmp/cache
       - run:
           name: Restore Docker image cache
-          command: docker load -i /cache/docker.tar
+          command: docker load -i /tmp/cache/docker.tar
       - run:
           name: Tag image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,8 @@ jobs:
             fi
               echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_GAR_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
               source $BASH_ENV
-              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:$GAR_TAG
-              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:latest
+              docker tag <<parameters.image>> $GAR_IMAGE:$GAR_TAG
+              docker tag <<parameters.image>> $GAR_IMAGE:latest
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:
@@ -549,7 +549,9 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only:
+                - master
+                - RRM-181
 
       - deploy-to-gar:
           name: deploy-autoendpoint-gar
@@ -563,7 +565,9 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only:
+                - master
+                - RRM-181
 
       - deploy-load-test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,7 +458,7 @@ jobs:
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:
-          image: $GAR_IMAGE
+          image: "${GCP_GAR_REPO}/<<parameters.image>>"
           google-project-id: GCP_GAR_PROJECT_ID
           registry-url: <<parameters.registry-url>>
           tag: $GAR_TAG,latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,9 +328,9 @@ jobs:
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save <<parameters.image>>
-          command: mkdir -p /tmp/cache; docker save -o /tmp/cache/docker.tar "<<parameters.image>>"
+          command: mkdir -p /cache; docker save -o /cache/docker.tar "<<parameters.image>>"
       - persist_to_workspace:
-          root: /tmp/cache
+          root: /cache
           paths:
             - docker.tar
 
@@ -369,10 +369,10 @@ jobs:
       - setup_remote_docker
       - docker_login
       - attach_workspace:
-          at: /tmp/cache
+          at: /cache
       - run:
           name: Restore Docker image cache
-          command: docker load -i /tmp/cache/docker.tar
+          command: docker load -i /cache/docker.tar
       - run:
           name: Deploy to Dockerhub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,8 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo 'export GAR_TAG=master' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "RRM-181" ]; then
+              echo 'export GAR_TAG=debug' >> $BASH_ENV
             elif [ ! -z "${CIRCLE_TAG}" ]; then
               echo "export GAR_TAG=$CIRCLE_TAG" >> $BASH_ENV
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,8 +451,8 @@ jobs:
             fi
               echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_GAR_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
               source $BASH_ENV
-              docker tag <<parameters.image>>:build $GAR_IMAGE:$GAR_TAG
-              docker tag <<parameters.image>>:build $GAR_IMAGE:latest
+              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:$GAR_TAG
+              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:latest
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -542,11 +542,11 @@ workflows:
       - deploy-to-gar:
           name: deploy-autoconnect-gar
           image: autoconnect
-          requires:
-            - build-autoconnect
-            - Integration Tests
-            - Rust Unit Tests
-            - Rust Formatting Check
+          #requires:
+          #  - build-autoconnect
+          #  - Integration Tests
+          #  - Rust Unit Tests
+          #  - Rust Formatting Check
           filters:
             tags:
               only: /.*/
@@ -558,11 +558,11 @@ workflows:
       - deploy-to-gar:
           name: deploy-autoendpoint-gar
           image: autoendpoint
-          requires:
-            - build-autoendpoint
-            - Integration Tests
-            - Rust Unit Tests
-            - Rust Formatting Check
+          #requires:
+          #  - build-autoendpoint
+          #  - Integration Tests
+          #  - Rust Unit Tests
+          #  - Rust Formatting Check
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This now mounts the workspace so we can load the built image from that. Also, I fixed the image name in the `gcp-gcr/push-image` step.

This was tested successfully in https://app.circleci.com/pipelines/github/mozilla-services/autopush-rs/2873/workflows/9adebe2f-13e8-4e5d-a853-e78b7f6ca368