### PR TITLE
Feat: Add Glean reporting for DAU

### DIFF
--- a/autoconnect/Cargo.toml
+++ b/autoconnect/Cargo.toml
@@ -57,3 +57,8 @@ default = ["bigtable"]
 bigtable = ["autopush_common/bigtable", "autoconnect_settings/bigtable"]
 emulator = ["bigtable"]
 log_vapid = []
+glean = [
+    "autopush_common/glean",
+    "autoconnect_settings/glean",
+    "autoconnect_ws/glean",
+]

--- a/autoconnect/autoconnect-settings/Cargo.toml
+++ b/autoconnect/autoconnect-settings/Cargo.toml
@@ -25,3 +25,4 @@ autopush_common.workspace = true
 # specify the default via the calling crate, in order to simplify default chains.
 bigtable = ["autopush_common/bigtable"]
 emulator = ["bigtable"]
+glean = []

--- a/autoconnect/autoconnect-settings/src/app_state.rs
+++ b/autoconnect/autoconnect-settings/src/app_state.rs
@@ -12,6 +12,8 @@ use autoconnect_common::{
     registry::ClientRegistry,
 };
 use autopush_common::db::{client::DbClient, DbSettings, StorageType};
+#[cfg(feature = "glean")]
+use autopush_common::glean::GleanSettings;
 
 use crate::{Settings, ENV_PREFIX};
 
@@ -30,6 +32,8 @@ pub struct AppState {
     pub broadcaster: Arc<RwLock<BroadcastChangeTracker>>,
 
     pub settings: Settings,
+    #[cfg(feature = "glean")]
+    pub glean_settings: GleanSettings,
     pub router_url: String,
     pub endpoint_url: String,
 }
@@ -91,6 +95,12 @@ impl AppState {
 
         let router_url = settings.router_url();
         let endpoint_url = settings.endpoint_url();
+        #[cfg(feature = "glean")]
+        let glean_settings: GleanSettings =
+            serde_json::from_str(&settings.glean_settings.clone().unwrap_or_else(|| {
+                panic!("Glean feature enabled, but no glean_settings configured")
+            }))
+            .unwrap_or_else(|e| panic!("Glean settings are indecipherable.{:?}", e));
 
         Ok(Self {
             db,
@@ -102,6 +112,8 @@ impl AppState {
             settings,
             router_url,
             endpoint_url,
+            #[cfg(feature = "glean")]
+            glean_settings,
         })
     }
 

--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -108,6 +108,9 @@ pub struct Settings {
     ///
     /// By default, the number of available physical CPUs is used as the worker count.
     pub actix_workers: Option<usize>,
+
+    /// various Glean settings.
+    pub glean_settings: Option<String>,
 }
 
 impl Default for Settings {
@@ -139,6 +142,7 @@ impl Default for Settings {
             msg_limit: 150,
             actix_max_connections: None,
             actix_workers: None,
+            glean_settings: None,
         }
     }
 }

--- a/autoconnect/autoconnect-ws/Cargo.toml
+++ b/autoconnect/autoconnect-ws/Cargo.toml
@@ -33,3 +33,6 @@ async-stream = "0.3"
 ctor.workspace = true
 
 autoconnect_common = { workspace = true, features = ["test-support"] }
+
+[features]
+glean = ["autoconnect_ws_sm/glean"]

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
@@ -30,3 +30,6 @@ tokio.workspace = true
 serde_json.workspace = true
 
 autoconnect_common = { workspace = true, features = ["test-support"] }
+
+[features]
+glean = []

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
@@ -172,22 +172,18 @@ impl UnidentifiedClient {
                                 "Failed to construct Glean record: {:?}",
                                 e
                             ))
-                        })?
-                        .add_string("app", "autoconnect")
-                        .map_err(|e| {
-                            SMErrorKind::Internal(format!(
-                                "Failed to construct Glean record: {:?}",
-                                e
-                            ))
                         })?;
-                    let glean_string =
-                        Glean::try_new(&glean_settings, "autopush", "dau", &metric_set, None, None)
-                            .map_err(|e| {
-                                SMErrorKind::Internal(format!(
-                                    "Failed to compose Glean record: {:?}",
-                                    e
-                                ))
-                            })?;
+                    let glean_string = Glean::try_new(
+                        &glean_settings,
+                        "autoconnect",
+                        "dau",
+                        &metric_set,
+                        None,
+                        None,
+                    )
+                    .map_err(|e| {
+                        SMErrorKind::Internal(format!("Failed to compose Glean record: {:?}", e))
+                    })?;
                     println!("{}", glean_string);
                 }
                 return Ok(GetOrCreateUser {

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -82,3 +82,5 @@ emulator = ["bigtable"]
 stub = []
 # Verbosely log vapid assertions (NOT ADVISED FOR WIDE PRODUCTION USE)
 log_vapid = []
+
+glean = ["autopush_common/glean"]

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -201,16 +201,18 @@ pub async fn get_channels_route(
                 .add_string("uaid", &user.uaid.to_string())
                 .map_err(|e| {
                     ApiErrorKind::General(format!("Failed to construct Glean record: {:?}", e))
-                })?
-                .add_string("app", "autoendpoint")
-                .map_err(|e| {
-                    ApiErrorKind::General(format!("Failed to construct Glean record: {:?}", e))
                 })?;
-            let glean_string =
-                Glean::try_new(glean_settings, "autopush", "dau", &metric_set, None, None)
-                    .map_err(|e| {
-                        ApiErrorKind::General(format!("Failed to compose Glean record: {:?}", e))
-                    })?;
+            let glean_string = Glean::try_new(
+                glean_settings,
+                "autoendpoint",
+                "dau",
+                &metric_set,
+                None,
+                None,
+            )
+            .map_err(|e| {
+                ApiErrorKind::General(format!("Failed to compose Glean record: {:?}", e))
+            })?;
             println!("{}", glean_string);
         }
     }

--- a/autoendpoint/src/routes/registration.rs
+++ b/autoendpoint/src/routes/registration.rs
@@ -15,6 +15,8 @@ use crate::server::AppState;
 
 use autopush_common::db::User;
 use autopush_common::endpoint::make_endpoint;
+#[cfg(feature = "glean")]
+use autopush_common::glean::{Glean, GleanSettings, MetricSet};
 
 /// Handle the `POST /v1/{router_type}/{app_id}/registration` route
 pub async fn register_uaid_route(
@@ -189,6 +191,28 @@ pub async fn get_channels_route(
             .with_tag("os", &os)
             .with_tag("browser", &browser)
             .send();
+        #[cfg(feature = "glean")]
+        {
+            // Compose the "Glean" metric string and write it to STDOUT, which is the
+            // expected destination.
+            let glean_settings: &GleanSettings = app_state.glean_settings.as_ref();
+            let mut metric_set = MetricSet::default();
+            metric_set
+                .add_string("uaid", &user.uaid.to_string())
+                .map_err(|e| {
+                    ApiErrorKind::General(format!("Failed to construct Glean record: {:?}", e))
+                })?
+                .add_string("app", "autoendpoint")
+                .map_err(|e| {
+                    ApiErrorKind::General(format!("Failed to construct Glean record: {:?}", e))
+                })?;
+            let glean_string =
+                Glean::try_new(glean_settings, "autopush", "dau", &metric_set, None, None)
+                    .map_err(|e| {
+                        ApiErrorKind::General(format!("Failed to compose Glean record: {:?}", e))
+                    })?;
+            println!("{}", glean_string);
+        }
     }
     let channel_ids = db.get_channels(&uaid).await?;
 

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -18,6 +18,9 @@ use autopush_common::{
     middleware::sentry::SentryWrapper,
 };
 
+#[cfg(feature = "glean")]
+use autopush_common::glean::GleanSettings;
+
 use crate::error::{ApiError, ApiErrorKind, ApiResult};
 use crate::metrics;
 #[cfg(feature = "stub")]
@@ -45,6 +48,8 @@ pub struct AppState {
     pub apns_router: Arc<ApnsRouter>,
     #[cfg(feature = "stub")]
     pub stub_router: Arc<StubRouter>,
+    #[cfg(feature = "glean")]
+    pub glean_settings: Box<GleanSettings>,
 }
 
 pub struct Server;
@@ -107,6 +112,10 @@ impl Server {
         );
         #[cfg(feature = "stub")]
         let stub_router = Arc::new(StubRouter::new(settings.stub.clone())?);
+
+        #[cfg(feature = "glean")]
+        let glean_settings: Box<GleanSettings> = Box::new(settings.glean_settings.clone());
+
         let app_state = AppState {
             metrics: metrics.clone(),
             settings,
@@ -117,6 +126,8 @@ impl Server {
             apns_router,
             #[cfg(feature = "stub")]
             stub_router,
+            #[cfg(feature = "glean")]
+            glean_settings,
         };
 
         spawn_pool_periodic_reporter(

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -5,6 +5,9 @@ use fernet::{Fernet, MultiFernet};
 use serde::Deserialize;
 use url::Url;
 
+#[cfg(feature = "glean")]
+use autopush_common::glean::GleanSettings;
+
 use crate::routers::apns::settings::ApnsSettings;
 use crate::routers::fcm::settings::FcmSettings;
 #[cfg(feature = "stub")]
@@ -47,6 +50,8 @@ pub struct Settings {
     pub apns: ApnsSettings,
     #[cfg(feature = "stub")]
     pub stub: StubSettings,
+    #[cfg(feature = "glean")]
+    pub glean_settings: GleanSettings,
 }
 
 impl Default for Settings {
@@ -81,6 +86,8 @@ impl Default for Settings {
             apns: ApnsSettings::default(),
             #[cfg(feature = "stub")]
             stub: StubSettings::default(),
+            #[cfg(feature = "glean")]
+            glean_settings: GleanSettings::default(),
         }
     }
 }

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -63,7 +63,7 @@ form_urlencoded = { version = "1.2", optional = true }
 [dev-dependencies]
 mockito = "0.31"
 tempfile = "3.2.0"
-tokio = { workspace=true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 actix-rt = "2.8"
 
 [features]
@@ -79,3 +79,4 @@ bigtable = [
 emulator = [
     "bigtable",
 ] # used for testing big table, requires an external bigtable emulator running.
+glean = []

--- a/autopush-common/src/glean.rs
+++ b/autopush-common/src/glean.rs
@@ -332,14 +332,12 @@ mod tests {
             None,
         )?;
 
-        dbg!(&glean);
         assert_eq!(&glean.fields.document_namespace, "APPLICATION_ID");
         assert_eq!(&glean.fields.document_type, "category_name");
         assert_eq!(&glean.fields.user_agent, &None);
         assert_eq!(&glean.fields.ip_address, &None);
         assert!(!&glean.fields.document_id.is_empty());
         let de_payload = Value::from_str(&glean.fields.payload)?;
-        dbg!(&de_payload);
         assert_eq!(
             de_payload
                 .get("client_info")
@@ -402,7 +400,6 @@ mod tests {
 
         let pinfo = &de_payload.get("ping_info").unwrap();
         let sts = parse_rfc3339(&pinfo.get("start_time").unwrap().to_string());
-        dbg!(&de_payload.get("ping_info").unwrap().get("end_time"));
         let ets = parse_rfc3339(&pinfo.get("end_time").unwrap().to_string());
         assert_eq!(sts, ets);
         assert!(sts > now);
@@ -416,8 +413,7 @@ mod tests {
 
         let settings: GleanSettings = serde_json::from_str(setting_string)?;
 
-        dbg!(settings);
-
+        assert_eq!(settings.application_id, "APPLICATION_ID");
         Ok(())
     }
 }

--- a/autopush-common/src/glean.rs
+++ b/autopush-common/src/glean.rs
@@ -1,0 +1,423 @@
+use chrono::prelude::{DateTime, Utc};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::HashMap, fmt::Display, time::SystemTime, vec::Vec};
+use uuid::Uuid;
+
+// TODO: We should probably denote that this is hand-rolled rust.
+const PARSER_ID: &str = "glean_parser v15.0.1";
+
+/// Construct a Glean compatible output string containing a recordable event.
+///
+/// Glean requires that all metrics be fully declared using the `metrics.yaml` and `pings.yaml` declaration file.
+/// For this explanation, we will assume that `pings.yaml` declares a single pingtype of `autotrack` and
+/// metrics.yaml declares a category of `autotrack`, with the abbreviate metric list of:
+///  * `first_string` - type: "string"; send_in_pings: "autotrack"
+///  * `second_string` - type: "string"; send_in_pings: "autotrack"
+///  * `first_quantity` - type: "quantity"; send_in_pings: "autotrack"
+///  * `second_quantity` - type: "quantity"; send_in_pings: "autotrack"
+///
+/// To record a Glean event
+/// ```
+/// # These values are provided by Glean once the application is approved.
+/// const GLEAN_APPLICATION_ID:&str = "GleanApplicationId";
+/// const GLEAN_DISPLAY_VERSION:&str = "GleanDisplayVersion";
+/// const GLEAN_CHANNEL:&str = "GleanChannel";
+///
+/// let glean_settings = GleanSettings {
+///     application_id: GLEAN_APPLICATION_ID.to_owned(),
+///     display_version: GLEAN_DISPLAY_VERSION.to_owned(),
+///     channel: GLEAN_CHANNEL.to_owned(),
+/// };
+///
+/// let mut metric_set = MetricSet::default()
+///     .add_string("first_string", "First")?
+///     .add_quantity("second_quantity", 1)?;
+///
+/// let glean = Glean::try_new(
+///     &glean_settings,
+///     "autotrack",        # the ping.yaml / metrics.yaml Category name
+///     "some_event",       # the metrics.yaml Event descriptor name
+///     metric_set,
+///     None,
+///     None,
+///     )?.to_string();
+///
+/// print!("{}", glean);
+///
+/// ```
+#[derive(serde::Serialize, Debug)]
+pub struct Glean {
+    #[serde(rename = "Timestamp")]
+    timestamp: String,
+    #[serde(rename = "Logger")]
+    logger: String,
+    #[serde(rename = "Type")]
+    gtype: String,
+    #[serde(rename = "Fields")]
+    fields: Ping,
+}
+
+impl Glean {
+    pub fn try_new(
+        glean_settings: &GleanSettings,
+
+        category_name: &str,
+        event_name: &str,
+        metric_set: &MetricSet,
+
+        user_agent: Option<&str>, // These are optional (and should not be filled for autopush)
+        ip_address: Option<&str>,
+    ) -> Result<Self, serde_json::Error> {
+        let now: DateTime<Utc> = SystemTime::now().into();
+        let event = make_event(now, &glean_settings.display_version, event_name)?;
+        let payload = PingPayload::try_new(
+            metric_set,
+            event,
+            &glean_settings.display_version,
+            &glean_settings.channel,
+            now,
+        )?;
+        Ok(Self {
+            timestamp: now.to_rfc3339(),
+            logger: "glean".to_owned(),
+            gtype: "glean-server-event".to_owned(),
+            fields: Ping::new(
+                glean_settings,
+                category_name,
+                user_agent,
+                ip_address,
+                &payload,
+            ),
+        })
+    }
+}
+
+impl Display for Glean {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&serde_json::to_string(self).unwrap())
+    }
+}
+
+pub(crate) fn make_event(
+    timestamp: DateTime<Utc>,
+    category: &str,
+    name: &str,
+) -> Result<HashMap<String, Value>, serde_json::Error> {
+    let mut event: HashMap<String, Value> = HashMap::new();
+
+    event.insert(
+        "timestamp".to_owned(),
+        Value::from(timestamp.timestamp_millis()),
+    );
+
+    event.insert("category".to_owned(), Value::from(category));
+    event.insert("name".to_owned(), Value::from(name));
+    Ok(event)
+}
+
+/// MetricSet is kind of the work-horse for defining the metrics being "recorded".
+/// Ideally, this would validate the metrics against some yaml file and only allow
+/// those that have been defined, in addition, it would also only allow metrics that
+/// would be constructed for the various pings.
+///
+/// I am not that clever.
+///
+/// Glean offers two types of recordable data for Events, either "string" values
+/// (which have a max length of 255 characters) or "quantity" (which are analogs
+/// for counters and are Max i64)
+/// You are to define each of these in the `metrics.yaml` file.
+#[derive(Clone, Default)]
+pub struct MetricSet {
+    quantities: HashMap<String, Value>,
+    strings: HashMap<String, Value>,
+}
+
+impl MetricSet {
+    /// Set a single string value
+    pub fn add_string(&mut self, key: &str, value: &str) -> Result<&mut Self, serde_json::Error> {
+        let v = Value::from(value);
+        self.strings.insert(key.to_owned(), v);
+        Ok(self)
+    }
+
+    /// Set a single quantity value
+    pub fn add_quantity(&mut self, key: &str, value: i64) -> Result<&mut Self, serde_json::Error> {
+        self.quantities.insert(key.to_owned(), Value::from(value));
+        Ok(self)
+    }
+
+    /// Set a batch of strings
+    pub fn set_strings(
+        &mut self,
+        values: HashMap<&str, &str>,
+    ) -> Result<&mut MetricSet, serde_json::Error> {
+        for (key, value) in values.iter() {
+            self.add_string(key, value)?;
+        }
+        Ok(self)
+    }
+
+    /// Set a batch of quantities
+    pub fn set_quantities(
+        &mut self,
+        values: HashMap<&str, i64>,
+    ) -> Result<&mut MetricSet, serde_json::Error> {
+        for (key, value) in values.iter() {
+            self.add_quantity(key, *value)?;
+        }
+        Ok(self)
+    }
+
+    /// Convenience function to set all quantity and string values desired.
+    pub fn try_new(
+        quantities: Option<HashMap<&str, i64>>,
+        strings: Option<HashMap<&str, &str>>,
+    ) -> Result<Self, serde_json::Error> {
+        let mut metric_set = Self::default();
+        if let Some(quantities) = quantities {
+            metric_set.set_quantities(quantities)?;
+        }
+        if let Some(strings) = strings {
+            metric_set.set_strings(strings)?;
+        }
+        Ok(metric_set)
+    }
+
+    // TODO: Add from_hashmap?
+}
+
+impl Serialize for MetricSet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("metrics", 2)?;
+        state.serialize_field("quantity", &self.quantities)?;
+        state.serialize_field("string", &self.strings)?;
+
+        state.end()
+    }
+}
+
+/// The "ping payload" is the content of the "Ping" event. In `server.yaml`,
+/// fields maked as `send_in_pings` should only include those fields in the associated
+/// Ping category. We're a bit more lax about that here, but we should check to see
+/// if that complicates things.
+#[derive(serde::Serialize)]
+pub(crate) struct PingPayload {
+    metrics: MetricSet,
+    events: Vec<HashMap<String, Value>>,
+    ping_info: HashMap<String, Value>,
+    client_info: HashMap<String, Value>,
+}
+
+impl PingPayload {
+    fn try_new(
+        metrics: &MetricSet,
+        event: HashMap<String, Value>,
+        display_version: &str,
+        channel: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Self, serde_json::error::Error> {
+        let timestamp_str = timestamp.to_rfc3339();
+        // This should be put in `make_event`, but it's kept separate because
+        // the various `glean_parser` built code keeps it separate.
+        // I am not sworn that this is an awesome way to do it, so I can be
+        // easily convinced to put it in `make_event`
+        let mut ping_info: HashMap<String, Value> = HashMap::new();
+        ping_info.insert("seq".to_owned(), Value::from(0));
+        ping_info.insert("start_time".to_owned(), Value::from(timestamp_str.as_str()));
+        ping_info.insert("end_time".to_owned(), Value::from(timestamp_str));
+
+        let mut client_info: HashMap<String, Value> = HashMap::new();
+        client_info.insert("telemetry_sdk_build".to_owned(), Value::from(PARSER_ID));
+        client_info.insert("first_run_date".to_owned(), Value::from("Unknown"));
+        client_info.insert("os".to_owned(), Value::from("Unknown"));
+        client_info.insert("os_version".to_owned(), Value::from("Unknown"));
+        client_info.insert("architecture".to_owned(), Value::from("Unknown"));
+        client_info.insert("app_build".to_owned(), Value::from("Unknown"));
+        client_info.insert(
+            "app_display_version".to_owned(),
+            Value::from(display_version),
+        );
+        client_info.insert("app_channel".to_owned(), Value::from(channel));
+
+        Ok(Self {
+            metrics: metrics.clone(),
+            events: vec![event],
+            ping_info,
+            client_info,
+        })
+    }
+}
+
+/// Compose a "Ping" event.
+#[derive(serde::Serialize, Debug)]
+pub struct Ping {
+    document_namespace: String,
+    document_type: String,
+    document_version: String,
+    document_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ip_address: Option<String>,
+    payload: String,
+}
+
+impl Ping {
+    fn new(
+        glean_settings: &GleanSettings,
+        ping_category: &str,
+        user_agent: Option<&str>,
+        ip_address: Option<&str>,
+        payload: &PingPayload,
+    ) -> Self {
+        Ping {
+            document_namespace: glean_settings.application_id.to_owned(),
+            document_type: ping_category.to_owned(),
+            document_version: "1".to_owned(),
+            document_id: Uuid::new_v4().to_string(),
+            user_agent: user_agent.map(|v| v.to_owned()),
+            ip_address: ip_address.map(|v| v.to_owned()),
+            payload: serde_json::to_string(payload).unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Default, Debug, Serialize)]
+pub struct GleanSettings {
+    application_id: String,
+    display_version: String, // AKA: display_version
+    channel: String,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::str::FromStr;
+    use std::time::SystemTime;
+
+    use super::{Glean, GleanSettings, MetricSet};
+    use chrono::{DateTime, Utc};
+    use serde_json::Value;
+
+    fn parse_rfc3339(time: &str) -> SystemTime {
+        let dt: DateTime<Utc> = time.parse().unwrap();
+        SystemTime::from(dt)
+    }
+
+    #[test]
+    fn test_glean() -> Result<(), serde_json::Error> {
+        let now = SystemTime::now();
+
+        let metric_set = MetricSet::default()
+            .add_string("first_string", "First")?
+            .add_quantity("first_quant", 1)?
+            .clone();
+
+        let glean_settings = GleanSettings {
+            application_id: "APPLICATION_ID".to_owned(),
+            display_version: "DISPLAY_VERSION".to_owned(),
+            channel: "CHANNEL".to_owned(),
+        };
+
+        let glean = Glean::try_new(
+            &glean_settings,
+            "category_name",
+            "event_name",
+            &metric_set,
+            None,
+            None,
+        )?;
+
+        dbg!(&glean);
+        assert_eq!(&glean.fields.document_namespace, "APPLICATION_ID");
+        assert_eq!(&glean.fields.document_type, "category_name");
+        assert_eq!(&glean.fields.user_agent, &None);
+        assert_eq!(&glean.fields.ip_address, &None);
+        assert!(!&glean.fields.document_id.is_empty());
+        let de_payload = Value::from_str(&glean.fields.payload)?;
+        dbg!(&de_payload);
+        assert_eq!(
+            de_payload
+                .get("client_info")
+                .unwrap()
+                .get("app_channel")
+                .unwrap(),
+            &Value::from("CHANNEL")
+        );
+        assert_eq!(
+            de_payload
+                .get("client_info")
+                .unwrap()
+                .get("app_display_version")
+                .unwrap(),
+            &Value::from("DISPLAY_VERSION")
+        );
+        assert_eq!(
+            de_payload
+                .get("events")
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .get("category")
+                .unwrap(),
+            &Value::from("category_name")
+        );
+        assert_eq!(
+            de_payload
+                .get("events")
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            &Value::from("event_name")
+        );
+        assert_eq!(
+            de_payload
+                .get("metrics")
+                .unwrap()
+                .get("quantity")
+                .unwrap()
+                .get("first_quant")
+                .unwrap(),
+            &Value::from(1)
+        );
+        assert_eq!(
+            de_payload
+                .get("metrics")
+                .unwrap()
+                .get("string")
+                .unwrap()
+                .get("first_string")
+                .unwrap(),
+            &Value::from("First")
+        );
+
+        let ts = parse_rfc3339(&glean.timestamp);
+        assert!(ts > now);
+
+        let pinfo = &de_payload.get("ping_info").unwrap();
+        let sts = parse_rfc3339(&pinfo.get("start_time").unwrap().to_string());
+        dbg!(&de_payload.get("ping_info").unwrap().get("end_time"));
+        let ets = parse_rfc3339(&pinfo.get("end_time").unwrap().to_string());
+        assert_eq!(sts, ets);
+        assert!(sts > now);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_settings() -> Result<(), serde_json::Error> {
+        let setting_string = "{\"application_id\": \"APPLICATION_ID\", \"display_version\": \"DISPLAY\", \"channel\": \"CHANNEL\"}";
+
+        let settings: GleanSettings = serde_json::from_str(setting_string)?;
+
+        dbg!(settings);
+
+        Ok(())
+    }
+}

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -9,6 +9,8 @@ extern crate slog_scope;
 pub mod db;
 pub mod endpoint;
 pub mod errors;
+#[cfg(feature = "glean")]
+pub mod glean;
 pub mod logging;
 pub mod metrics;
 pub mod middleware;

--- a/glean/metrics_server.yaml
+++ b/glean/metrics_server.yaml
@@ -1,0 +1,49 @@
+## This file describes the "server" metrics. It's used along with
+## `pings.yaml`
+## This defines the various allowed metrics that are to be captured.
+## Each metric is written as a JSON blob to the default logger output.
+
+---
+# Schema
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+# Category
+autopush:
+
+  # Event
+  dau:
+
+    type: "event"
+    send_in_pings:
+      - "autoconnect"
+      - "autoendpoint"
+
+    description: >
+      A record of the connecting Push User info for recording the Daily Active Use (DAU). Users must have at least one active subscription.
+
+    expires: "never"
+    bugs:
+      - "https://github.com/mozilla-services/autopush-rs/issues"
+    data_reviews:
+      # TODO:
+      - "https://example.com"
+    notification_emails:
+      - "push-admin+glean@mozilla.com"
+
+  uaid:
+    type: "string"
+    send_in_pings:
+      - "autoconnect"
+      - "autoendpoint"
+
+    description: >
+      The Push User Identifier (UAID) for any user that has one or more subscriptions. This is only used for Daily Active Use (DAU).
+
+    expires: "never"
+    bugs:
+      - "https://github.com/mozilla-services/autopush-rs/issues"
+    data_reviews:
+      # TODO:
+      - "https://example.com"
+    notification_emails:
+      - "push-admin+glean@mozilla.com"

--- a/glean/metrics_server.yaml
+++ b/glean/metrics_server.yaml
@@ -8,15 +8,13 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 # Category
-autopush:
+autoconnect:
 
   # Event
   dau:
-
     type: "event"
     send_in_pings:
-      - "autoconnect"
-      - "autoendpoint"
+      - "autopush"  # There is only one ping type.
 
     description: >
       A record of the connecting Push User info for recording the Daily Active Use (DAU). Users must have at least one active subscription.
@@ -30,11 +28,11 @@ autopush:
     notification_emails:
       - "push-admin+glean@mozilla.com"
 
+  # Datum
   uaid:
     type: "string"
     send_in_pings:
-      - "autoconnect"
-      - "autoendpoint"
+      - "autopush"
 
     description: >
       The Push User Identifier (UAID) for any user that has one or more subscriptions. This is only used for Daily Active Use (DAU).
@@ -47,3 +45,43 @@ autopush:
       - "https://example.com"
     notification_emails:
       - "push-admin+glean@mozilla.com"
+
+# Category
+autoendpoint:
+
+  # Event
+  dau:
+    type: "event"
+    send_in_pings:
+      - "autopush"
+
+    description: >
+      A record of the connecting Push User info for recording the Daily Active Use (DAU). Users must have at least one active subscription.
+
+    expires: "never"
+    bugs:
+      - "https://github.com/mozilla-services/autopush-rs/issues"
+    data_reviews:
+      # TODO:
+      - "https://example.com"
+    notification_emails:
+      - "push-admin+glean@mozilla.com"
+
+  # Datum
+  uaid:
+    type: "string"
+    send_in_pings:
+      - "autopush"
+
+    description: >
+      The Push User Identifier (UAID) for any user that has one or more subscriptions. This is only used for Daily Active Use (DAU).
+
+    expires: "never"
+    bugs:
+      - "https://github.com/mozilla-services/autopush-rs/issues"
+    data_reviews:
+      # TODO:
+      - "https://example.com"
+    notification_emails:
+      - "push-admin+glean@mozilla.com"
+

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -1,0 +1,38 @@
+## Describe the `pings` you're sending out.
+## This file also does double duty as the wrapper file for server metric logging.
+## The metrics for server logging are described in `metrics_server.yaml`, but are
+## limited to `event`, `string`, & `quantity`.
+
+# Schema
+$schema: moz://mozilla.org/schemas/glean/pings/1-0-0
+
+# Each group defines a discrete logging event. `event` and the field types
+# in `metrics_server.yaml` are associated with these, and discrete Loggers
+# are built for each.
+# NOTE: A potentially empty `metrics` group will always be built since that's
+# the default. It depends on if any of the `event` or field types specified indicate
+# if they're included in the default `metrics` ping.
+
+# There are no groups, well, technically, this is the group. It's
+# limited to alphanum.
+autoconnect:
+  bugs:
+    - "https://github.com/mozilla-services/autopush-rs/issues"
+  data_reviews:
+    # TODO:
+    - "https://example.com"
+  notification_emails:
+    - "push-admin+glean@mozilla.com"
+  description: "Record information related to the Daily Active Use (DAU) of the desktop connection server"
+  include_client_id: false
+
+autoendpoint:
+  bugs:
+    - "https://github.com/mozilla-services/autopush-rs/issues"
+  data_reviews:
+    # TODO:
+    - "https://example.com"
+  notification_emails:
+    - "push-admin+glean@mozilla.com"
+  description: "Record information related to the Daily Active Use (DAU) of the endpoint server by the mobile client."
+  include_client_id: false

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -13,9 +13,8 @@ $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 # the default. It depends on if any of the `event` or field types specified indicate
 # if they're included in the default `metrics` ping.
 
-# There are no groups, well, technically, this is the group. It's
-# limited to alphanum.
-autoconnect:
+# Ping Name
+autopush:
   bugs:
     - "https://github.com/mozilla-services/autopush-rs/issues"
   data_reviews:
@@ -23,16 +22,5 @@ autoconnect:
     - "https://example.com"
   notification_emails:
     - "push-admin+glean@mozilla.com"
-  description: "Record information related to the Daily Active Use (DAU) of the desktop connection server"
-  include_client_id: false
-
-autoendpoint:
-  bugs:
-    - "https://github.com/mozilla-services/autopush-rs/issues"
-  data_reviews:
-    # TODO:
-    - "https://example.com"
-  notification_emails:
-    - "push-admin+glean@mozilla.com"
-  description: "Record information related to the Daily Active Use (DAU) of the endpoint server by the mobile client."
+  description: "Record information related to the Daily Active Use (DAU)"
   include_client_id: false


### PR DESCRIPTION
This adds a "glean::Glean" struct that can be used to compose a Glean parsable log string. See code for details.

Closes: #SYNC-4409