### PR TITLE
feat: Add redis based reliability reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,10 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         command: gcloud beta emulators bigtable start --host-port=localhost:8086
+      # - image: redis/redis-stack-server
+      #  auth:
+      #    username: $DOCKER_USER
+      #    password: $DOCKER_PASS
     resource_class: large
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "openssl",
  "protobuf",
  "rand 0.8.5",
+ "redis",
  "regex",
  "reqwest 0.12.8",
  "sentry",
@@ -1099,6 +1100,16 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -2958,6 +2969,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92f61607c4c4442b575fbc3f31a5dd4e5dd69cfea8f6afec5b83e24f61c126ab"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,6 +3565,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/autoconnect/Cargo.toml
+++ b/autoconnect/Cargo.toml
@@ -57,3 +57,9 @@ default = ["bigtable"]
 bigtable = ["autopush_common/bigtable", "autoconnect_settings/bigtable"]
 emulator = ["bigtable"]
 log_vapid = []
+reliable_report = [
+    "autoconnect_settings/reliable_report",
+    "autoconnect_web/reliable_report",
+    "autoconnect_ws/reliable_report",
+    "autopush_common/reliable_report",
+]

--- a/autoconnect/autoconnect-common/src/protocol.rs
+++ b/autoconnect/autoconnect-common/src/protocol.rs
@@ -85,6 +85,8 @@ pub struct ClientAck {
     #[serde(rename = "channelID")]
     pub channel_id: Uuid,
     pub version: String,
+    #[serde(default)]
+    pub reliability_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/autoconnect/autoconnect-settings/Cargo.toml
+++ b/autoconnect/autoconnect-settings/Cargo.toml
@@ -25,3 +25,4 @@ autopush_common.workspace = true
 # specify the default via the calling crate, in order to simplify default chains.
 bigtable = ["autopush_common/bigtable"]
 emulator = ["bigtable"]
+reliable_report = ["autopush_common/reliable_report"]

--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -108,6 +108,8 @@ pub struct Settings {
     ///
     /// By default, the number of available physical CPUs is used as the worker count.
     pub actix_workers: Option<usize>,
+    #[cfg(feature = "reliable_report")]
+    pub reliability_dsn: Option<String>,
 }
 
 impl Default for Settings {
@@ -139,6 +141,8 @@ impl Default for Settings {
             msg_limit: 150,
             actix_max_connections: None,
             actix_workers: None,
+            #[cfg(feature = "reliable_report")]
+            reliability_dsn: None,
         }
     }
 }

--- a/autoconnect/autoconnect-web/Cargo.toml
+++ b/autoconnect/autoconnect-web/Cargo.toml
@@ -34,3 +34,9 @@ ctor.workspace = true
 tokio.workspace = true
 
 autoconnect_common = { workspace = true, features = ["test-support"] }
+
+[features]
+reliable_report = [
+    "autopush_common/reliable_report",
+    "autoconnect_ws/reliable_report",
+]

--- a/autoconnect/autoconnect-ws/Cargo.toml
+++ b/autoconnect/autoconnect-ws/Cargo.toml
@@ -33,3 +33,9 @@ async-stream = "0.3"
 ctor.workspace = true
 
 autoconnect_common = { workspace = true, features = ["test-support"] }
+
+[features]
+reliable_report = [
+    "autopush_common/reliable_report",
+    "autoconnect_ws_sm/reliable_report",
+]

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
@@ -30,3 +30,6 @@ tokio.workspace = true
 serde_json.workspace = true
 
 autoconnect_common = { workspace = true, features = ["test-support"] }
+
+[features]
+reliable_report = []

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
@@ -138,6 +138,11 @@ impl WebPushClient {
         &self.app_state.settings
     }
 
+    #[cfg(feature = "reliable_report")]
+    pub fn app_reliability(&self) -> &autopush_common::reliability::PushReliability {
+        &self.app_state.reliability
+    }
+
     /// Connect this `WebPushClient` to the `ClientRegistry`
     ///
     /// Returning a `Stream` of `ServerNotification`s from the `ClientRegistry`

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -82,3 +82,5 @@ emulator = ["bigtable"]
 stub = []
 # Verbosely log vapid assertions (NOT ADVISED FOR WIDE PRODUCTION USE)
 log_vapid = []
+
+reliable_report = ["autopush_common/reliable_report"]

--- a/autoendpoint/src/extractors/routers.rs
+++ b/autoendpoint/src/extractors/routers.rs
@@ -79,6 +79,8 @@ impl FromRequest for Routers {
                 metrics: app_state.metrics.clone(),
                 http: app_state.http.clone(),
                 endpoint_url: app_state.settings.endpoint_url(),
+                #[cfg(feature = "reliable_report")]
+                reliability: app_state.reliability.clone(),
             },
             fcm: app_state.fcm_router.clone(),
             apns: app_state.apns_router.clone(),

--- a/autoendpoint/src/routers/apns/router.rs
+++ b/autoendpoint/src/routers/apns/router.rs
@@ -1,4 +1,6 @@
 use autopush_common::db::client::DbClient;
+#[cfg(feature = "reliable_report")]
+use autopush_common::reliability::{PushReliability, PushReliabilityState};
 
 use crate::error::{ApiError, ApiResult};
 use crate::extractors::notification::Notification;
@@ -34,6 +36,8 @@ pub struct ApnsRouter {
     endpoint_url: Url,
     metrics: Arc<StatsdClient>,
     db: Box<dyn DbClient>,
+    #[cfg(feature = "reliable_report")]
+    reliability: Arc<PushReliability>,
 }
 
 struct ApnsClientData {
@@ -115,6 +119,7 @@ impl ApnsRouter {
         endpoint_url: Url,
         metrics: Arc<StatsdClient>,
         db: Box<dyn DbClient>,
+        #[cfg(feature = "reliable_report")] reliability: Arc<PushReliability>,
     ) -> Result<Self, ApnsError> {
         let channels = settings.channels()?;
 
@@ -130,6 +135,8 @@ impl ApnsRouter {
             endpoint_url,
             metrics,
             db,
+            #[cfg(feature = "reliable_report")]
+            reliability,
         })
     }
 
@@ -397,7 +404,7 @@ impl Router for ApnsRouter {
         Ok(router_data)
     }
 
-    async fn route_notification(&self, notification: &Notification) -> ApiResult<RouterResponse> {
+    async fn route_notification(&self, notification: Notification) -> ApiResult<RouterResponse> {
         debug!(
             "Sending APNS notification to UAID {}",
             notification.subscription.user.uaid
@@ -420,7 +427,7 @@ impl Router for ApnsRouter {
             .and_then(Value::as_str)
             .ok_or(ApnsError::NoReleaseChannel)?;
         let aps_json = router_data.get("aps").cloned();
-        let mut message_data = build_message_data(notification)?;
+        let mut message_data = build_message_data(&notification)?;
         message_data.insert("ver", notification.message_id.clone());
 
         // Get client and build payload
@@ -473,9 +480,24 @@ impl Router for ApnsRouter {
                 .await);
         }
 
+        #[cfg(feature = "reliable_report")]
+        {
+            // Record that we've sent the message out to APNS.
+            // We can't set the state here because the notification isn't
+            // mutable, but we are also essentially consuming the
+            // notification nothing else should modify it.
+            self.reliability
+                .record(
+                    &notification.subscription.reliability_id,
+                    PushReliabilityState::Transmitted,
+                    &notification.reliable_state,
+                    notification.expiry,
+                )
+                .await;
+        }
         // Sent successfully, update metrics and make response
         trace!("APNS request was successful");
-        incr_success_metrics(&self.metrics, "apns", channel, notification);
+        incr_success_metrics(&self.metrics, "apns", channel, &notification);
 
         Ok(RouterResponse::success(
             self.endpoint_url
@@ -501,6 +523,8 @@ mod tests {
     use async_trait::async_trait;
     use autopush_common::db::client::DbClient;
     use autopush_common::db::mock::MockDbClient;
+    #[cfg(feature = "reliable_report")]
+    use autopush_common::reliability::PushReliability;
     use cadence::StatsdClient;
     use mockall::predicate;
     use std::collections::HashMap;
@@ -562,6 +586,8 @@ mod tests {
             endpoint_url: Url::parse("http://localhost:8080/").unwrap(),
             metrics: Arc::new(StatsdClient::from_sink("autopush", cadence::NopMetricSink)),
             db,
+            #[cfg(feature = "reliable_report")]
+            reliability: Arc::new(PushReliability::new(&None, &None).unwrap()),
         }
     }
 
@@ -607,7 +633,7 @@ mod tests {
         let router = make_router(client, db);
         let notification = make_notification(default_router_data(), None, RouterType::APNS);
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_ok(), "result = {result:?}");
         assert_eq!(
             result.unwrap(),
@@ -646,7 +672,7 @@ mod tests {
         let data = "test-data".to_string();
         let notification = make_notification(default_router_data(), Some(data), RouterType::APNS);
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_ok(), "result = {result:?}");
         assert_eq!(
             result.unwrap(),
@@ -668,7 +694,7 @@ mod tests {
         );
         let notification = make_notification(router_data, None, RouterType::APNS);
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_err());
         assert!(
             matches!(
@@ -701,7 +727,7 @@ mod tests {
             .return_once(|_| Ok(()));
         let router = make_router(client, db.into_boxed_arc());
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_err());
         assert!(
             matches!(
@@ -729,7 +755,7 @@ mod tests {
         let router = make_router(client, db);
         let notification = make_notification(default_router_data(), None, RouterType::APNS);
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_err());
         assert!(
             matches!(
@@ -762,7 +788,7 @@ mod tests {
         );
         let notification = make_notification(router_data, None, RouterType::APNS);
 
-        let result = router.route_notification(&notification).await;
+        let result = router.route_notification(notification).await;
         assert!(result.is_err());
         assert!(
             matches!(

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -21,6 +21,9 @@ pub fn build_message_data(notification: &Notification) -> ApiResult<HashMap<&'st
         message_data.insert_opt("enc", notification.headers.encryption.as_ref());
         message_data.insert_opt("cryptokey", notification.headers.crypto_key.as_ref());
         message_data.insert_opt("enckey", notification.headers.encryption_key.as_ref());
+        // Report the data to the UA. How this value is reported back is still a work in progress, but
+        // we do set the state to "accepted" on desktop "ACK" at least.
+        message_data.insert_opt("rid", notification.subscription.reliability_id.as_ref());
     }
 
     Ok(message_data)
@@ -239,7 +242,7 @@ pub mod tests {
                 user,
                 channel_id: channel_id(),
                 vapid: None,
-                tracking_id: None,
+                reliability_id: None,
             },
             headers: NotificationHeaders {
                 ttl: 0,
@@ -252,6 +255,12 @@ pub mod tests {
             timestamp: 0,
             sort_key_timestamp: 0,
             data,
+            #[cfg(feature = "reliable_report")]
+            reliable_state: None,
+            #[cfg(feature = "reliable_report")]
+            expiry: None,
+            #[cfg(feature = "reliable_report")]
+            reliability_id: None,
         }
     }
 }

--- a/autoendpoint/src/routers/mod.rs
+++ b/autoendpoint/src/routers/mod.rs
@@ -35,7 +35,7 @@ pub trait Router {
     ) -> Result<HashMap<String, serde_json::Value>, RouterError>;
 
     /// Route a notification to the user
-    async fn route_notification(&self, notification: &Notification) -> ApiResult<RouterResponse>;
+    async fn route_notification(&self, notification: Notification) -> ApiResult<RouterResponse>;
 }
 
 /// The response returned when a router routes a notification

--- a/autoendpoint/src/routers/stub/router.rs
+++ b/autoendpoint/src/routers/stub/router.rs
@@ -89,7 +89,7 @@ impl Router for StubRouter {
         Ok(router_data)
     }
 
-    async fn route_notification(&self, notification: &Notification) -> ApiResult<RouterResponse> {
+    async fn route_notification(&self, notification: Notification) -> ApiResult<RouterResponse> {
         debug!(
             "Sending Test notification to UAID {}",
             notification.subscription.user.uaid

--- a/autoendpoint/src/routes/mod.rs
+++ b/autoendpoint/src/routes/mod.rs
@@ -1,3 +1,5 @@
 pub mod health;
 pub mod registration;
+#[cfg(feature = "reliable_report")]
+pub mod reliability;
 pub mod webpush;

--- a/autoendpoint/src/routes/reliability.rs
+++ b/autoendpoint/src/routes/reliability.rs
@@ -1,0 +1,28 @@
+use actix_web::{web::Data, HttpResponse};
+use serde_json::json;
+
+use crate::server::AppState;
+
+pub async fn report_handler(app_state: Data<AppState>) -> HttpResponse {
+    let reliability = app_state.reliability.clone();
+    match reliability.report().await {
+        Ok(Some(v)) => {
+            debug!("🔍 Reporting {:?}", &v);
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .body(json!(v).to_string())
+        }
+        Ok(None) => {
+            debug!("🔍 Reporting, but nothing to report");
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .body(json!({"error": "No data"}).to_string())
+        }
+        Err(e) => {
+            debug!("🔍🟥 Reporting, Error {:?}", &e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .body(json!({"error": e.to_string()}).to_string())
+        }
+    }
+}

--- a/autoendpoint/src/routes/webpush.rs
+++ b/autoendpoint/src/routes/webpush.rs
@@ -9,12 +9,12 @@ use actix_web::web::Data;
 use actix_web::HttpResponse;
 
 /// Handle the `POST /wpush/{api_version}/{token}` and `POST /wpush/{token}` routes
+/// This is the endpoint for all incoming Push subscription updates.
 pub async fn webpush_route(
     notification: Notification,
     routers: Routers,
     _app_state: Data<AppState>,
 ) -> ApiResult<HttpResponse> {
-    // TODO:
     sentry::configure_scope(|scope| {
         scope.set_extra(
             "uaid",
@@ -25,7 +25,7 @@ pub async fn webpush_route(
         RouterType::from_str(&notification.subscription.user.router_type)
             .map_err(|_| ApiErrorKind::InvalidRouterType)?,
     );
-    Ok(router.route_notification(&notification).await?.into())
+    Ok(router.route_notification(notification).await?.into())
 }
 
 /// Handle the `DELETE /m/{message_id}` route

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -60,6 +60,8 @@ grpcio-sys = { version = "=0.13.0", optional = true }
 protobuf = { version = "=2.28.0", optional = true } # grpcio does not support protobuf 3+
 form_urlencoded = { version = "1.2", optional = true }
 
+redis = { version = "0.27", optional = true }
+
 [dev-dependencies]
 mockito = "0.31"
 tempfile = "3.2.0"
@@ -80,3 +82,4 @@ bigtable = [
 emulator = [
     "bigtable",
 ] # used for testing big table, requires an external bigtable emulator running.
+reliable_report = ["dep:redis"]

--- a/autopush-common/src/db/client.rs
+++ b/autopush-common/src/db/client.rs
@@ -107,6 +107,14 @@ pub trait DbClient: Send + Sync {
         None
     }
 
+    /// Record the Reliability Report to long term storage.
+    #[cfg(feature = "reliable_report")]
+    async fn log_report(
+        &self,
+        reliability_id: &str,
+        state: crate::reliability::PushReliabilityState,
+    ) -> DbResult<()>;
+
     fn box_clone(&self) -> Box<dyn DbClient>;
 }
 

--- a/autopush-common/src/db/mock.rs
+++ b/autopush-common/src/db/mock.rs
@@ -95,6 +95,15 @@ impl DbClient for Arc<MockDbClient> {
         Arc::as_ref(self).remove_message(uaid, sort_key).await
     }
 
+    #[cfg(feature = "reliable_report")]
+    async fn log_report(
+        &self,
+        reliability_id: &str,
+        state: crate::reliability::PushReliabilityState,
+    ) -> DbResult<()> {
+        Arc::as_ref(self).log_report(reliability_id, state).await
+    }
+
     async fn router_table_exists(&self) -> DbResult<bool> {
         Arc::as_ref(self).router_table_exists().await
     }

--- a/autopush-common/src/db/mod.rs
+++ b/autopush-common/src/db/mod.rs
@@ -245,6 +245,10 @@ pub struct NotificationRecord {
     /// value before sending it to storage or a connection node.
     #[serde(skip_serializing_if = "Option::is_none")]
     updateid: Option<String>,
+    /// Internal Push Reliability tracking id. (Applied only to subscription updates generated
+    /// by Mozilla owned and consumed messages, like SendTab updates.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reliability_id: Option<String>,
 }
 
 impl NotificationRecord {
@@ -333,6 +337,9 @@ impl NotificationRecord {
             data: self.data,
             headers: self.headers.map(|m| m.into()),
             sortkey_timestamp: key.sortkey_timestamp,
+            reliability_id: None,
+            #[cfg(feature = "reliable_report")]
+            reliable_state: None,
         })
     }
 

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -13,6 +13,8 @@ pub mod logging;
 pub mod metrics;
 pub mod middleware;
 pub mod notification;
+#[cfg(feature = "reliable_report")]
+pub mod reliability;
 pub mod sentry;
 pub mod tags;
 pub mod test_support;

--- a/autopush-common/src/notification.rs
+++ b/autopush-common/src/notification.rs
@@ -27,6 +27,10 @@ pub struct Notification {
     pub sortkey_timestamp: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reliability_id: Option<String>,
+    #[cfg(feature = "reliable_report")]
+    pub reliable_state: Option<crate::reliability::PushReliabilityState>,
 }
 
 pub const TOPIC_NOTIFICATION_PREFIX: &str = "01";

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -1,0 +1,180 @@
+/// Push Reliability Recorder
+///
+/// This allows us to track messages from select, known parties (currently, just
+/// mozilla generated and consumed) so that we can identify potential trouble spots
+/// and where messages expire early. Message expiration can lead to message loss
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use redis::Commands;
+
+use crate::db::client::DbClient;
+use crate::errors::{ApcError, ApcErrorKind, Result};
+
+pub const COUNTS: &str = "state_counts";
+pub const EXPIRY: &str = "expiry";
+
+/// The various states that a message may transit on the way from reception to delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum PushReliabilityState {
+    #[serde(rename = "received")]
+    Received, // Subscription was received by the Push Server
+    #[serde(rename = "stored")]
+    Stored, // Subscription was stored because it could not be delivered immediately
+    #[serde(rename = "retreived")]
+    Retreived, // Subscription was taken from storage for delivery
+    #[serde(rename = "transmitted_webpush")]
+    IntTransmitted, // Subscription was handed off between autoendpoint and autoconnect
+    #[serde(rename = "accepted_webpush")]
+    IntAccepted, // Subscription was accepted by autoconnect from autopendpoint
+    #[serde(rename = "transmitted")]
+    Transmitted, // Subscription was handed off for delivery to the UA
+    #[serde(rename = "accepted")]
+    Accepted, // Subscription was accepted for delivery by the UA
+    #[serde(rename = "delivered")]
+    Delivered, // Subscription was provided to the WebApp recipient by the UA
+    #[serde(rename = "expired")]
+    Expired, // Subscription expired naturally (e.g. TTL=0)
+}
+
+// TODO: Differentiate between "transmitted via webpush" and "transmitted via bridge"?
+impl std::fmt::Display for PushReliabilityState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Received => "received",
+            Self::Stored => "stored",
+            Self::Retreived => "retrieved",
+            Self::Transmitted => "transmitted",
+            Self::IntTransmitted => "transmitted_webpush",
+            Self::IntAccepted => "accepted_webpush",
+            Self::Accepted => "accepted",
+            Self::Delivered => "delivered",
+            Self::Expired => "expired",
+        })
+    }
+}
+
+impl std::str::FromStr for PushReliabilityState {
+    type Err = ApcError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s.to_lowercase().as_str() {
+            "received" => Self::Received,
+            "stored" => Self::Stored,
+            "retrieved" => Self::Retreived,
+            "transmitted" => Self::Transmitted,
+            "accepted" => Self::Accepted,
+            "transmitted_webpush" => Self::IntTransmitted,
+            "accepted_webpush" => Self::IntAccepted,
+            "delivered" => Self::Delivered,
+            "expired" => Self::Expired,
+            _ => {
+                return Err(
+                    ApcErrorKind::GeneralError(format!("Unknown tracker state \"{}\"", s)).into(),
+                );
+            }
+        })
+    }
+}
+
+impl serde::Serialize for PushReliabilityState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct PushReliability {
+    client: Option<Arc<redis::Client>>,
+    db: Option<Box<dyn DbClient>>,
+}
+
+impl PushReliability {
+    // Do the magic to make a report instance, whatever that will be.
+    pub fn new(reliability_dsn: &Option<String>, db: &Option<Box<dyn DbClient>>) -> Result<Self> {
+        if reliability_dsn.is_none() {
+            debug!("🔍 No reliability DSN declared.");
+            return Ok(Self::default());
+        };
+
+        let client = if let Some(dsn) = reliability_dsn {
+            let rclient = redis::Client::open(dsn.clone()).map_err(|e| {
+                ApcErrorKind::GeneralError(format!("Could not connect to redis server: {:?}", e))
+            })?;
+            Some(Arc::new(rclient))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            client,
+            db: db.clone(),
+        })
+    }
+
+    // Record the record state change to storage.
+    pub async fn record(
+        &self,
+        reliability_id: &Option<String>,
+        new: PushReliabilityState,
+        old: &Option<PushReliabilityState>,
+        expr: Option<u64>,
+    ) -> Option<PushReliabilityState> {
+        if reliability_id.is_none() {
+            return None;
+        }
+        let id = reliability_id.clone().unwrap();
+        if let Some(client) = &self.client {
+            debug!(
+                "🔍 {} from {} to {}",
+                id,
+                old.map(|v| v.to_string())
+                    .unwrap_or_else(|| "None".to_owned()),
+                new
+            );
+            if let Ok(mut con) = client.get_connection() {
+                let mut pipeline = redis::Pipeline::new();
+                let pipeline = pipeline.hincr(COUNTS, new.to_string(), 1);
+                let pipeline = if let Some(old) = old {
+                    pipeline
+                        .hincr(COUNTS, old.to_string(), -1)
+                        .zrem(EXPIRY, format!("{}#{}", &old, id))
+                } else {
+                    pipeline
+                };
+                // Errors are not fatal, and should not impact message flow, but
+                // we should record them somewhere.
+                let _ = pipeline
+                    .zadd(EXPIRY, format!("{}#{}", new, id), expr.unwrap_or_default())
+                    .exec(&mut con)
+                    .inspect_err(|e| {
+                        warn!("🔍 Failed to write to storage: {:?}", e);
+                    });
+            }
+        };
+        if let Some(db) = &self.db {
+            // Errors are not fatal, and should not impact message flow, but
+            // we should record them somewhere.
+            let _ = db.log_report(&id, new).await.inspect_err(|e| {
+                warn!("🔍 Unable to record reliability state: {:?}", e);
+            });
+        }
+        Some(new)
+    }
+
+    // Return a snapshot of milestone states
+    // This will probably not be called directly, but useful for debugging.
+    pub async fn report(&self) -> Result<Option<HashMap<String, i32>>> {
+        if let Some(client) = &self.client {
+            if let Ok(mut conn) = client.get_connection() {
+                return Ok(Some(conn.hgetall(COUNTS).map_err(|e| {
+                    ApcErrorKind::GeneralError(format!("Could not read report {:?}", e))
+                })?));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/docs/src/reliability.md
+++ b/docs/src/reliability.md
@@ -1,0 +1,29 @@
+# Push Reliability Tracing
+
+AutoPush does a lot to ensure that messages and subscriptions stay private. There are many reasons for this, aside from simply respecting user privacy, which include the high cost of data capture and retention. Tracking this information can easily increase costs by thousands of dollars a month.
+
+Traditionally, AutoPush has relied on "external" tracking to determine how reliably it can deliver a message. "External" in this case, means a Mozilla internal group that tracks how "successful" a Send Tab to Device is. There are some complications with this, as that group has a different qualification for "success" than AutoPush does (delivery within a very short timeframe). Autopush should be able to determine if there are any points of loss internally without incurring the sizable costs for full tracking.
+
+This can be done via sampling, but it's important to only sample push messages that have agreed to this. Fortunately, we can use those same Mozilla generated and consumed push notification messages for "Send Tab". (The action of sending a tab is done by the user, but the use of the AutoPush system is an internal detail. It would be like tracking a dollar bill through a vending machine. We don't know or care who put the bill into the machine, nor do we care what they purchased. We are only watching to make sure the bill doesn't get stuck or fall out somewhere.)
+
+## Configuration
+
+In order to start the process, the AutoEndpoint configuration file gets a list of VAPID public keys to look for. The key format is not a standard PEM format, so the `convert_pem_to_x962.py` file is used to convert the public key format to something that's more scan-able.
+
+That key is registered using the `autoendpoint.tracking_keys` configuration setting.
+
+Push Reliability requires a Redis like memory storage system to manage the various milestone transactions. Milestones are tracked using two internal stores, the first being a Hash Incrementor (HINCR) "state_counts" table, which records the count of message at a given state. and an "expiry" table to record the expiration timestamp for the subscription.
+
+Push Reliablity also includes a bigtable `reliability` column family, which is used to create a long term record which can be used for more "in depth" analysis of a given message's path.
+
+## Operation
+
+If an incoming subscription is validated and contains a matching VAPID public key, then a `reliability_id` is assigned to the message. This ID is a random UUID that is attached to the message. All tracking is tied to this ID alone, and only performed if the `reliable_report` feature is enabled in the code.
+
+Various milestones have been set along a given messages path. These are defined in `autopush_common::reliability::PushReliabilityState`. When a message transitions from one state to the next, the new `state_count` is incremented, and the old `state_count` is decremented. In addition, the "expiry" table which is a scored hash table records the message expiration. The "expiry" table uses a combo of the "`state`#`reliability_id`" as the key. with the expiration timestamp as the value. This table is scanned by the separate `scripts/reliability_cron.py` script, which looks for expired keys, decrements their counts, and logs the expired status to bigtable. This script is required because there are no known data stores that provide this function automatically (recommendations are very welcome). The use of an outside script is to ensure that only a single application decrements values and logs data, preventing possible race conditions.
+
+"Live" counts can be displayed using any tool that can read the Redis data store, or the AutoEndpoint `/__milestones__` endpoint can be queried. Historical tracking is not part of this, and should be done using external tooling and the `reliability_cron.py` script.
+
+## Data Retention
+
+Push Subscpritions have a maximum lifetime of 30 days. The Redis Reliability tracking information will last as long as the message TTL. The Bigtable Reliability Log information will be retained for twice the maximum subscription lifetime, of 60 days to allow for some longer term trend analysis. (Note, this reliability information does not have any record of the user, subscription provider, or message content. It only includes the milestone, and timestamp when the message crossed that milestone.)

--- a/scripts/reliablity_cron.py
+++ b/scripts/reliablity_cron.py
@@ -1,0 +1,212 @@
+#! python3
+
+"""
+This program reaps expired records and adjusts counts.
+
+Currently, this is desined to run on a cron, however it
+can be adapted to include it's own timing loop.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import time
+import pdb
+
+from typing import cast
+
+import redis
+import toml
+
+from google.cloud.bigtable.data import (
+    BigtableDataClientAsync,
+    RowMutationEntry,
+    SetCell,
+)
+
+
+class Counter:
+    """Manage Redis-like storage counts
+
+    Current milestone counts are managed in a Redis-like storage system.
+    There are two parts required, one is the active milestone count (as
+    an HINCR). The other is a ZHash that contains the expiration
+    timestamp for records.
+    Our 'garbage collection' goes through the ZHash looking for expired
+    records and removes them while decrementing the associated HINCR count,
+    indicating that the record expired "in place".
+
+    We also update the Bigtable message log indicating that a message
+    failed to be delivered.
+    """
+
+    def __init__(self, log: logging.Logger, settings):
+        try:
+            import pdb
+
+            pdb.set_trace()
+            self.redis = redis.Redis.from_url(settings.reliability_dsn)
+            self.bigtable = BigtableDataClientAsync(
+                project=settings.bigtable["project"]
+            )
+            self.log = log
+            self.settings = settings
+        except Exception as e:
+            log.error(e)
+
+    async def gc(self) -> dict[str, int | float]:
+        """Prune expired elements, decrementing counters and logging result"""
+        start = time.time()
+        # The table of counts
+        counts = self.settings.count_table
+        # The table of expirations
+        expiry = self.settings.expiry_table
+        # the BigTable reliability family
+        log_family = self.settings.log_family
+
+        # Fetch the candidates to purge.
+        pdb.set_trace()
+        mutations = list()
+        purged = cast(
+            list[bytes], self.redis.zrange(expiry, -1, int(start), byscore=True)
+        )
+        # Fix up the counts
+        with self.redis.pipeline() as pipeline:
+            for key in purged:
+                # clean up the counts.
+                parts = key.split(b"#", 2)
+                state = parts[0]
+                self.log.debug(f"🪦 decr {state.decode()}")
+                pipeline.hincrby(counts, state.decode(), -1)
+                pipeline.zrem(expiry, key)
+                # and add the log info.
+                mutations.append(
+                    RowMutationEntry(
+                        key, SetCell(log_family, "expired", int(start * 1000))
+                    )
+                )
+                mutations.append(
+                    RowMutationEntry(
+                        key,
+                        SetCell(
+                            log_family,
+                            "error",
+                            "expired",
+                        ),
+                    )
+                )
+            if len(purged) > 0:
+                # make the changes to redis,
+                pipeline.execute()
+                # then add the bigtable logs
+                table = self.bigtable.get_table(
+                    self.settings.bigtable.get("instance"),
+                    self.settings.bigtable.get("table"),
+                )
+                await table.bulk_mutate_rows(mutations)
+
+        result = {
+            "trimmed": len(purged),
+            "time": int(start * 1000) - (time.time() * 1000),
+        }
+        if len(purged):
+            self.log.info(
+                f"🪦 Trimmed {result.get("trimmed")} in {result.get("time")}ms"
+            )
+        return result
+
+
+def config(env_args: os._Environ = os.environ) -> argparse.Namespace:
+    """Read the configuration from the args and environment."""
+    parser = argparse.ArgumentParser(
+        description="Manage Autopush Reliability Tracking Redis data."
+    )
+    parser.add_argument("-c", "--config", help="configuration_file", action="append")
+    parser.add_argument(
+        "--reliability_dsn",
+        "-r",
+        help="DSN to connect to the Redis like service.",
+        default=env_args.get(
+            "AUTOCONNECT_RELIABILITY_DSN", env_args.get("AUTOEND_RELIABILITY_DSN")
+        ),
+    )
+    parser.add_argument(
+        "--db_dsn",
+        "-b",
+        help="User Agent ID",
+        default=env_args.get("AUTOCONNECT_DB_DSN", env_args.get("AUTOEND_DB_DSN")),
+    )
+    parser.add_argument(
+        "--db_settings",
+        "-s",
+        help="User Agent ID",
+        default=env_args.get(
+            "AUTOCONNECT_DB_SETTINGS", env_args.get("AUTOEND_DB_SETTINGS")
+        ),
+    )
+    parser.add_argument(
+        "--count_table",
+        help="Name of Redis table of milestone counts",
+        default=env_args.get("AUTOTRACK_COUNTS", "state_counts"),
+    )
+    parser.add_argument(
+        "--expiry_table",
+        help="Name of Redis table of milestone expirations",
+        default=env_args.get("AUTOTRACK_EXPIRY", "expiry"),
+    )
+    parser.add_argument(
+        "--log_family",
+        help="Name of Bigtable log family",
+        default=env_args.get("AUTOTRACK_EXPIRY", "reliability"),
+    )
+    args = parser.parse_args()
+
+    # if we have a config file, read from that and then reload.
+    if args.config is not None:
+        for filename in args.config:
+            with open(filename, "r") as f:
+                args = parser.set_defaults(**toml.load(f))
+    args = parser.parse_args()
+
+    # fixup the bigtable settings so that they're easier for this script to deal with.
+    if args.db_settings is not None:
+        bt_settings = json.loads(args.db_settings)
+        parts = bt_settings.get("table_name").split("/")
+        for i in range(0, len(parts), 2):
+            # remember: the `tablename` dsn uses plurals for
+            # `projects`, `instances`, & `tables`
+            bt_settings[parts[i].rstrip("s")] = parts[i + 1]
+        args.bigtable = bt_settings
+
+    return args
+
+
+def init_logs():
+    """Initialize logging (based on `PYTHON_LOG` environ)"""
+    level = getattr(logging, os.environ.get("PYTHON_LOG", "INFO").upper(), None)
+    logging.basicConfig(level=level)
+    log = logging.getLogger("autotrack")
+    return log
+
+
+async def amain(log, settings):
+    """Async main loop"""
+    counter = Counter(log, settings)
+    _result = await counter.gc()
+    # TODO: adjust timing loop based on result time.
+    # Ideally, this would have a loop that it runs on that becomes tighter the more items
+    # were purged, and adjusts based on the time it took to run.
+    return
+
+
+def main():
+    """Configure and start async main loop"""
+    log = init_logs()
+    log.info("Starting up...")
+    asyncio.run(amain(log, config()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_bt.sh
+++ b/scripts/setup_bt.sh
@@ -12,11 +12,15 @@ TABLE_NAME=${TABLE_NAME:-"autopush"}
 MESSAGE_FAMILY=${MESSAGE_FAMILY:-"message"}
 MESSAGE_TOPIC_FAMILY=${MESSAGE_TOPIC_FAMILY:-"message_topic"}
 ROUTER_FAMILY=${ROUTER_FAMILY:-"router"}
+RELIABILITY_FAMILY=${RELIABILITY_FAMILY:-"reliability"}
 
 cbt -project $PROJECT -instance $INSTANCE createtable $TABLE_NAME
 cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $MESSAGE_FAMILY
 cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $MESSAGE_TOPIC_FAMILY
 cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $ROUTER_FAMILY
+cbt -project $PROJECT -instance $INSTANCE createfamily $TABLE_NAME $RELIABILITY_FAMILY
+
 cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_FAMILY "maxage=1s or maxversions=1"
 cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_TOPIC_FAMILY "maxage=1s or maxversions=1"
 cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $ROUTER_FAMILY maxversions=1
+cbt -project $PROJECT -instance $INSTANCE setgcpolicy $TABLE_NAME $MESSAGE_TOPIC_FAMILY "maxage=60d or maxversions=1"

--- a/tests/integration/async_push_test_client.py
+++ b/tests/integration/async_push_test_client.py
@@ -28,6 +28,7 @@ class ClientMessageType(Enum):
     ACK = "ack"
     NACK = "nack"
     PING = "ping"
+    NOTIFICATION = "notification"
 
 
 class AsyncPushTestClient:

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -25,7 +25,6 @@ import psutil
 import pytest
 import uvicorn
 import websockets
-
 from cryptography.fernet import Fernet
 from fastapi import FastAPI, Request
 from jose import jws

--- a/tests/load/locustfiles/stored.py
+++ b/tests/load/locustfiles/stored.py
@@ -230,7 +230,7 @@ class StoredNotifAutopushUser(FastHttpUser):
         assert self.ws
         data = self.ws.recv()
         if not isinstance(data, str):
-            logger.error("recv_message unexpectedly recieved bytes")
+            logger.error("recv_message unexpectedly received bytes")
             data = str(data)
         self.on_ws_message(self.ws, data)
 


### PR DESCRIPTION
This adds a feature flag `reliable_report` that optionally enables Push
message reliablity reporting. The report is done in two parts.
The first part uses a Redis like storage system to note message states.
This will require a regularly run "cleanup" script to sweep for expired
messages and adust the current counts, as well log those states to some
sequential logging friendly storage (e.g. common logging or steamed to
a file). The clean-up script should be a singleton to prevent possible
race conditions.

The second component will write a record of the state transition
times for tracked messages to a storage system that is indexed by the
tracking_id. This will allow for more "in depth" analysis by external
tooling.

The idea being that reporting will be comprised of two parts:
One part which shows active states of messages (with a log of prior
states to show trends over time), and an optional "in-depth" record
that could be used to show things like length of time in storage,
overall success rates, survivability rates, etc.

This patch also:
* fixes a few typos
* changes several methods that should consume Notifications, actually  consume them.
* convert from `tracking_id` to `reliability_id`
* convert instance of specialized `Metrics` to generic Cadence (to make calls more consistent)
* adds a `RELIABLE_REPORT` flag to testing.

Closes: [SYNC-4327](https://mozilla-hub.atlassian.net/browse/SYNC-4327)