### PR TITLE
bug: Address insecure sub header fetch. 

### DIFF
--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -332,6 +332,9 @@ fn validate_vapid_jwt(
             jsonwebtoken::errors::ErrorKind::InvalidAudience => {
                 return Err(VapidError::InvalidAudience.into());
             }
+            jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(e) => {
+                return Err(VapidError::InvalidVapid(format!("Missing required {}", e)).into());
+            }
             _ => {
                 // Attempt to match up the majority of ErrorKind variants.
                 // The third-party errors all defer to the source, so we can

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -87,7 +87,7 @@ impl FromRequest for Subscription {
             if let Some(ref header) = vapid {
                 let sub = header
                     .vapid
-                    .sub()
+                    .insecure_sub()
                     .map_err(|e: VapidError| {
                         // Capture the type of error and add it to metrics.
                         let mut tags = Tags::default();
@@ -423,8 +423,8 @@ pub mod tests {
         let enc_key = jsonwebtoken::EncodingKey::from_ec_der(&PRIV_KEY);
         let claims = VapidClaims {
             exp,
-            aud: aud.to_string(),
-            sub: sub.to_string(),
+            aud: Some(aud.to_string()),
+            sub: Some(sub.to_string()),
         };
         let token = jsonwebtoken::encode(&jwk_header, &claims, &enc_key).unwrap();
 
@@ -566,8 +566,8 @@ pub mod tests {
         let enc_key = jsonwebtoken::EncodingKey::from_ec_der(&PRIV_KEY);
         let claims = VapidClaims {
             exp: VapidClaims::default_exp() - 100,
-            aud: domain.to_owned(),
-            sub: "mailto:admin@example.com".to_owned(),
+            aud: Some(domain.to_owned()),
+            sub: Some("mailto:admin@example.com".to_owned()),
         };
         let token = jsonwebtoken::encode(&jwk_header, &claims, &enc_key).unwrap();
         // try standard form with padding

--- a/autoendpoint/src/headers/vapid.rs
+++ b/autoendpoint/src/headers/vapid.rs
@@ -255,8 +255,8 @@ mod tests {
             returned_header.unwrap().claims(),
             Ok(VapidClaims {
                 exp: 1713564872,
-                aud: Some("https://push.services.mozilla.com".to_string()),
-                sub: Some("mailto:admin@example.com".to_string())
+                aud: Some("https://push.services.mozilla.com".to_owned()),
+                sub: Some("mailto:admin@example.com".to_owned())
             })
         );
 
@@ -264,7 +264,7 @@ mod tests {
         let returned_header = VapidHeader::parse(VALID_HEADER);
         assert_eq!(
             returned_header.unwrap().insecure_sub(),
-            Ok("mailto:admin@example.com".to_string())
+            Ok("mailto:admin@example.com".to_owned())
         )
     }
 }

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -153,7 +153,7 @@ pub async fn handle_error(
 
     if let Some(Ok(claims)) = vapid.map(|v| v.vapid.claims()) {
         let mut extras = err.extras.unwrap_or_default();
-        extras.extend([("sub".to_owned(), claims.sub)]);
+        extras.extend([("sub".to_owned(), claims.sub.unwrap_or_default())]);
         err.extras = Some(extras);
     };
     err

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -117,6 +117,7 @@ impl FcmClient {
             .http_client
             .post(self.endpoint.clone())
             .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
             .json(&message)
             .timeout(self.timeout)
             .send()
@@ -150,10 +151,13 @@ impl FcmClient {
             return Err(match (status, data.error) {
                 (StatusCode::UNAUTHORIZED, _) => RouterError::Authentication,
                 (StatusCode::NOT_FOUND, _) => RouterError::NotFound,
-                (_, Some(error)) => RouterError::Upstream {
-                    status: error.status,
-                    message: error.message,
-                },
+                (_, Some(error)) => {
+                    info!("🌉Bridge Error: {:?}, {:?}", error.message, &self.endpoint);
+                    RouterError::Upstream {
+                        status: error.status,
+                        message: error.message,
+                    }
+                }
                 (status, None) => RouterError::Upstream {
                     status: status.to_string(),
                     message: "Unknown reason".to_string(),

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -1,4 +1,4 @@
-use autopush_common::{db::client::DbClient, MAX_NOTIFICATION_TTL};
+use autopush_common::{db::client::DbClient, MAX_FCM_NOTIFICATION_TTL};
 
 use crate::error::ApiResult;
 use crate::extractors::notification::Notification;
@@ -153,8 +153,8 @@ impl Router for FcmRouter {
 
         let (routing_token, app_id) =
             self.routing_info(router_data, &notification.subscription.user.uaid)?;
-        let ttl =
-            MAX_NOTIFICATION_TTL.min(self.settings.min_ttl.max(notification.headers.ttl as u64));
+        let ttl = MAX_FCM_NOTIFICATION_TTL
+            .min(self.settings.min_ttl.max(notification.headers.ttl as u64));
 
         // Send the notification to FCM
         let client = self

--- a/autoendpoint/src/routers/webpush.rs
+++ b/autoendpoint/src/routers/webpush.rs
@@ -216,7 +216,8 @@ impl WebPushRouter {
                             vapid
                                 .vapid
                                 .claims()
-                                .map(|c| c.sub.unwrap_or_default())
+                                .ok()
+                                .and_then(|c| c.sub)
                                 .unwrap_or_default()
                         }),
                     )),

--- a/autoendpoint/src/routers/webpush.rs
+++ b/autoendpoint/src/routers/webpush.rs
@@ -168,7 +168,9 @@ impl WebPushRouter {
         let mut err = ApiError::from(error);
         if let Some(Ok(claims)) = vapid.map(|v| v.vapid.claims()) {
             let mut extras = err.extras.unwrap_or_default();
-            extras.extend([("sub".to_owned(), claims.sub)]);
+            if let Some(sub) = claims.sub {
+                extras.extend([("sub".to_owned(), sub)]);
+            }
             err.extras = Some(extras);
         };
         err
@@ -209,12 +211,14 @@ impl WebPushRouter {
                 self.handle_error(
                     ApiErrorKind::Router(RouterError::SaveDb(
                         e,
-                        // try to extract the `sub` from the VAPID clamis.
-                        notification
-                            .subscription
-                            .vapid
-                            .as_ref()
-                            .map(|vapid| vapid.vapid.claims().map(|c| c.sub).unwrap_or_default()),
+                        // try to extract the `sub` from the VAPID claims.
+                        notification.subscription.vapid.as_ref().map(|vapid| {
+                            vapid
+                                .vapid
+                                .claims()
+                                .map(|c| c.sub.unwrap_or_default())
+                                .unwrap_or_default()
+                        }),
                     )),
                     notification.subscription.vapid.clone(),
                 )

--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -166,25 +166,9 @@ impl TryFrom<&str> for BigTableDbSettings {
         // specify the default string "default" if it's not specified.
         // There's a small chance that this could be reported as "unspecified", so this
         // removes that confusion.
-        // Looking at the python-bigtable code, this appears to be a unique value per instance
-        // https://github.com/googleapis/python-bigtable/blob/7ea3c23d7fd06a64dc87b5bad93134f05efb847b/docs/classic_client/snippets.py#L50
-        // with `unique_resource_id()` defined at
-        // https://github.com/googleapis/python-test-utils/blob/d7e04575661fab82167d2292653a541ec4a88699/test_utils/system.py#L70
-        // When we specified a simple static "default", we noticed a higher level of
-        // "Connection Resets" from the production Bigtable servers.
-        me.app_profile_id = format!(
-            "app-prof-{}-{}",
-            if me.app_profile_id.is_empty() {
-                "default".to_owned()
-            } else {
-                me.app_profile_id
-            },
-            // Python uses a string based on a ms timestamp, but since we deploy A LOT of these at the same time,
-            // I'm wondering if there's a risk for collision. Thus I'm using higher entropy UUIDv4.
-            // Forcing hyphenation to stay consistent. (Hopefully there's no string length limits, but since
-            // we aren't getting direction and the emulator doesn't care, YOLO!)
-            uuid::Uuid::new_v4().hyphenated()
-        );
+        if me.app_profile_id.is_empty() {
+            "default".clone_into(&mut me.app_profile_id);
+        }
 
         Ok(me)
     }

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -44,10 +44,10 @@ pub mod util;
 /// "abandoned" and any router info assigned to a User Agent that has not contacted
 /// Autopush in 60 days can be discarded.
 ///
-const ONE_DAY: u64 = 24 * 60 * 60;
+const ONE_DAY_IN_SECONDS: u64 = 24 * 60 * 60;
 /// The maximum TTL for notifications, 30 days in seconds
-pub const MAX_NOTIFICATION_TTL: u64 = 30 * ONE_DAY;
+pub const MAX_NOTIFICATION_TTL: u64 = 30 * ONE_DAY_IN_SECONDS;
 /// FCM has a max TTL of 4 weeks.
-pub const MAX_FCM_NOTIFICATION_TTL: u64 = 4 * 7 * ONE_DAY;
+pub const MAX_FCM_NOTIFICATION_TTL: u64 = 4 * 7 * ONE_DAY_IN_SECONDS;
 /// The maximum TTL for router records, 60 days in seconds
 pub const MAX_ROUTER_TTL: u64 = 2 * MAX_NOTIFICATION_TTL;

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -34,7 +34,7 @@ pub mod util;
 /// That gets back to the concept that Push messages are supposed to be "timely".
 /// A user may not appreciate that they have an undelivered calendar reminder from
 /// 58 days ago, nor should they be interested in a meeting alert that happened last
-/// month. When a User Agent (UA) connects, it recieves all pending messages. If
+/// month. When a User Agent (UA) connects, it receives all pending messages. If
 /// a user has not used the User Agent in more than
 /// [60 days](https://searchfox.org/mozilla-central/search?q=OFFER_PROFILE_RESET_INTERVAL_MS),
 /// the User Agent suggest "refreshing Firefox", which essentially throws away one's
@@ -44,7 +44,10 @@ pub mod util;
 /// "abandoned" and any router info assigned to a User Agent that has not contacted
 /// Autopush in 60 days can be discarded.
 ///
+const ONE_DAY: u64 = 24 * 60 * 60;
 /// The maximum TTL for notifications, 30 days in seconds
-pub const MAX_NOTIFICATION_TTL: u64 = 30 * 24 * 60 * 60;
+pub const MAX_NOTIFICATION_TTL: u64 = 30 * ONE_DAY;
+/// FCM has a max TTL of 4 weeks.
+pub const MAX_FCM_NOTIFICATION_TTL: u64 = 4 * 7 * ONE_DAY;
 /// The maximum TTL for router records, 60 days in seconds
 pub const MAX_ROUTER_TTL: u64 = 2 * MAX_NOTIFICATION_TTL;


### PR DESCRIPTION
When insecurely getting the `sub` for tracking and errors, we were not
properly decoding. This was resulting in a VAPID error being generated.
This should not impact processing, but was generating a lot of logging
messages.

* FCM would reject TTLS > that 4 weeks, which is less than
our 30 day max. Added a specific filter for that.

* fixed some spelling mistakes.

Closes: [SYNC-4514](https://mozilla-hub.atlassian.net/browse/SYNC-4514)

[SYNC-4514]: https://mozilla-hub.atlassian.net/browse/SYNC-4514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ