### PR TITLE
chore(ci): Add capability to build and push test images to GCR.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,7 @@ jobs:
   build-integration-test-container:
     docker:
       - image: cimg/base:2024.06
+    resource_class: large
     parameters:
       image:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,12 +479,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              only: master
       - build-test-container:
-          name: Build Notification Test Image
-          image: autopush-notification-tests
-          path: notification
+          name: Build End-To-End Test Image
+          image: autopush-end-to-end-tests
+          path: end-to-end
           filters:
             tags:
               only: /.*/
@@ -538,10 +536,10 @@ workflows:
             branches:
               only: master
       - deploy:
-          name: Push Notification Test Image
-          image: autopush-notification-tests
+          name: Push End-To-End Test Image
+          image: autopush-end-to-end-tests
           requires:
-            - Build Notification Test Image
+            - Build End-To-End Test Image
             - python-checks
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,11 +168,21 @@ jobs:
           command: |
             make integration-test
             cp -r ~/project/tests/integration ~/project/workspace/test-results
+      - run:
+          name: Save Docker Image to Workspace
+          command: |
+            mkdir -p /tmp/cache
+            docker tag integration-tests autopush-integration-tests
+            docker save -o /tmp/cache/autopush-integration-tests.tar autopush-integration-tests
       - store_artifacts:
           path: ~/project/workspace/test-results/integration_test_results.xml
           destination: integration_test_results.xml
       - store_test_results:
           path: workspace/test-results
+      - persist_to_workspace:
+          root: /tmp/cache
+          paths:
+            - autopush-integration-tests.tar
 
   test-unit:
     docker:
@@ -303,9 +313,9 @@ jobs:
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save <<parameters.image>>
-          command: mkdir -p /cache; docker save -o /cache/<<parameters.image>>.tar "<<parameters.image>>"
+          command: mkdir -p /tmp/cache; docker save -o /tmp/cache/<<parameters.image>>.tar "<<parameters.image>>"
       - persist_to_workspace:
-          root: /cache
+          root: /tmp/cache
           paths:
             - <<parameters.image>>.tar
 
@@ -325,10 +335,10 @@ jobs:
       - run:
           name: Save Docker Image to Workspace
           command: |
-            mkdir -p /cache
-            docker save -o /cache/<< parameters.image >>.tar << parameters.image >>
+            mkdir -p /tmp/cache
+            docker save -o /tmp/cache/<< parameters.image >>.tar << parameters.image >>
       - persist_to_workspace:
-          root: /cache
+          root: /tmp/cache
           paths:
             - << parameters.image >>.tar
 
@@ -340,7 +350,6 @@ jobs:
         default: build
       image:
         type: string
-        default: docker
       registry-url:
         type: string
         default: us-docker.pkg.dev
@@ -387,29 +396,6 @@ jobs:
           registry-url: <<parameters.registry-url>>
           tag: $GAR_TAG,latest
 
-  deploy-load-test:
-    docker:
-      - image: cimg/base:2024.06
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker
-      - run:
-          name: Load Docker Image From Workspace
-          command: docker load -i /tmp/workspace/autopush-locust.tar
-      - docker_login:
-          load: True
-      - run:
-          name: Push to Docker Hub
-          command: |
-            echo ${DOCKERHUB_LOAD_TEST_REPO}:${CIRCLE_SHA1}
-            docker tag autopush-locust ${DOCKERHUB_LOAD_TEST_REPO}:${CIRCLE_SHA1}
-            docker tag autopush-locust ${DOCKERHUB_LOAD_TEST_REPO}:latest
-            docker images
-            docker push "${DOCKERHUB_LOAD_TEST_REPO}:${CIRCLE_SHA1}"
-            docker push "${DOCKERHUB_LOAD_TEST_REPO}:latest"
-
 workflows:
   build-test-deploy:
     jobs:
@@ -454,15 +440,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-
-      - build-test-container:
-          name: Build Integration Test Image
-          image: autopush-integration-test
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: master
       - build-test-container:
           name: Build Load Test Image
           image: autopush-load-test
@@ -470,7 +447,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: sync-4559
       - build-test-container:
           name: Build Notification Test Image
           image: autopush-notification-test
@@ -478,7 +455,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: sync-4559
 
       # Comment out the following two sections for local CircleCI testing.
       - deploy:
@@ -510,7 +487,7 @@ workflows:
               only: master
       - deploy:
           name: Push Load Test Image
-          image: autopush-load-test
+          image: autopush-load-tests
           requires:
             - Build Load Test Image
             - python-checks
@@ -518,10 +495,10 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: sync-4559
       - deploy:
           name: Push Notification Test Image
-          image: autopush-notification-test
+          image: autopush-notification-tests
           requires:
             - Build Notification Test Image
             - python-checks
@@ -529,15 +506,15 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: sync-4559
       - deploy:
           name: Push Integration Test Image
-          image: autopush-integration-test
+          image: autopush-integration-tests
           requires:
-            - Build Integration Test Image
+            - Integration Tests
             - python-checks
           filters:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: sync-4559

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,13 +322,15 @@ jobs:
     parameters:
       image:
         type: string
+      path:
+        type: string
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Build Image
-          command: docker build -t << parameters.image >>:build -f ./tests/integration/Dockerfile .
+          command: docker build -t << parameters.image >>:build -f ./tests/<< parameters.path >>/Dockerfile .
       - run:
           name: Save Docker Image to Workspace
           command: |
@@ -443,6 +445,7 @@ workflows:
       - build-test-container:
           name: Build Load Test Image
           image: autopush-load-tests
+          path: load
           filters:
             tags:
               only: /.*/
@@ -451,6 +454,7 @@ workflows:
       - build-test-container:
           name: Build Notification Test Image
           image: autopush-notification-tests
+          path: notification
           filters:
             tags:
               only: /.*/
@@ -459,6 +463,7 @@ workflows:
       - build-test-container:
           name: Build Integration Test Image
           image: autopush-integration-tests
+          path: integration
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,35 @@ jobs:
           paths:
             - << parameters.image >>.tar
 
+  build-integration-test-container:
+    docker:
+      - image: cimg/base:2024.06
+    parameters:
+      image:
+        type: string
+      path:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build Image
+          command: |
+            docker buildx build --target planner -f ./tests/<< parameters.path >>/Dockerfile .
+            docker buildx build --target cacher -f ./tests/<< parameters.path >>/Dockerfile .
+            docker buildx build --target builder -f ./tests/<< parameters.path >>/Dockerfile .
+            docker buildx build --target integration-tests -t << parameters.image >>:build -f ./tests/<< parameters.path >>/Dockerfile .
+      - run:
+          name: Save Docker Image to Workspace
+          command: |
+            mkdir -p /tmp/cache
+            docker save -o /tmp/cache/<< parameters.image >>.tar << parameters.image >>:build
+      - persist_to_workspace:
+          root: /tmp/cache
+          paths:
+            - << parameters.image >>.tar
+
   deploy:
     executor: gcp-gcr/default
     parameters:
@@ -460,7 +489,7 @@ workflows:
               only: /.*/
             branches:
               only: master
-      - build-test-container:
+      - build-integration-test-container:
           name: Build Integration Test Image
           image: autopush-integration-tests
           path: integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,27 +162,24 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - attach_workspace:
+          at: /tmp/cache
       - create_test_result_workspace
+      - run:
+          name: Restore Docker image cache
+          command: |
+            docker load -i /tmp/cache/autopush-integration-tests.tar
+            docker tag autopush-integration-tests:build integration-tests
       - run:
           name: Integration tests (Bigtable)
           command: |
             make integration-test
             cp -r ~/project/tests/integration ~/project/workspace/test-results
-      - run:
-          name: Save Docker Image to Workspace
-          command: |
-            mkdir -p /tmp/cache
-            docker tag integration-tests autopush-integration-tests
-            docker save -o /tmp/cache/autopush-integration-tests.tar autopush-integration-tests
       - store_artifacts:
           path: ~/project/workspace/test-results/integration_test_results.xml
           destination: integration_test_results.xml
       - store_test_results:
           path: workspace/test-results
-      - persist_to_workspace:
-          root: /tmp/cache
-          paths:
-            - autopush-integration-tests.tar
 
   test-unit:
     docker:
@@ -331,12 +328,12 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Build Image
-          command: docker build -t << parameters.image >> -f ./tests/integration/Dockerfile .
+          command: docker build -t << parameters.image >>:build -f ./tests/integration/Dockerfile .
       - run:
           name: Save Docker Image to Workspace
           command: |
             mkdir -p /tmp/cache
-            docker save -o /tmp/cache/<< parameters.image >>.tar << parameters.image >>
+            docker save -o /tmp/cache/<< parameters.image >>.tar << parameters.image >>:build
       - persist_to_workspace:
           root: /tmp/cache
           paths:
@@ -409,6 +406,9 @@ workflows:
               only: /.*/
       - test-integration:
           name: Integration Tests
+          requires:
+            - Build Integration Test Image
+            - python-checks
           filters:
             tags:
               only: /.*/
@@ -442,7 +442,7 @@ workflows:
               only: /.*/
       - build-test-container:
           name: Build Load Test Image
-          image: autopush-load-test
+          image: autopush-load-tests
           filters:
             tags:
               only: /.*/
@@ -450,7 +450,15 @@ workflows:
               only: sync-4559
       - build-test-container:
           name: Build Notification Test Image
-          image: autopush-notification-test
+          image: autopush-notification-tests
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: sync-4559
+      - build-test-container:
+          name: Build Integration Test Image
+          image: autopush-integration-tests
           filters:
             tags:
               only: /.*/
@@ -511,6 +519,7 @@ workflows:
           name: Push Integration Test Image
           image: autopush-integration-tests
           requires:
+            - Build Integration Test Image
             - Integration Tests
             - python-checks
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: sync-4559
+              only: master
       - build-test-container:
           name: Build Notification Test Image
           image: autopush-notification-tests
@@ -459,7 +459,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: sync-4559
+              only: master
       - build-test-container:
           name: Build Integration Test Image
           image: autopush-integration-tests
@@ -467,8 +467,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              only: sync-4559
 
       # Comment out the following two sections for local CircleCI testing.
       - deploy:
@@ -508,7 +506,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: sync-4559
+              only: master
       - deploy:
           name: Push Notification Test Image
           image: autopush-notification-tests
@@ -519,7 +517,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: sync-4559
+              only: master
       - deploy:
           name: Push Integration Test Image
           image: autopush-integration-tests
@@ -531,4 +529,4 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: sync-4559
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,51 +303,34 @@ jobs:
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save <<parameters.image>>
-          command: mkdir -p /cache; docker save -o /cache/docker.tar "<<parameters.image>>"
+          command: mkdir -p /cache; docker save -o /cache/<<parameters.image>>.tar "<<parameters.image>>"
       - persist_to_workspace:
           root: /cache
           paths:
-            - docker.tar
+            - <<parameters.image>>.tar
 
-  build-load-test:
+  build-test-container:
     docker:
       - image: cimg/base:2024.06
+    parameters:
+      image:
+        type: string
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Build Image
-          command: docker build -t autopush-locust -f ./tests/load/Dockerfile .
+          command: docker build -t << parameters.image >> -f ./tests/integration/Dockerfile .
       - run:
           name: Save Docker Image to Workspace
           command: |
-            mkdir -p /tmp/workspace
-            docker save -o /tmp/workspace/autopush-locust.tar autopush-locust
+            mkdir -p /cache
+            docker save -o /cache/<< parameters.image >>.tar << parameters.image >>
       - persist_to_workspace:
-          root: /tmp/workspace
+          root: /cache
           paths:
-            - autopush-locust.tar
-
-  build-integration-test:
-    docker:
-      - image: cimg/base:2024.06
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Build Image
-          command: docker build -t autopush-integration-tests -f ./tests/integration/Dockerfile .
-      - run:
-          name: Save Docker Image to Workspace
-          command: |
-            mkdir -p /tmp/workspace
-            docker save -o /tmp/workspace/autopush-integration-tests.tar autopush-integration-tests
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - autopush-integration-tests.tar
+            - << parameters.image >>.tar
 
   deploy:
     executor: gcp-gcr/default
@@ -357,6 +340,7 @@ jobs:
         default: build
       image:
         type: string
+        default: docker
       registry-url:
         type: string
         default: us-docker.pkg.dev
@@ -376,7 +360,7 @@ jobs:
           at: /tmp/cache
       - run:
           name: Restore Docker image cache
-          command: docker load -i /tmp/cache/docker.tar
+          command: docker load -i /tmp/cache/<<parameters.image>>.tar
       # This is the easiest way to tag multiple images using different
       # conditions for the GAR_TAG variable in the smallest amount of code.
       #
@@ -471,12 +455,25 @@ workflows:
             tags:
               only: /.*/
 
-      - build-load-test:
+      - build-test-container:
+          name: Build Integration Test Image
+          image: autopush-integration-test
           filters:
             tags:
               only: /.*/
-
-      - build-integration-test:
+            branches:
+              only: master
+      - build-test-container:
+          name: Build Load Test Image
+          image: autopush-load-test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
+      - build-test-container:
+          name: Build Notification Test Image
+          image: autopush-notification-test
           filters:
             tags:
               only: /.*/
@@ -511,10 +508,33 @@ workflows:
               only: /.*/
             branches:
               only: master
-
-      - deploy-load-test:
+      - deploy:
+          name: Push Load Test Image
+          image: autopush-load-test
           requires:
-            - build-load-test
+            - Build Load Test Image
+            - python-checks
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
+      - deploy:
+          name: Push Notification Test Image
+          image: autopush-notification-test
+          requires:
+            - Build Notification Test Image
+            - python-checks
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
+      - deploy:
+          name: Push Integration Test Image
+          image: autopush-integration-test
+          requires:
+            - Build Integration Test Image
             - python-checks
           filters:
             tags:

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ upgrade:
 	$(CARGO) upgrade
 	$(CARGO) update
 
-integration-test:
+build-integration-test:
 	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml build
+
+integration-test:
 	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml run -it --name integration-tests tests
 	docker cp integration-tests:/code/integration_test_results.xml $(INTEGRATION_TEST_DIR)
 

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=cacher $CARGO_HOME $CARGO_HOME
 
 RUN cargo build --features=emulator
 
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm AS integration-tests
 
 # =============================================================================
 # Setup Integration test image

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -26,7 +26,11 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN \
     apt-get -qq update && \
     apt-get -qq install --no-install-recommends -y \
-      cmake libssl-dev ca-certificates pkg-config build-essential
+      cmake \
+      libssl-dev \
+      ca-certificates \
+      pkg-config \
+      build-essential
 
 RUN cargo chef cook --recipe-path recipe.json
 
@@ -38,7 +42,12 @@ ARG APT_CACHE_BUST
 RUN mkdir -m 755 bin
 RUN apt-get -qq update && \
     apt-get -qq upgrade && apt-get -qq install --no-install-recommends -y \
-      cmake libssl-dev ca-certificates libstdc++6 libstdc++-12-dev
+      cmake \
+      libssl-dev \
+      ca-certificates \
+      libstdc++6 \
+      libstdc++-12-dev
+
 RUN cargo --version && \
     rustc --version
 COPY . .

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -68,7 +68,8 @@ ENV DB_DSN=grpc://localhost:8086
 RUN apt-get update && apt install -y --no-install-recommends \
     git \
     build-essential \
-    curl
+    curl \
+    gpg
 
 RUN python -m venv ${PYTHON_VENV}
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -2,7 +2,55 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# =============================================================================
+# Pull in the version of cargo-chef we plan to use, so that all the below steps
+# use a consistent set of versions.
+FROM lukemathwalker/cargo-chef:0.1.68-rust-slim-bookworm AS chef
+WORKDIR /app
+
+# =============================================================================
+# Analyze the project, and produce a plan to compile its dependcies. This will
+# be run every time. The output should only change if the dependencies of the
+# project change, or if significant details of the build process change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# =============================================================================
+# Use the plan from above to build only the dependencies of the project. This
+# should almost always be pulled straight from cache unless dependencies or the
+# build process change.
+FROM chef AS cacher
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN \
+    apt-get -qq update && \
+    apt-get -qq install --no-install-recommends -y \
+      cmake libssl-dev ca-certificates pkg-config build-essential
+
+RUN cargo chef cook --recipe-path recipe.json
+
+# =============================================================================
+# Now build the project, taking advantage of the cached dependencies from above.
+FROM chef AS builder
+ARG APT_CACHE_BUST
+
+RUN mkdir -m 755 bin
+RUN apt-get -qq update && \
+    apt-get -qq upgrade && apt-get -qq install --no-install-recommends -y \
+      cmake libssl-dev ca-certificates libstdc++6 libstdc++-12-dev
+RUN cargo --version && \
+    rustc --version
+COPY . .
+COPY --from=cacher /app/target target
+COPY --from=cacher $CARGO_HOME $CARGO_HOME
+
+RUN cargo build --features=emulator
+
 FROM python:3.12-slim-bookworm
+
+# =============================================================================
+# Setup Integration test image
 
 LABEL org.opencontainers.image.authors="contextual-services-team@mozilla.com"
 
@@ -19,24 +67,13 @@ ENV DB_DSN=grpc://localhost:8086
 # (g++/make for gevent on pypy)
 RUN apt-get update && apt install -y --no-install-recommends \
     git \
-    gpg \
     build-essential \
-    python3-dev \
-    curl \
-    libstdc++6 \
-    libstdc++-12-dev \
-    libssl-dev \
-    pkg-config \
-    cmake
+    curl
 
 RUN python -m venv ${PYTHON_VENV}
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 
 RUN python -m pip install --upgrade pip
-
-# Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.81 -y
-RUN rustc --version
 
 # Setup poetry and install requirements
 ENV POETRY_VIRTUALENVS_CREATE=false \
@@ -52,10 +89,10 @@ RUN apt-get update -y && apt install google-cloud-cli-cbt -y
 
 COPY . /code
 
-WORKDIR /code
+COPY --from=builder /app/target/debug /code/target/debug
+COPY --from=builder /app/version.json /code
 
-# Build app
-RUN cargo build --features=emulator
+WORKDIR /code
 
 RUN chmod +x scripts/setup_bt.sh
 

--- a/tests/notification/Dockerfile
+++ b/tests/notification/Dockerfile
@@ -56,9 +56,9 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 WORKDIR /code
-ADD notification/ /code
-ADD ../poetry.lock /code
-ADD ../pyproject.toml /code
+ADD ./tests/notification/ /code
+ADD ./tests/poetry.lock /code
+ADD ./tests/pyproject.toml /code
 
 RUN poetry install --only=notification
 

--- a/tests/notification/docker-compose.yml
+++ b/tests/notification/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       SERVER_URL: server
     build:
-      context: ..
-      dockerfile: notification/Dockerfile
+      context: ../..
+      dockerfile: tests/notification/Dockerfile
     depends_on: 
       - server
     network_mode: host


### PR DESCRIPTION
Adds the steps needed to build and push our containerized tests to GCR.

[SYNC-4559](https://mozilla-hub.atlassian.net/browse/SYNC-4559)

[SYNC-4559]: https://mozilla-hub.atlassian.net/browse/SYNC-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ