### PR TITLE
Feat: Add urgency support

### DIFF
--- a/autoconnect/Cargo.toml
+++ b/autoconnect/Cargo.toml
@@ -56,6 +56,7 @@ docopt = "1.1"
 default = ["bigtable"]
 bigtable = ["autopush_common/bigtable", "autoconnect_settings/bigtable"]
 emulator = ["bigtable"]
+urgency = ["autoconnect_ws/urgency"]
 log_vapid = []
 reliable_report = [
     "autoconnect_settings/reliable_report",

--- a/autoconnect/autoconnect-common/Cargo.toml
+++ b/autoconnect/autoconnect-common/Cargo.toml
@@ -27,3 +27,4 @@ autopush_common.workspace = true
 
 [features]
 test-support = []
+urgency = []

--- a/autoconnect/autoconnect-common/src/protocol.rs
+++ b/autoconnect/autoconnect-common/src/protocol.rs
@@ -14,6 +14,9 @@ use uuid::Uuid;
 
 use autopush_common::notification::Notification;
 
+#[cfg(feature = "urgency")]
+use autopush_common::db::Urgency;
+
 #[derive(Debug, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum BroadcastValue {
@@ -64,6 +67,11 @@ pub enum ClientMessage {
     Nack {
         code: Option<i32>,
         version: String,
+    },
+
+    #[cfg(feature = "urgency")]
+    Urgency {
+        min: Urgency,
     },
 
     Ping,
@@ -122,6 +130,11 @@ pub enum ServerMessage {
     },
 
     Notification(Notification),
+
+    #[cfg(feature = "urgency")]
+    Urgency {
+        status: u32,
+    },
 
     Ping,
 }

--- a/autoconnect/autoconnect-ws/Cargo.toml
+++ b/autoconnect/autoconnect-ws/Cargo.toml
@@ -39,3 +39,4 @@ reliable_report = [
     "autopush_common/reliable_report",
     "autoconnect_ws_sm/reliable_report",
 ]
+urgency = ["autoconnect_ws_sm/urgency"]

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/Cargo.toml
@@ -33,3 +33,4 @@ autoconnect_common = { workspace = true, features = ["test-support"] }
 
 [features]
 reliable_report = []
+urgency = ["autoconnect_common/urgency"]

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/mod.rs
@@ -12,7 +12,7 @@ use autoconnect_common::{
 
 use autoconnect_settings::{AppState, Settings};
 use autopush_common::{
-    db::User,
+    db::{Urgency, User},
     notification::Notification,
     util::{ms_since_epoch, user_agent::UserAgentInfo},
 };
@@ -297,6 +297,8 @@ pub struct ClientFlags {
     pub old_record_version: bool,
     /// First time a user has connected "today"
     pub emit_channel_metrics: bool,
+    /// Minimum urgency
+    pub min_urgency: Urgency,
 }
 
 impl Default for ClientFlags {
@@ -307,6 +309,7 @@ impl Default for ClientFlags {
             check_storage: false,
             old_record_version: false,
             emit_channel_metrics: false,
+            min_urgency: Urgency::VeryLow,
         }
     }
 }

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/on_client_msg.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/identified/on_client_msg.rs
@@ -9,6 +9,9 @@ use autoconnect_common::{
 };
 use autopush_common::{endpoint::make_endpoint, util::sec_since_epoch};
 
+#[cfg(feature = "urgency")]
+use autopush_common::{db::Urgency, util::ms_since_epoch};
+
 use super::WebPushClient;
 use crate::error::{SMError, SMErrorKind};
 
@@ -38,6 +41,8 @@ impl WebPushClient {
                 self.nack(code);
                 Ok(vec![])
             }
+            #[cfg(feature = "urgency")]
+            ClientMessage::Urgency { min } => Ok(self.change_min_urgency(min).await?),
             ClientMessage::Ping => Ok(vec![self.ping()?]),
         }
     }
@@ -328,6 +333,42 @@ impl WebPushClient {
             Err(SMErrorKind::UaidReset.into())
         } else {
             Ok(vec![])
+        }
+    }
+
+    /// Update minimum urgency for the user and the flag
+    ///
+    /// If the new urgency is lower than the previous one,
+    /// We check pending messages, to send messages that were
+    /// retained because of their urgency
+    #[cfg(feature = "urgency")]
+    async fn change_min_urgency(
+        &mut self,
+        new_min: Urgency,
+    ) -> Result<Vec<ServerMessage>, SMError> {
+        // Change the min urgency
+        self.flags.min_urgency = new_min;
+
+        if let Some(mut user) = self.app_state.db.get_user(&self.uaid).await? {
+            // If the user hasn't set a minimum urgency yet, they receive all messages,
+            // which is equivalent to setting very-low as a minimum
+            let current_urgency = user.urgency.unwrap_or(Urgency::VeryLow);
+
+            // We update the user
+            user.urgency = Some(new_min);
+            user.connected_at = ms_since_epoch();
+            self.app_state.db.update_user(&mut user).await?;
+
+            let mut res = vec![ServerMessage::Urgency { status: 200 }];
+            // if new urgency < previous: fetch pending messages
+            if new_min < current_urgency {
+                self.ack_state.unacked_stored_highest = None;
+                self.current_timestamp = None;
+                res.append(&mut self.check_storage().await?);
+            }
+            Ok(res)
+        } else {
+            Ok(vec![ServerMessage::Urgency { status: 404 }])
         }
     }
 }

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
@@ -9,7 +9,7 @@ use autoconnect_common::{
 };
 use autoconnect_settings::{AppState, Settings};
 use autopush_common::{
-    db::{User, USER_RECORD_VERSION},
+    db::{Urgency, User, USER_RECORD_VERSION},
     util::{ms_since_epoch, ms_utc_midnight},
 };
 
@@ -145,6 +145,7 @@ impl UnidentifiedClient {
                         .record_version
                         .map_or(true, |rec_ver| rec_ver < USER_RECORD_VERSION),
                     emit_channel_metrics: user.connected_at < ms_utc_midnight(),
+                    min_urgency: user.urgency.unwrap_or(Urgency::VeryLow),
                     ..Default::default()
                 };
                 user.node_id = Some(self.app_state.router_url.to_owned());

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -249,6 +249,7 @@ pub mod tests {
             },
             headers: NotificationHeaders {
                 ttl: 0,
+                urgency: None,
                 topic: Some("test-topic".to_string()),
                 encoding: Some("test-encoding".to_string()),
                 encryption: Some("test-encryption".to_string()),

--- a/autopush-common/src/db/models.rs
+++ b/autopush-common/src/db/models.rs
@@ -23,6 +23,8 @@ pub(crate) struct NotificationHeaders {
     encryption_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     encoding: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    urgency: Option<String>,
 }
 
 #[allow(clippy::implicit_hasher)]
@@ -33,6 +35,7 @@ impl From<NotificationHeaders> for HashMap<String, String> {
         map.insert_opt("encryption", val.encryption);
         map.insert_opt("encryption_key", val.encryption_key);
         map.insert_opt("encoding", val.encoding);
+        map.insert_opt("urgency", val.urgency);
         map
     }
 }
@@ -44,6 +47,7 @@ impl From<HashMap<String, String>> for NotificationHeaders {
             encryption: val.get("encryption").map(|v| v.to_string()),
             encryption_key: val.get("encryption_key").map(|v| v.to_string()),
             encoding: val.get("encoding").map(|v| v.to_string()),
+            urgency: val.get("urgency").map(|v| v.to_string()),
         }
     }
 }


### PR DESCRIPTION
It allows clients to define the minimum urgency of messages they wish to receive. For example, a client with low battery can request a high urgency message only until their battery is good again.