### PR TITLE
fix SYNC-4566: Change the path for end to end testci builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ workflows:
       - build-test-container:
           name: Build End-To-End Test Image
           image: autopush-end-to-end-tests
-          path: end-to-end
+          path: notification
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This fixes the path for the end to end docker image that gets built on CI.

This is building fine on CI but we are getting an error that will need to be fixed first: https://mozilla-hub.atlassian.net/browse/SYNC-4567