### PR TITLE
fix SYNC-4567: Pin poetry and update makefile to use new commands.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
           name: Set up Python
           command: |
             pip install --upgrade pip
-            pip install poetry
+            pip install poetry==2.0.0
 
 jobs:
   audit:
@@ -147,7 +147,7 @@ jobs:
           name: Set up Python
           command: |
             pip install --upgrade pip
-            pip install poetry
+            pip install poetry==2.0.0
       - run:
           name: isort, black, flake8, pydocstyle and mypy
           command: make lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INTEGRATION_TEST_DIR := $(TESTS_DIR)/integration
 INTEGRATION_TEST_FILE := $(INTEGRATION_TEST_DIR)/test_integration_all_rust.py
 NOTIFICATION_TEST_DIR := $(TESTS_DIR)/notification
 LOAD_TEST_DIR := $(TESTS_DIR)/load
-POETRY := poetry --directory $(TESTS_DIR)
+POETRY := poetry --project $(TESTS_DIR)
 DOCKER_COMPOSE := docker compose
 PYPROJECT_TOML := $(TESTS_DIR)/pyproject.toml
 POETRY_LOCK := $(TESTS_DIR)/poetry.lock
@@ -22,6 +22,9 @@ $(INSTALL_STAMP): $(PYPROJECT_TOML) $(POETRY_LOCK)
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
 	$(POETRY) install
 	touch $(INSTALL_STAMP)
+
+install_poetry:
+	curl -sSL https://install.python-poetry.org | python3 - --version 2.0.0
 
 upgrade:
 	$(CARGO) install cargo-edit ||


### PR DESCRIPTION
This pins poetry on CI to use version 2.0.0 and updates our make file to make use of the `--project` flag. I also added a make command to install the pinned version.