### PR TITLE
doc: Update CONTRIBUTING to emphasize commit signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,13 @@ Before submitting a PR:
   your reviewer's responsibility to ensure your patch includes adequate tests.
 
 When submitting a PR:
+- **[Sign all your git commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification)**.
+  We cannot accept any PR that does not have all commits signed. This is a policy
+  put in place by our Security Operations team and is enforced by our CI processes.
 - You agree to license your code under the project's open source license
   ([MPL 2.0](/LICENSE)).
 - Base your branch off the current `master`.
 - Add both your code and new tests if relevant.
-- Sign your git commit.
 - Run the test suite to make sure your code passes linting and tests.
 - Ensure your changes do not reduce code coverage of the test suite.
 - Please do not include merge commits in pull requests; include only commits
@@ -93,5 +95,5 @@ passed and the commit message is properly formatted.
 BREAKING CHANGE: This patch requires developer to lower expectations about
     what "delicious" and "cookie" may mean. Some sadness may result.
 
-Closes #3.14, #9.75
+Closes #314, #975
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL := /bin/sh
 CARGO = cargo
-TESTS_DIR := tests
+# For unknown reasons, poetry on CI will sometimes "forget" what it's current path is, which
+# can confuse relative path lookups.
+# Let's be very explicit about it for now.
+TESTS_DIR := `pwd`/tests
 TEST_RESULTS_DIR ?= workspace/test-results
 PYTEST_ARGS ?= $(if $(SKIP_SENTRY),-m "not sentry") $(if $(TEST_STUB),,-m "not stub") # Stub tests do not work in CI
 INTEGRATION_TEST_DIR := $(TESTS_DIR)/integration

--- a/PR_TEMPLATE.md
+++ b/PR_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 Describe these changes.
 
+> **NOTE:** We can only accept PRS with all commits [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification). PRs that contain _any_ unsigned commits will not be accepted and the PR _must_ be resubmitted. If this is something you cannot provide, please disclose and a team member _may_ duplicate the PR as signed for you (depending on availablity and priority. Thank you for your understanding and cooperation.)
+
 ## Testing
 
 How should reviewers test?


### PR DESCRIPTION
While previously mentioned in the CONTRIBUTING.md document, we should emphasize and assist folk in understanding the importance of signing commits for PRs. We cannot accept unsigned code, which can lead to frustration with folk very kindly providing support for us.