### PR TITLE
fix(ci): Fix auto connect/endpoint deployments from circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,8 +415,8 @@ jobs:
             fi
               echo "export GAR_IMAGE=\"<<parameters.registry-url>>/${GCP_GAR_PROJECT_ID}/${GCP_GAR_REPO}/<<parameters.image>>\"" >> $BASH_ENV
               source $BASH_ENV
-              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:$GAR_TAG
-              docker tag <<parameters.image>>:<<parameters.build_tag>> $GAR_IMAGE:latest
+              docker tag <<parameters.image>> $GAR_IMAGE:$GAR_TAG
+              docker tag <<parameters.image>> $GAR_IMAGE:latest
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:
@@ -457,7 +457,7 @@ workflows:
 
       - build:
           name: build-autoconnect
-          image: autoconnect:build
+          image: autoconnect
           crate: autoconnect
           binary: autoconnect
           filters:
@@ -466,7 +466,7 @@ workflows:
 
       - build:
           name: build-autoendpoint
-          image: autoendpoint:build
+          image: autoendpoint
           crate: autoendpoint
           binary: autoendpoint
           filters:


### PR DESCRIPTION
When I was working on #812 I mislabeled the autoconnect/endpoint docker images in the deploy step. This should fix that. I am also running those steps on CI to make sure everything works.