### PR TITLE
fix(ci): remove all tagging of images on CI before deploy stages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
           name: Restore Docker image cache
           command: |
             docker load -i /tmp/cache/autopush-integration-tests.tar
-            docker tag autopush-integration-tests:build integration-tests
+            docker tag autopush-integration-tests integration-tests
       - run:
           name: Integration tests (Bigtable)
           command: |


### PR DESCRIPTION
This is hopefully the last change needed. This remove all tagging in the build step and leaves it to the deploy steps.