### PR TITLE
feat: rename autopush prefix metrics to autoconnect

### DIFF
--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -128,7 +128,7 @@ impl Default for Settings {
             crypto_key: format!("[{}]", Fernet::generate_key()),
             statsd_host: Some("localhost".to_owned()),
             // Matches the legacy value
-            statsd_label: "autopush".to_owned(),
+            statsd_label: "autoconnect".to_owned(),
             statsd_port: 8125,
             db_dsn: None,
             db_settings: "".to_owned(),


### PR DESCRIPTION
Closes [SYNC-4354](https://mozilla-hub.atlassian.net/browse/SYNC-4354)

Panels in autopush dashboard that have "autopush" prefix will be duplicated and updated. During migration to hosted Prometheus, these will persist as old dashboards will be decommissioned in March.

A new legacy autopush prefix tab with matching panels has been created in the autopush GCP dashboard.

[SYNC-4354]: https://mozilla-hub.atlassian.net/browse/SYNC-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ