### PR TITLE
bug: Disable "reliable_report" as default feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,9 +2569,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef2593ffb6958c941575cee70c8e257438749971869c4ae5acf6f91a168a61"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
 ]

--- a/autoconnect/Cargo.toml
+++ b/autoconnect/Cargo.toml
@@ -53,7 +53,7 @@ actix-service = "2.0"
 docopt = "1.1"
 
 [features]
-default = ["bigtable", "reliable_report"]
+default = ["bigtable"]
 bigtable = ["autopush_common/bigtable", "autoconnect_settings/bigtable"]
 emulator = ["bigtable"]
 log_vapid = []

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -68,7 +68,7 @@ tempfile = "3.2.0"
 tokio = { workspace = true, features = ["fs", "macros"] }
 
 [features]
-default = ["bigtable", "reliable_report"]
+default = ["bigtable"]
 # data store types
 bigtable = ["autopush_common/bigtable"]
 


### PR DESCRIPTION
This should not be enabled by default