### PR TITLE
bug: Make VAPID sub assertion optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,9 +2569,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "a2ef2593ffb6958c941575cee70c8e257438749971869c4ae5acf6f91a168a61"
 dependencies = [
  "adler2",
 ]

--- a/autoconnect/autoconnect-common/src/registry.rs
+++ b/autoconnect/autoconnect-common/src/registry.rs
@@ -85,7 +85,7 @@ impl ClientRegistry {
     pub async fn disconnect(&self, uaid: &Uuid, uid: &Uuid) -> Result<()> {
         trace!("ClientRegistry::disconnect");
         let mut clients = self.clients.write().await;
-        let client_exists = clients.get(uaid).map_or(false, |client| client.uid == *uid);
+        let client_exists = clients.get(uaid).is_some_and(|client| client.uid == *uid);
         if client_exists {
             clients.remove(uaid).expect("Couldn't remove client?");
             return Ok(());

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -151,7 +151,9 @@ pub async fn handle_error(
 
     if let Some(Ok(claims)) = vapid.map(|v| v.vapid.claims()) {
         let mut extras = err.extras.unwrap_or_default();
-        extras.extend([("sub".to_owned(), claims.sub.unwrap_or_default())]);
+        if let Some(sub) = claims.sub {
+            extras.extend([("sub".to_owned(), sub)]);
+        }
         err.extras = Some(extras);
     };
     err

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -253,9 +253,9 @@ pub fn retry_policy(max: usize) -> RetryPolicy {
 
 fn retryable_internal_err(status: &RpcStatus) -> bool {
     match status.code() {
-        RpcStatusCode::UNKNOWN => {
-            "error occurred when fetching oauth2 token." == status.message().to_ascii_lowercase()
-        }
+        RpcStatusCode::UNKNOWN => status
+            .message()
+            .eq_ignore_ascii_case("error occurred when fetching oauth2 token."),
         RpcStatusCode::INTERNAL => [
             "rst_stream",
             "rst stream",


### PR DESCRIPTION
Only reports `sub` if it is present and non-empty.

Closes: [SYNC-4564](https://mozilla-hub.atlassian.net/browse/SYNC-4564)


[SYNC-4564]: https://mozilla-hub.atlassian.net/browse/SYNC-4564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ