### PR TITLE
feat: Add reliability tracking of Error state.

### DIFF
--- a/autoconnect/autoconnect-web/src/routes.rs
+++ b/autoconnect/autoconnect-web/src/routes.rs
@@ -57,6 +57,13 @@ pub async fn push_route(
             .await;
         HttpResponse::Ok().finish()
     } else {
+        #[cfg(feature = "reliable_report")]
+        notif
+            .record_reliability(
+                &app_state.reliability,
+                autopush_common::reliability::ReliabilityState::Errored,
+            )
+            .await;
         HttpResponse::NotFound().body("Client not available")
     }
 }

--- a/autoendpoint/src/routers/fcm/router.rs
+++ b/autoendpoint/src/routers/fcm/router.rs
@@ -177,6 +177,10 @@ impl Router for FcmRouter {
         let platform = "fcmv1";
         trace!("Sending message to {platform}: [{:?}]", &app_id);
         if let Err(e) = client.send(message_data, routing_token, ttl).await {
+            #[cfg(feature = "reliable_report")]
+            notification
+                .record_reliability(&self.reliability, ReliabilityState::Errored)
+                .await;
             return Err(handle_error(
                 e,
                 &self.metrics,

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -36,6 +36,8 @@ pub enum ReliabilityState {
     Delivered, // Message was provided to the WebApp recipient by the UA
     #[serde(rename = "expired")]
     Expired, // Message expired naturally (e.g. TTL=0)
+    #[serde(rename = "errored")]
+    Errored, // Message errored out for some reason during delivery.
 }
 
 // TODO: Differentiate between "transmitted via webpush" and "transmitted via bridge"?
@@ -51,6 +53,7 @@ impl std::fmt::Display for ReliabilityState {
             Self::Accepted => "accepted",
             Self::Delivered => "delivered",
             Self::Expired => "expired",
+            Self::Errored => "errored",
         })
     }
 }
@@ -69,6 +72,7 @@ impl std::str::FromStr for ReliabilityState {
             "accepted_webpush" => Self::IntAccepted,
             "delivered" => Self::Delivered,
             "expired" => Self::Expired,
+            "errored" => Self::Errored,
             _ => {
                 return Err(
                     ApcErrorKind::GeneralError(format!("Unknown tracker state \"{}\"", s)).into(),


### PR DESCRIPTION
This is a debatable work in progress that records when an message goes into an ERROR state. This does **NOT** do any fine grain about _what_ error. If you want to know that, it's more on you. This is just noting that "ok, tick that this message failed for some reason" for the eventual collection report phase.

Pro: punting errored messages to an explicit state provides cleaner snapshots of final message states.
Con: this obscures where the message hit an error, meaning that it's easier to ignore potential bottlenecks.