### PR TITLE
chore: upload test artifacts to ETE pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,62 @@
 version: 2.1
 
 orbs:
+  gcp-cli: circleci/gcp-cli@3.3.0
   gcp-gcr: circleci/gcp-gcr@0.16.3
+
+executors:
+  audit-executor:
+    docker:
+      # NOTE: update version for all # RUST_VER
+      - image: rust:1.83
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  python-checks-executor:
+    docker:
+      - image: python:3.12-slim-bookworm
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  rust-checks-executor:
+    docker:
+      - image: python:3.12-slim-bookworm
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          RUST_BACKTRACE: 1
+          RUST_TEST_THREADS: 1
+  unit-test-executor:
+    docker:
+      - image: python:3.12-slim-bookworm
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          RUST_BACKTRACE: 1
+          RUST_TEST_THREADS: 1
+      - image: google/cloud-sdk:latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        command: gcloud beta emulators bigtable start --host-port=localhost:8086
+  integration-test-executor:
+    docker:
+      - image: cimg/base:2025.02
+        environment:
+          RUST_BACKTRACE: 1
+  build-executor:
+    docker:
+      - image: docker:18.03.0-ce
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  build-test-container-executor:
+    docker:
+      - image: cimg/base:2025.02
+
+
 
 commands:
   docker_login:
@@ -60,7 +115,7 @@ commands:
   build_applications:
     steps:
       - run:
-          name: Build Applicatins
+          name: Build Applications
           command: cargo build --features=emulator
   setup_bigtable:
     steps:
@@ -109,15 +164,34 @@ commands:
             pip install --upgrade pip
             pip install poetry==2.0.0
 
+  upload_to_gcs:
+    parameters:
+      source:
+        type: string
+      destination:
+        type: string
+      extension:
+        type: enum
+        enum: ["xml", "json"]
+    steps:
+      - run:
+          name: Upload << parameters.source >> << parameters.extension >> Files to GCS
+          when: always  # Ensure the step runs even if previous steps, like test runs, fail
+          command: |
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
+              FILES=$(ls -1 << parameters.source>>/*.<< parameters.extension>> )
+              if [ -z "$FILES" ]; then
+                echo "No << parameters.extension >> files found in << parameters.source >>/"
+                exit 1
+              fi
+              gsutil cp $FILES << parameters.destination >>
+            else
+              echo "Skipping artifact upload, not on 'master' branch."
+            fi
+
 jobs:
   audit:
-    docker:
-      # NOTE: update version for all # RUST_VER
-      - image: rust:1.83
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-
+    executor: audit-executor
     resource_class: large
     steps:
       - checkout
@@ -130,11 +204,7 @@ jobs:
           command: cargo audit
 
   python-checks:
-    docker:
-      - image: python:3.12-slim-bookworm
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    executor: python-checks-executor
     steps:
       - checkout
       - run:
@@ -153,13 +223,11 @@ jobs:
           command: make lint
 
   test-integration:
-    docker:
-      - image: cimg/base:2024.06
-        environment:
-          RUST_BACKTRACE: 1
+    executor: integration-test-executor
     resource_class: large
     steps:
       - checkout
+      - gcp-cli/setup
       - setup_remote_docker:
           docker_layer_caching: true
       - attach_workspace:
@@ -171,36 +239,23 @@ jobs:
             docker load -i /tmp/cache/autopush-integration-tests.tar
             docker tag autopush-integration-tests integration-tests
       - run:
-          name: Integration tests (Bigtable)
-          command: |
-            make integration-test
-            cp ~/project/tests/integration/integration_test_results.xml ~/project/workspace/test-results/integration_test_results.xml
-      - store_artifacts:
-          path: ~/project/workspace/test-results/integration_test_results.xml
-          destination: integration_test_results.xml
+          name: Integration tests
+          command: make integration-test
       - store_test_results:
           path: workspace/test-results
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/autopush-rs/junit
+          extension: xml
 
   test-unit:
-    docker:
-      - image: python:3.12-slim-bookworm
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        environment:
-          RUST_BACKTRACE: 1
-          RUST_TEST_THREADS: 1
-      - image: google/cloud-sdk:latest
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        command: gcloud beta emulators bigtable start --host-port=localhost:8086
+    executor: unit-test-executor
     resource_class: 2xlarge
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
-      # Need to download the poetry.lock files so we can use their
+      # Need to download the poetry.lock files, so we can use their
       # checksums in restore_cache.
       - restore_test_cache:
           cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
@@ -208,6 +263,7 @@ jobs:
       - setup_rust
       - setup_cbt
       - setup_bigtable
+      - gcp-cli/setup
       - run:
           name: Install cargo-nextest
           command: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
@@ -218,41 +274,36 @@ jobs:
       - run:
           name: Install cargo-llvm-cov
           command: cargo install cargo-llvm-cov
-      # Note: This build can potentially exceed the amount of memory availble to the CircleCI instance.
+      # Note: This build can potentially exceed the amount of memory available to the CircleCI instance.
       # We've seen that limiting the number of jobs helps reduce the frequency of this. (Note that
       # when doing discovery, we found that the docker image `meminfo` and `cpuinfo` often report
       # the machine level memory and CPU which are far higher than the memory allocated to the docker
       # instance. This may be causing rust to be overly greedy triggering the VM to OOM the process.)
       - run:
-          name: Report tests and coverage
+          name: Unit tests
           command: |
-            cargo llvm-cov --summary-only --json --output-path workspace/test-results/cov.json nextest --features=emulator --features=bigtable --jobs=2 --profile=ci
-      - store_artifacts:
-          path: ~/project/workspace/test-results/cov.json
-          destination: cov.json
-      - store_artifacts:
-          path: ~/project/target/nextest/ci/junit.xml
-          destination: junit.xml
+            make unit-test
       - store_test_results:
-          path: target/nextest/ci
+          path: workspace/test-results
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/autopush-rs/junit
+          extension: xml
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/autopush-rs/coverage
+          extension: json
       - save_test_cache:
           cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
 
   rust-checks:
-    docker:
-      - image: python:3.12-slim-bookworm
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        environment:
-          RUST_BACKTRACE: 1
-          RUST_TEST_THREADS: 1
+    executor: rust-checks-executor
     resource_class: large
     environment:
       BIGTABLE_EMULATOR_HOST: localhost:8086
     steps:
       - checkout
-      # Need to download the poetry.lock files so we can use their
+      # Need to download the poetry.lock files, so we can use their
       # checksums in restore_cache.
       - restore_test_cache:
           cache_key: rust-v2-cache-{{ checksum "Cargo.lock" }}
@@ -268,11 +319,7 @@ jobs:
             cargo clippy --all --all-targets --all-features -- -D warnings --deny=clippy::dbg_macro
 
   build:
-    docker:
-      - image: docker:18.03.0-ce
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    executor: build-executor
     resource_class: large
     working_directory: /dockerflow
     parameters:
@@ -317,8 +364,7 @@ jobs:
             - <<parameters.image>>.tar
 
   build-test-container:
-    docker:
-      - image: cimg/base:2024.06
+    executor: build-test-container-executor
     parameters:
       image:
         type: string
@@ -342,8 +388,7 @@ jobs:
             - << parameters.image >>.tar
 
   build-integration-test-container:
-    docker:
-      - image: cimg/base:2024.06
+    executor: build-test-container-executor
     resource_class: large
     parameters:
       image:
@@ -445,7 +490,7 @@ workflows:
             tags:
               only: /.*/
       - test-unit:
-          name: Rust Unit Tests
+          name: Unit Tests
           filters:
             tags:
               only: /.*/
@@ -454,7 +499,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-
       - build:
           name: build-autoconnect
           image: autoconnect
@@ -463,7 +507,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-
       - build:
           name: build-autoendpoint
           image: autoendpoint
@@ -502,8 +545,8 @@ workflows:
           image: autoconnect
           requires:
             - build-autoconnect
+            - Unit Tests
             - Integration Tests
-            - Rust Unit Tests
             - Rust Formatting Check
           filters:
             tags:
@@ -516,8 +559,8 @@ workflows:
           image: autoendpoint
           requires:
             - build-autoendpoint
+            - Unit Tests
             - Integration Tests
-            - Rust Unit Tests
             - Rust Formatting Check
           filters:
             tags:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,17 @@ CARGO = cargo
 # Let's be very explicit about it for now.
 TESTS_DIR := `pwd`/tests
 TEST_RESULTS_DIR ?= workspace/test-results
+
+# In order to be consumed by the ETE Test Metric Pipeline, files need to follow a strict naming
+# convention: {job_number}__{utc_epoch_datetime}__{workflow}__{test_suite}__results{-index}.xml
+WORKFLOW := build-test-deploy
+EPOCH_TIME := $(shell date +"%s")
+TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
+UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
+UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
+INTEGRATION_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml
+INTEGRATION_JUNIT_XML_LEGACY := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__legacy-results.xml
+
 # NOTE: Do not be clever.
 # The integration tests (and a few others) use pytest markers to control
 # the tests that are being run. These markers are set and defined within
@@ -39,12 +50,23 @@ upgrade:
 	$(CARGO) upgrade
 	$(CARGO) update
 
+.ONESHELL:
+unit-test:
+	cargo llvm-cov --summary-only --json --output-path $(UNIT_COVERAGE_JSON) \
+	  nextest --features=emulator --features=bigtable --jobs=2 --profile=ci
+	exit_code=$?
+	mv target/nextest/ci/junit.xml $(UNIT_JUNIT_XML)
+	exit $$exit_code
+
 build-integration-test:
 	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml build
 
+.ONESHELL:
 integration-test:
 	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml run -it --name integration-tests tests
-	docker cp integration-tests:/code/integration_test_results.xml $(INTEGRATION_TEST_DIR)
+	exit_code=$?
+	docker cp integration-tests:/code/integration__results.xml $(INTEGRATION_JUNIT_XML)
+	exit $$exit_code
 
 integration-test-clean:
 	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml down
@@ -54,14 +76,14 @@ integration-test-legacy: ## pytest markers are stored in `tests/pytest.ini`
 	$(POETRY) -V
 	$(POETRY) install --without dev,load,notification --no-root
 	$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
-		--junit-xml=$(TEST_RESULTS_DIR)/integration_test_legacy_results.xml \
+		--junit-xml=$(INTEGRATION_JUNIT_XML_LEGACY) \
 		-v $(PYTEST_ARGS)
 
 integration-test-local: ## pytest markers are stored in `tests/pytest.ini`
 	$(POETRY) -V
 	$(POETRY) install --without dev,load,notification --no-root
 	$(POETRY) run pytest $(INTEGRATION_TEST_FILE) \
-		--junit-xml=$(TEST_RESULTS_DIR)/integration_test_results.xml \
+		--junit-xml=$(INTEGRATION_JUNIT_XML) \
 		-v $(PYTEST_ARGS)
 
 notification-test:

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -108,4 +108,4 @@ WORKDIR /code
 RUN chmod +x scripts/setup_bt.sh
 
 # Pytest markers are defined in the `pyproject.toml`:`[tool.pytest.ini_options]` file.
-CMD ["sh", "-c", "./scripts/setup_bt.sh && poetry run pytest tests/integration/test_integration_all_rust.py --junit-xml=integration_test_results.xml -v"]
+CMD ["sh", "-c", "./scripts/setup_bt.sh && poetry run pytest tests/integration/test_integration_all_rust.py --junit-xml=integration__results.xml -v"]


### PR DESCRIPTION
* create a unit test Make target
* rename unit and integration test artifact files to comply with ETE pipeline specifications
* add upload test artifact step to 'master' workflow
* remove circleci artifact storage to reduce costs
* address schema validation warnings by moving image definitions from `jobs` to `executors`
    * Example:
    ![image](https://github.com/user-attachments/assets/07407e7e-1e4c-4c3d-b51b-f44a4cc9df9f)
* fix typos

Closes: #[SYNC-4574](https://mozilla-hub.atlassian.net/browse/SYNC-4574)
Relates To: https://github.com/mozilla/ecosystem-test-scripts/pull/54

[SYNC-4574]: https://mozilla-hub.atlassian.net/browse/SYNC-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ