### PR TITLE
bug: switch metrics to `/metrics` endpoint

### DIFF
--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -212,8 +212,11 @@ impl Server {
                 .service(web::resource("/__lbheartbeat__").route(web::get().to(lb_heartbeat_route)))
                 .service(web::resource("/__version__").route(web::get().to(version_route)));
             #[cfg(feature = "reliable_report")]
+            // Note: Only the endpoint returns the Prometheus "/metrics" collection report. This report contains all metrics for both
+            // connection and endpoint, inclusive. It is served here mostly for simplicity's sake (since the endpoint handles more
+            // HTTP requests than the connection server, and this will simplify metric collection and reporting.)
             let app = app.service(
-                web::resource("/export")
+                web::resource("/metrics")
                     .route(web::get().to(crate::routes::reliability::report_handler)),
             );
             app


### PR DESCRIPTION
Added some comments to help improve longevity and understanding.