### PR TITLE
chore: tag 1.74.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="1.74.1"></a>
+## 1.74.1 (2025-03-18)
+
+
+#### Bug Fixes
+
+*   switch metrics to `/metrics` endpoint (#861) ([57eedaf4](https://github.com/mozilla-services/autopush-rs/commit/57eedaf4de899b3b66157ebc772b99a84fe7cc2c))
+
+#### Chore
+
+*   tag 1.74.0 (#860) ([17bbf04a](https://github.com/mozilla-services/autopush-rs/commit/17bbf04a3d6d0e6303a85bd6796f87971e832bc2))
+
+
+
 <a name="1.74.0"></a>
 ## 1.74.0 (2025-03-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.74.0"
+version = "1.74.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.74.0"
+version = "1.74.1"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes
*   switch metrics to `/metrics` endpoint (#861) ([57eedaf4](https://github.com/mozilla-services/autopush-rs/commit/57eedaf4de899b3b66157ebc772b99a84fe7cc2c))

#### Chore
*   tag 1.74.0 (#860) ([17bbf04a](https://github.com/mozilla-services/autopush-rs/commit/17bbf04a3d6d0e6303a85bd6796f87971e832bc2))

