### PR TITLE
bug: compare tracking keys in raw form.

### DIFF
--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -61,7 +61,11 @@ impl Server {
         let bind_address = format!("{}:{}", settings.host, settings.port);
         let fernet = settings.make_fernet();
         let endpoint_url = settings.endpoint_url();
-        let reliability_filter = VapidTracker(settings.tracking_keys());
+        let reliability_filter = VapidTracker(
+            settings
+                .tracking_keys()
+                .map_err(|e| ApiErrorKind::General(format!("Configuration Error: {e}")))?,
+        );
         let db_settings = DbSettings {
             dsn: settings.db_dsn.clone(),
             db_settings: if settings.db_settings.is_empty() {

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -173,10 +173,10 @@ impl Settings {
             .collect()
     }
 
-    /// Get the list of tracking public keys
-    // TODO: this should return a Vec<[u8]> so that key formatting errors do not cause
-    // false rejections. This is not a problem now since we have access to the source
-    // public key, but that may not always be true.
+    /// Get the list of tracking public keys converted to raw, x962 format byte arrays.
+    /// (This avoids problems with formatting, padding, and other concerns. x962 precedes the
+    /// EC key pair with a `\04` byte. We'll keep that value in place for now, since the value we
+    /// are comparing against will also have the same prefix.)
     pub fn tracking_keys(&self) -> Result<Vec<Vec<u8>>, ConfigError> {
         let keys = &self.tracking_keys.replace(['"', ' '], "");
         // I'm sure there's a more clever way to do this. I don't care. I want simple.

--- a/autopush-common/src/util/mod.rs
+++ b/autopush-common/src/util/mod.rs
@@ -45,6 +45,11 @@ pub fn b64_encode_std(input: &Vec<u8>) -> String {
     base64::engine::general_purpose::STANDARD_NO_PAD.encode(input)
 }
 
+/// Try to decode the string, first as URL safe, then as STD.
+pub fn b64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    b64_decode_url(input).or_else(|_| b64_decode_std(input))
+}
+
 pub fn deserialize_u32_to_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
It is possible for the tracking key to be specified in Standard format vs. URL safe. In addition, there are other formatting concerns when comparing as encoded strings. To be more accurate, we should compare the raw public key string.

NOTE: I'm going to fix the config file for the servers. This patch is lower priority and is only to catch future misconfiguration problems.