### PR TITLE
chore: tag 1.74.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="1.74.2"></a>
+## 1.74.2 (2025-03-20)
+
+
+#### Chore
+
+*   tag 1.74.1 (#862) ([d07ee886](https://github.com/mozilla-services/autopush-rs/commit/d07ee8866a04bda426508e59d1b3fa4657b1f3f1))
+
+#### Bug Fixes
+
+*   compare tracking keys in raw form. (#863) ([49a466b8](https://github.com/mozilla-services/autopush-rs/commit/49a466b89aba59640654c84e884f6839364ad636))
+*   Autoendpoint should be less strict about config options (#859) ([8598172d](https://github.com/mozilla-services/autopush-rs/commit/8598172d84a7139f2038f9b95ec1bca0413b3c9f))
+
+
+
 <a name="1.74.1"></a>
 ## 1.74.1 (2025-03-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "a2",
  "actix-cors",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.74.1"
+version = "1.74.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.74.1"
+version = "1.74.2"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.74.1 (#862) ([d07ee886](https://github.com/mozilla-services/autopush-rs/commit/d07ee8866a04bda426508e59d1b3fa4657b1f3f1))

#### Bug Fixes

*   compare tracking keys in raw form. (#863) ([49a466b8](https://github.com/mozilla-services/autopush-rs/commit/49a466b89aba59640654c84e884f6839364ad636))
*   Autoendpoint should be less strict about config options (#859) ([8598172d](https://github.com/mozilla-services/autopush-rs/commit/8598172d84a7139f2038f9b95ec1bca0413b3c9f))

