### PR TITLE
bug: Add diagnostic for stage

### DIFF
--- a/autopush-common/src/util/mod.rs
+++ b/autopush-common/src/util/mod.rs
@@ -47,7 +47,22 @@ pub fn b64_encode_std(input: &Vec<u8>) -> String {
 
 /// Try to decode the string, first as URL safe, then as STD.
 pub fn b64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    b64_decode_url(input).or_else(|_| b64_decode_std(input))
+    // This is very verbose, but for some reason the key on stage is failing.
+    // This code should help identify the cause and should be temporary.
+    match b64_decode_url(input) {
+        Ok(v) => Ok(v),
+        Err(base64::DecodeError::InvalidByte(pos, chr)) => {
+            warn!(
+                "Decode: invalid byte {:?} at {} in {:?}",
+                chr as char, pos, input
+            );
+            b64_decode_std(input)
+        }
+        Err(e) => {
+            warn!("Decode: Unexpected error {:?} for {:?}", &e, input);
+            Err(e)
+        }
+    }
 }
 
 pub fn deserialize_u32_to_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>


### PR DESCRIPTION
This is a temporary PR that should not go to production. This PR adds several diagnostics for issues that we're seeing on the stage server which include:

1) Valid URL encoded tracking keys are being rejected by the base64
   decoder
2) Trackable requests coming from FxA do not appear to be detected

This adds some quick diagnostic code which will allow dev to determine the potential discrepencies.