### PR TITLE
chore: tag 1.75.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="1.75.1"></a>
+## 1.75.1 (2025-05-28)
+
+
+#### Bug Fixes
+
+*   Include image deploy script in CI (#974) ([1d5d0b07](https://github.com/mozilla-services/autopush-rs/commit/1d5d0b07c916138b62cea7dea7b72c959a9d6b02))
+
+#### Chore
+
+*   tag 1.75.0 (#973) ([4c77b14a](https://github.com/mozilla-services/autopush-rs/commit/4c77b14a9e145288b9ba48e09d3b2787dc7c3620))
+
+
+
 <a name="1.75.0"></a>
 ## 1.75.0 (2025-05-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.75.0"
+version = "1.75.1"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes

*   Include image deploy script in CI (#974) ([1d5d0b07](https://github.com/mozilla-services/autopush-rs/commit/1d5d0b07c916138b62cea7dea7b72c959a9d6b02))

#### Chore

*   tag 1.75.0 (#973) ([4c77b14a](https://github.com/mozilla-services/autopush-rs/commit/4c77b14a9e145288b9ba48e09d3b2787dc7c3620))