### PR TITLE
bug: Use full paths in compiled docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,7 +590,7 @@ workflows:
             tags:
               only: /.*/
 
-      # Comment out the following two sections for local CircleCI testing.
+      # Comment out the following three sections for local CircleCI testing.
       - deploy:
           name: deploy-autoconnect
           image: autoconnect

--- a/scripts/reliability/Dockerfile
+++ b/scripts/reliability/Dockerfile
@@ -19,5 +19,6 @@ ENV GOOGLE_APPLICATION_CREDENTIALS = /app/keys/service-account-key.json
 ENV AUTOTRACK_REPORT_BUCKET_NAME = "autopush_reliability"
 ENV AUTOTRACK_OUTPUT="md json"
 RUN pip install .
-CMD ["python3", "reliability_report.py"]
+# Specifying the full paths here to avoid an issue with executables not found.
+CMD ["/usr/local/bin/python3", "/app/reliability_report.py"]
 


### PR DESCRIPTION
Deployment is reporting that it can't find the executable, so specifying the full paths to all elements.