### PR TITLE
bug: Do not set the `GOOGLE_APPLICATION_CREDENTIALS in the reliability docker image

### DIFF
--- a/scripts/reliability/Dockerfile
+++ b/scripts/reliability/Dockerfile
@@ -7,13 +7,8 @@ WORKDIR /app
 # should this be templated? Some have a path here I presume gets loaded via a Docker build.
 # (e.g. fxa uses `/app/keys/keyfile_name.json`)
 # loaded va the webservices-infra cronjob.yaml:: containers::volumeMounts
-VOLUME [ "keys" "/app/keys" ]
-ENV GOOGLE_APPLICATION_CREDENTIALS = /app/keys/service-account-key.json
-
-# these will need to be templated in the calling k8s config.
-# ENV AUTOEND__DB_SETTINGS = '{"table_name":"projects/test/instance/test/tables/autopush"}'
-# ENV AUTOEND__DB_DSN = "grpc:://localhost:8086"
-# ENV AUTOEND__RELIABILITY_DSN = "redis:://localhost"
+# VOLUME [ "keys" "/app/keys" ]
+# ENV GOOGLE_APPLICATION_CREDENTIALS = /app/keys/service-account-key.json
 
 # Generate the report
 ENV AUTOTRACK_REPORT_BUCKET_NAME = "autopush_reliability"


### PR DESCRIPTION
I'm getting a credential error with this, because I believe that the credentials are not being found.
Going to remove this to see if there's a default set that is passed to the docker image.