### PR TITLE
bug: Fix the report args.

### DIFF
--- a/scripts/reliability/reliability_report.py
+++ b/scripts/reliability/reliability_report.py
@@ -437,9 +437,9 @@ def config(env_args: os._Environ = os.environ) -> argparse.Namespace:
         "-s",
         help="Database settings",
         default=env_args.get(
-            "AUTOEND__DB_SETTINGS",
+            "AUTOCONNECT__DB_SETTINGS",
             env_args.get(
-                "AUTOCONNECT__DB_SETTINGS",
+                "AUTOEND__DB_SETTINGS",
                 '{"message_family":"message","router_family":"router", "table_name":"projects/test/instances/test/tables/autopush"}',
             ),
         ),


### PR DESCRIPTION
Due to a few last minute recommendations, the args fell out of sync.

Taking the opportunity to fix up some of the arguments to make better lexicographic sense. 