### PR TITLE
bug: address Python3.12 issues

### DIFF
--- a/scripts/reliability/reliability_report.py
+++ b/scripts/reliability/reliability_report.py
@@ -30,6 +30,7 @@ from google.cloud.bigtable.data import (
     RowRange,
     SetCell,
 )
+from google.api_core import exceptions as google_exceptions
 from google.cloud.bigtable.data.row_filters import FamilyNameRegexFilter
 from google.cloud import storage
 
@@ -233,8 +234,9 @@ class Redis:
 
         # Fetch the candidates to purge.
         mutations = list()
+        # python redis escapes the `-1` value. Use a literal start value.
         purged = cast(
-            list[bytes], await self.redis.zrange(expiry, -1, int(start), byscore=True)
+            list[bytes], await self.redis.zrange(expiry, 0, int(start), byscore=True)
         )
         # Fix up the counts
         async with self.redis.pipeline() as pipeline:
@@ -278,7 +280,7 @@ class Redis:
         }
         if len(purged):
             self.log.info(
-                f"🪦 Trimmed {result.get("trimmed")} in {result.get("time")}ms"
+                f"🪦 Trimmed {result.get('trimmed')} in {result.get('time')}ms"
             )
         return result
 
@@ -296,7 +298,7 @@ class Redis:
             # get all the unresolved terminals (since we remove them after we process them.)
             terminals = await self.redis.zrange(
                 self.settings.terminal_table,
-                -1,
+                0,
                 int(start_of_day.timestamp()),
                 withscores=True,
             )
@@ -361,7 +363,9 @@ class Redis:
         vals = await self.redis.hmget(self.settings.count_table, terminal_states)
         # redis returns a str:bytes, so can't just call dict(vals)
         term_counts = {
-            k: v for (k, v) in dict(zip(terminal_states, vals)).items() if v is not None
+            k: int(v)
+            for (k, v) in dict(zip(terminal_states, vals)).items()
+            if v is not None
         }
         if term_counts:
             self.log.info(
@@ -371,9 +375,10 @@ class Redis:
                 days=self.settings.terminal_max_retention_days
             )
             # Write the values to storage.
+            # Note: Python's redis client swaps `value` and `score`
             await self.redis.zadd(
                 self.settings.terminal_table,
-                {str(int(expiry.timestamp())): json.dumps(term_counts)},
+                {json.dumps(term_counts): expiry.timestamp()},
             )
         else:
             self.log.info(f"🧹 No matching terminal states found?")
@@ -579,23 +584,36 @@ async def amain(log: logging.Logger, settings: argparse.Namespace):
         await counter.terminal_snapshot()
         # if we have a bucket to write to, write the reports to the bucket.
         if settings.report_bucket_name:
-            client = storage.Client()
-            bucket = client.lookup_bucket(bucket_name=settings.report_bucket_name)
-            if bucket:
-                report_name = datetime.now().strftime("%Y-%m-%d")
-                # technically, `bucket.list_blobs` can return `.num_results` but since this is
-                # an iterator for the actual call and the call is only performed on demand, that
-                # would return 0.
-                reports = [blob for blob in bucket.list_blobs(prefix=report_name)]
-                if len(reports) == 0:
-                    if await counter.get_lock():
-                        await write_report(log, settings, bigtable, bucket, report_name)
-                        await clean_bucket(log, settings, bucket)
-                        await counter.release_lock()
+            try:
+                client = storage.Client()
+                try:
+                    bucket = client.lookup_bucket(
+                        bucket_name=settings.report_bucket_name
+                    )
+                except google_exceptions.NotFound:
+                    try:
+                        bucket = client.create_bucket(settings.report_bucket_name)
+                    except google_exceptions.Conflict:
+                        pass
+                if bucket:
+                    report_name = datetime.now().strftime("%Y-%m-%d")
+                    # technically, `bucket.list_blobs` can return `.num_results` but since this is
+                    # an iterator for the actual call and the call is only performed on demand, that
+                    # would return 0.
+                    reports = [blob for blob in bucket.list_blobs(prefix=report_name)]
+                    if len(reports) == 0:
+                        if await counter.get_lock():
+                            await write_report(
+                                log, settings, bigtable, bucket, report_name
+                            )
+                            await clean_bucket(log, settings, bucket)
+                            await counter.release_lock()
+                        else:
+                            log.debug("Could not get lock, skipping...")
                     else:
-                        log.debug("Could not get lock, skipping...")
-                else:
-                    log.debug("Reports already generated, skipping...")
+                        log.debug("Reports already generated, skipping...")
+            except google_exceptions.Forbidden as e:
+                log.error(f"Could not access bucket {settings.report_bucket_name}: {e}")
     # Maybe we're just interested in getting a report?
     if not settings.report_bucket_name:
         for style in settings.output:


### PR DESCRIPTION
* pyredis does not understand special `-1` values, use literals
* add handlers for bucket create/access
* fix zrange score/value switch

note: got the bastion server access running properly, so able to test this against stage rather than locally, thus some of the fixes.

The bastion doesn't have bucket access, so there may still need to be some fixes for the report writer.