### PR TITLE
feat: Improve endpoint reliability check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "a2",
  "actix-cors",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.75.2"
+version = "1.75.6"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "a2",
  "actix-cors",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.75.6"
+version = "1.75.3"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -218,7 +218,7 @@ impl PushReliability {
                     .inspect_err(|e| {
                         warn!("🔍 Redis internal storage error: {:?}", e);
                     })
-                    .map_err(|e| ApcErrorKind::RedisError(e))?;
+                    .map_err(ApcErrorKind::RedisError)?;
                 Ok(Some(redis::Value::Okay))
             },
         )

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -147,15 +147,20 @@ impl PushReliability {
             );
             match pool.get().await {
                 Ok(mut conn) => {
-                    let _ = self.internal_record(&mut conn, old, new, expr, id).await;
+                    let _ = self
+                        .internal_record(&mut conn, old, new, expr, id)
+                        .await
+                        .inspect_err(|e| {
+                            warn!("🔍⚠️ Unable to record reliability state: {:?}", e);
+                        });
                 }
-                Err(e) => warn!("🔍⚠️ Unable to record reliability state, {:?}", e),
+                Err(e) => warn!("🔍⚠️ Unable to get reliability state pool, {:?}", e),
             };
         };
         // Errors are not fatal, and should not impact message flow, but
         // we should record them somewhere.
         let _ = self.db.log_report(id, new).await.inspect_err(|e| {
-            warn!("🔍⚠️ Unable to record reliability state: {:?}", e);
+            warn!("🔍⚠️ Unable to record reliability state log: {:?}", e);
         });
         Some(new)
     }

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -175,7 +175,7 @@ impl PushReliability {
                 .unwrap_or_else(|| "None".to_owned()),
             new
         );
-        let _ = crate::redis_util::transaction(
+        crate::redis_util::transaction(
             conn,
             &[COUNTS, EXPIRY],
             self.retries,

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -217,8 +217,7 @@ impl PushReliability {
                     .await
                     .inspect_err(|e| {
                         warn!("🔍 Redis internal storage error: {:?}", e);
-                    })
-                    .map_err(ApcErrorKind::RedisError)?;
+                    })?;
                 Ok(Some(redis::Value::Okay))
             },
         )

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -213,11 +213,9 @@ impl PushReliability {
                 // retries if we return Ok(None), so we run the exec and return
                 // a nonce `Some` value.
                 // The turbo-fish is a fallback for edition 2024
-                pipe.query_async::<()>(conn)
-                    .await
-                    .inspect_err(|e| {
-                        warn!("🔍 Redis internal storage error: {:?}", e);
-                    })?;
+                pipe.query_async::<()>(conn).await.inspect_err(|e| {
+                    warn!("🔍 Redis internal storage error: {:?}", e);
+                })?;
                 Ok(Some(redis::Value::Okay))
             },
         )

--- a/scripts/reliability/reliability_report.py
+++ b/scripts/reliability/reliability_report.py
@@ -386,7 +386,7 @@ class Redis:
 
     async def get_lock(self) -> bool:
         """Use RedLock locking"""
-        lock_name = datetime.now().isoformat()
+        lock_name = f"LOCK_{datetime.now().isoformat()}"
         # set the default hold time fairly short, we'll extend the lock later if we succeed.
         self.lock = self.redis.lock(lock_name, timeout=self.settings.lock_acquire_time)
         # Fail the lock check quickly.


### PR DESCRIPTION
* Add some hinting to `health` to report vapid key signatures (to ensure that key values are propagating)
* Add db check to autoendpoint `health` check
* Try fix for off counts in `internal_record`
   * wrap action in a transaction (with retries), 
   * Add missing old state removal (not sure when/how that got dropped)
   * Add unit test for `internal_record`
* Add `LOCK_` prefix for redis lock record (because otherwise it's confusing)