### PR TITLE
Release/1.75.7

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# `clog` uses '*  ' as the bullet prefix. Changing this would cause the bulk of the file to be reformatted.
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+<a name="1.75.7"></a>
+## 1.75.7 (2025-06-17)
+
+#### Chore
+
+*   tag 1.75.3 (#982)
+
+#### Bug Fixes
+
+*   bug: address Python3.12 issues (#989) ([4e1e7080](https://github.com/mozilla-services/autopush-rs/commit/4e1e7080f8790c790e2486ce61f09452474a1c15))
+*   bug: Fix the report args. (#987) ([393207bf](https://github.com/mozilla-services/autopush-rs/commit/393207bfc0f8cbb5c6bac564b1f614ea607c7d0d))
+*   bug: Do not set the `GOOGLE_APPLICATION_CREDENTIALS in the reliability docker image (#984) ([20cf810a](https://github.com/mozilla-services/autopush-rs/commit/20cf810a571aac84ca08d983b9e5ecd32cddae7b))
+
+#### Features
+
+*   feat: Improve endpoint reliability check (#991) ([e658a2f8524a0f4c075520525759790c04f42a6a](https://github.com/mozilla-services/autopush-rs/commit/e658a2f8524a0f4c075520525759790c04f42a6a))
+
+**note: 1.75.4 - 1.75.5 were not released. This version contains the cumulative fixes.**
+
+
+<a name="1.75.7"></a>
+## 1.75.7 (2025-06-17)
+
+#### Chore
+
+*   tag 1.75.3 (#982)
+
+#### Bug Fixes
+
+*   bug: address Python3.12 issues (#989) ([4e1e7080](https://github.com/mozilla-services/autopush-rs/commit/4e1e7080f8790c790e2486ce61f09452474a1c15))
+*   bug: Fix the report args. (#987) ([393207bf](https://github.com/mozilla-services/autopush-rs/commit/393207bfc0f8cbb5c6bac564b1f614ea607c7d0d))
+*   bug: Do not set the `GOOGLE_APPLICATION_CREDENTIALS in the reliability docker image (#984) ([20cf810a](https://github.com/mozilla-services/autopush-rs/commit/20cf810a571aac84ca08d983b9e5ecd32cddae7b))
+*   bug
+
+#### Features
+
+*   feat: Improve endpoint reliability check (#991) ([e658a2f8](https://github.com/mozilla-services/autopush-rs/commit/e658a2f8524a0f4c075520525759790c04f42a6a))
+
+**note: 1.75.4 - 1.75.6 were not released. This version contains the cumulative fixes.**
+
+
 <a name="1.75.3"></a>
 ## 1.75.3 (2025-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,27 +18,6 @@
 **note: 1.75.4 - 1.75.5 were not released. This version contains the cumulative fixes.**
 
 
-<a name="1.75.7"></a>
-## 1.75.7 (2025-06-17)
-
-#### Chore
-
-*   tag 1.75.3 (#982)
-
-#### Bug Fixes
-
-*   bug: address Python3.12 issues (#989) ([4e1e7080](https://github.com/mozilla-services/autopush-rs/commit/4e1e7080f8790c790e2486ce61f09452474a1c15))
-*   bug: Fix the report args. (#987) ([393207bf](https://github.com/mozilla-services/autopush-rs/commit/393207bfc0f8cbb5c6bac564b1f614ea607c7d0d))
-*   bug: Do not set the `GOOGLE_APPLICATION_CREDENTIALS in the reliability docker image (#984) ([20cf810a](https://github.com/mozilla-services/autopush-rs/commit/20cf810a571aac84ca08d983b9e5ecd32cddae7b))
-*   bug
-
-#### Features
-
-*   feat: Improve endpoint reliability check (#991) ([e658a2f8](https://github.com/mozilla-services/autopush-rs/commit/e658a2f8524a0f4c075520525759790c04f42a6a))
-
-**note: 1.75.4 - 1.75.6 were not released. This version contains the cumulative fixes.**
-
-
 <a name="1.75.3"></a>
 ## 1.75.3 (2025-06-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autoconnect"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "a2",
  "actix-cors",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.75.3"
+version = "1.75.7"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.75.3"
+version = "1.75.7"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.75.3 (#982)

#### Bug Fixes

*   bug: address Python3.12 issues (#989) ([4e1e7080](https://github.com/mozilla-services/autopush-rs/commit/4e1e7080f8790c790e2486ce61f09452474a1c15))
*   bug: Fix the report args. (#987) ([393207bf](https://github.com/mozilla-services/autopush-rs/commit/393207bfc0f8cbb5c6bac564b1f614ea607c7d0d))
*   bug: Do not set the `GOOGLE_APPLICATION_CREDENTIALS in the reliability docker image (#984) ([20cf810a](https://github.com/mozilla-services/autopush-rs/commit/20cf810a571aac84ca08d983b9e5ecd32cddae7b))

#### Features

*   feat: Improve endpoint reliability check (#991) ([e658a2f8524a0f4c075520525759790c04f42a6a](https://github.com/mozilla-services/autopush-rs/commit/e658a2f8524a0f4c075520525759790c04f42a6a))

**note: 1.75.4 - 1.75.5 were not released. This version contains the cumulative fixes.**