### PR TITLE
chore: tag 1.75.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="1.75.10"></a>
+## 1.75.10 (2025-06-26)
+
+
+#### Bug Fixes
+
+*   Fix order of expiry key by using a struct. (#999) ([7dd4c44e](https://github.com/mozilla-services/autopush-rs/commit/7dd4c44efb1c7d1ed117c8fd5073032a71e9351c))
+
+#### Chore
+
+*   tag 1.75.9 (#998) ([dc141ddc](https://github.com/mozilla-services/autopush-rs/commit/dc141ddc3bacfefe00b1d6777582eeed22601e19))
+
+
+
 <a name="1.75.9"></a>
 ## 1.75.9 (2025-06-25)
 


### PR DESCRIPTION


#### Bug Fixes

*   Fix order of expiry key by using a struct. (#999) ([7dd4c44e](https://github.com/mozilla-services/autopush-rs/commit/7dd4c44efb1c7d1ed117c8fd5073032a71e9351c))

#### Chore

*   tag 1.75.9 (#998) ([dc141ddc](https://github.com/mozilla-services/autopush-rs/commit/dc141ddc3bacfefe00b1d6777582eeed22601e19))

