### PR TITLE
chore: Clippy updates for 1.88.0

### DIFF
--- a/autoconnect/autoconnect-settings/src/app_state.rs
+++ b/autoconnect/autoconnect-settings/src/app_state.rs
@@ -99,13 +99,13 @@ impl AppState {
                 settings.reliability_retry_count,
             )
             .map_err(|e| {
-                ConfigError::Message(format!("Could not start Reliability connection: {:?}", e))
+                ConfigError::Message(format!("Could not start Reliability connection: {e:?}"))
             })?,
         );
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(1))
             .build()
-            .unwrap_or_else(|e| panic!("Error while building reqwest::Client: {}", e));
+            .unwrap_or_else(|e| panic!("Error while building reqwest::Client: {e}"));
         let broadcaster = Arc::new(RwLock::new(BroadcastChangeTracker::new(Vec::new())));
 
         let router_url = settings.router_url();

--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -203,7 +203,7 @@ impl Settings {
         if let Some(ref hostname) = self.hostname {
             if self.resolve_hostname {
                 resolve_ip(hostname)
-                    .unwrap_or_else(|_| panic!("Failed to resolve provided hostname: {}", hostname))
+                    .unwrap_or_else(|_| panic!("Failed to resolve provided hostname: {hostname}"))
             } else {
                 hostname.clone()
             }
@@ -218,8 +218,7 @@ impl Settings {
         let non_zero = |val: Duration, name| {
             if val.is_zero() {
                 return Err(ConfigError::Message(format!(
-                    "Invalid {}_{}: cannot be 0",
-                    ENV_PREFIX, name
+                    "Invalid {ENV_PREFIX}_{name}: cannot be 0"
                 )));
             }
             Ok(())
@@ -308,9 +307,9 @@ mod tests {
     fn test_default_settings() {
         // Test that the Config works the way we expect it to.
         use std::env;
-        let port = format!("{}__PORT", ENV_PREFIX).to_uppercase();
-        let msg_limit = format!("{}__MSG_LIMIT", ENV_PREFIX).to_uppercase();
-        let fernet = format!("{}__CRYPTO_KEY", ENV_PREFIX).to_uppercase();
+        let port = format!("{ENV_PREFIX}__PORT").to_uppercase();
+        let msg_limit = format!("{ENV_PREFIX}__MSG_LIMIT").to_uppercase();
+        let fernet = format!("{ENV_PREFIX}__CRYPTO_KEY").to_uppercase();
 
         let v1 = env::var(&port);
         let v2 = env::var(&msg_limit);

--- a/autoconnect/autoconnect-web/src/test.rs
+++ b/autoconnect/autoconnect-web/src/test.rs
@@ -31,7 +31,7 @@ async fn json_msg(
 ) -> serde_json::Value {
     let item = framed.next().await.unwrap().unwrap();
     let ws::Frame::Text(bytes) = item else {
-        panic!("Expected Text not: {:#?}", item);
+        panic!("Expected Text not: {item:#?}");
     };
     serde_json::from_slice(&bytes).unwrap()
 }
@@ -87,7 +87,7 @@ pub async fn unsupported_websocket_message() {
 
     let item = framed.next().await.unwrap().unwrap();
     let ws::Frame::Close(Some(close_reason)) = item else {
-        panic!("Expected Close(Some(..)) not {:#?}", item);
+        panic!("Expected Close(Some(..)) not {item:#?}");
     };
     assert_eq!(close_reason.code, actix_http::ws::CloseCode::Unsupported);
     assert!(framed.next().await.is_none());
@@ -110,7 +110,7 @@ pub async fn invalid_webpush_message() {
 
     let item = framed.next().await.unwrap().unwrap();
     let ws::Frame::Close(Some(close_reason)) = item else {
-        panic!("Expected Close(Some(..)) not {:#?}", item);
+        panic!("Expected Close(Some(..)) not {item:#?}");
     };
     assert_eq!(close_reason.code, actix_http::ws::CloseCode::Error);
     assert!(framed.next().await.is_none());
@@ -133,7 +133,7 @@ pub async fn malformed_webpush_message() {
 
     let item = framed.next().await.unwrap().unwrap();
     let ws::Frame::Close(Some(close_reason)) = item else {
-        panic!("Expected Close(Some(..)) not {:#?}", item);
+        panic!("Expected Close(Some(..)) not {item:#?}");
     };
     assert_eq!(close_reason.code, actix_http::ws::CloseCode::Error);
     assert_eq!(close_reason.description.unwrap(), "Json");
@@ -212,7 +212,7 @@ pub async fn broadcast_after_ping() {
     tokio::time::sleep(Duration::from_secs_f32(0.2)).await;
     let item = framed.next().await.unwrap().unwrap();
     let ws::Frame::Ping(payload) = item else {
-        panic!("Expected Ping not: {:#?}", item);
+        panic!("Expected Ping not: {item:#?}");
     };
 
     broadcaster

--- a/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
+++ b/autoconnect/autoconnect-ws/autoconnect-ws-sm/src/unidentified.rs
@@ -257,7 +257,7 @@ mod tests {
             .unwrap();
         assert!(matches!(err.kind, SMErrorKind::InvalidMessage(_)));
         // Verify error message contains expected message type
-        assert!(format!("{}", err).contains(MessageType::Hello.as_ref()));
+        assert!(format!("{err}").contains(MessageType::Hello.as_ref()));
 
         // Test with Register message
         let client = uclient(Default::default());
@@ -271,7 +271,7 @@ mod tests {
             .unwrap();
         assert!(matches!(err.kind, SMErrorKind::InvalidMessage(_)));
         // Verify error message contains expected message type
-        assert!(format!("{}", err).contains(MessageType::Hello.as_ref()));
+        assert!(format!("{err}").contains(MessageType::Hello.as_ref()));
     }
 
     #[tokio::test]

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -349,7 +349,7 @@ fn validate_vapid_jwt(
                 return Err(VapidError::InvalidAudience.into());
             }
             jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(e) => {
-                return Err(VapidError::InvalidVapid(format!("Missing required {}", e)).into());
+                return Err(VapidError::InvalidVapid(format!("Missing required {e}")).into());
             }
             _ => {
                 // Attempt to match up the majority of ErrorKind variants.

--- a/autoendpoint/src/routers/common.rs
+++ b/autoendpoint/src/routers/common.rs
@@ -131,13 +131,13 @@ pub async fn handle_error(
             metrics,
             platform,
             app_id,
-            &format!("upstream_{}", status),
+            &format!("upstream_{status}"),
             error.status(),
             error.errno(),
         ),
 
         _ => {
-            warn!("Unknown error while sending bridge request: {}", error);
+            warn!("Unknown error while sending bridge request: {error}");
             incr_error_metric(
                 metrics,
                 platform,

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -116,7 +116,7 @@ impl FcmClient {
         let response = self
             .http_client
             .post(self.endpoint.clone())
-            .header("Authorization", format!("Bearer {}", token))
+            .header("Authorization", format!("Bearer {token}"))
             .header("Content-Type", "application/json")
             .json(&message)
             .timeout(self.timeout)

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -101,7 +101,7 @@ impl Server {
                 settings.reliability_retry_count,
             )
             .map_err(|e| {
-                ApiErrorKind::General(format!("Could not initialize Reliability Report: {:?}", e))
+                ApiErrorKind::General(format!("Could not initialize Reliability Report: {e:?}"))
             })?,
         );
         let http = reqwest::ClientBuilder::new()

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -189,7 +189,7 @@ impl Settings {
         for v in Self::read_list_from_str(keys, "Invalid AUTOEND_TRACKING_KEYS") {
             result.push(
                 util::b64_decode(v)
-                    .map_err(|e| ConfigError::Message(format!("Invalid tracking key: {:?}", e)))?,
+                    .map_err(|e| ConfigError::Message(format!("Invalid tracking key: {e:?}")))?,
             );
         }
         trace!("🔍 tracking_keys: {result:?}");

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -308,7 +308,7 @@ pub fn retryable_grpcio_err(metrics: &Arc<StatsdClient>) -> impl Fn(&grpcio::Err
                     metric(
                         metrics,
                         "CallFailure",
-                        Some(&format!("{:?}", grpc_call_status)),
+                        Some(&format!("{grpc_call_status:?}")),
                     );
                 }
                 retry
@@ -773,10 +773,7 @@ impl BigTableClientImpl {
                         "reliable_state",
                     )?)
                     .map_err(|e| {
-                        DbError::DeserializeString(format!(
-                            "Could not parse reliable_state {:?}",
-                            e
-                        ))
+                        DbError::DeserializeString(format!("Could not parse reliable_state {e:?}"))
                     })?,
                 );
             }

--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -155,7 +155,7 @@ impl TryFrom<&str> for BigTableDbSettings {
     type Error = DbError;
     fn try_from(setting_string: &str) -> Result<Self, Self::Error> {
         let mut me: Self = serde_json::from_str(setting_string)
-            .map_err(|e| DbError::General(format!("Could not parse DdbSettings: {:?}", e)))?;
+            .map_err(|e| DbError::General(format!("Could not parse DdbSettings: {e:?}")))?;
 
         if me.table_name.starts_with('/') {
             return Err(DbError::ConnectionError(

--- a/autopush-common/src/db/bigtable/pool.rs
+++ b/autopush-common/src/db/bigtable/pool.rs
@@ -65,24 +65,21 @@ impl BigTablePool {
         let bt_settings = BigTableDbSettings::try_from(settings.db_settings.as_str())?;
         debug!("🉑 DSN: {}", &endpoint);
         // Url::parsed() doesn't know how to handle `grpc:` schema, so it returns "null".
-        let parsed = url::Url::parse(endpoint).map_err(|e| {
-            DbError::ConnectionError(format!("Invalid DSN: {:?} : {:?}", endpoint, e))
-        })?;
+        let parsed = url::Url::parse(endpoint)
+            .map_err(|e| DbError::ConnectionError(format!("Invalid DSN: {endpoint:?} : {e:?}")))?;
         let connection = format!(
             "{}:{}",
             parsed
                 .host_str()
                 .ok_or_else(|| DbError::ConnectionError(format!(
-                    "Invalid DSN: Unparsable host {:?}",
-                    endpoint
+                    "Invalid DSN: Unparsable host {endpoint:?}"
                 )))?,
             parsed.port().unwrap_or(DEFAULT_GRPC_PORT)
         );
         // Make sure the path is empty.
         if !parsed.path().is_empty() {
             return Err(DbError::ConnectionError(format!(
-                "Invalid DSN: Table paths belong in AUTO*_DB_SETTINGS `tab: {:?}",
-                endpoint
+                "Invalid DSN: Table paths belong in AUTO*_DB_SETTINGS `tab: {endpoint:?}`"
             )));
         }
         debug!("🉑 connection string {}", &connection);

--- a/autopush-common/src/db/models.rs
+++ b/autopush-common/src/db/models.rs
@@ -67,8 +67,8 @@ impl RangeKey {
     pub(crate) fn parse_chidmessageid(key: &str) -> Result<RangeKey> {
         lazy_static! {
             static ref RE: RegexSet = RegexSet::new([
-                format!("^{}:\\S+:\\S+$", TOPIC_NOTIFICATION_PREFIX).as_str(),
-                format!("^{}:\\d+:\\S+$", STANDARD_NOTIFICATION_PREFIX).as_str(),
+                format!("^{TOPIC_NOTIFICATION_PREFIX}:\\S+:\\S+$").as_str(),
+                format!("^{STANDARD_NOTIFICATION_PREFIX}:\\d+:\\S+$").as_str(),
                 "^\\S{3,}:\\S+$"
             ])
             .unwrap();

--- a/autopush-common/src/endpoint.rs
+++ b/autopush-common/src/endpoint.rs
@@ -34,13 +34,13 @@ pub fn make_endpoint(
         base.extend(key_digest.iter());
         let encrypted = fernet.encrypt(&base).trim_matches('=').to_string();
         let final_url = root.join(&format!("v2/{encrypted}")).map_err(|e| {
-            ApcErrorKind::GeneralError(format!("Encrypted endpoint data is not URL-safe {:?}", e))
+            ApcErrorKind::GeneralError(format!("Encrypted endpoint data is not URL-safe {e:?}"))
         })?;
         Ok(final_url.to_string())
     } else {
         let encrypted = fernet.encrypt(&base).trim_matches('=').to_string();
         let final_url = root.join(&format!("v1/{encrypted}")).map_err(|e| {
-            ApcErrorKind::GeneralError(format!("Encrypted endpoint data is not URL-safe {:?}", e))
+            ApcErrorKind::GeneralError(format!("Encrypted endpoint data is not URL-safe {e:?}"))
         })?;
         Ok(final_url.to_string())
     }

--- a/autopush-common/src/logging.rs
+++ b/autopush-common/src/logging.rs
@@ -11,8 +11,8 @@ pub fn init_logging(json: bool, name: &str, version: &str) -> Result<()> {
         let hostname = gethostname().to_string_lossy().to_string();
 
         let drain = MozLogJson::new(io::stdout())
-            .logger_name(format!("{}-{}", name, version))
-            .msg_type(format!("{}:log", name))
+            .logger_name(format!("{name}-{version}"))
+            .msg_type(format!("{name}:log"))
             .hostname(hostname)
             .build()
             .fuse();

--- a/autopush-common/src/middleware/sentry.rs
+++ b/autopush-common/src/middleware/sentry.rs
@@ -145,7 +145,7 @@ where
         return;
     };
     debug!("Sending error to metrics: {:?}", err);
-    let label = format!("{}.{}", label_prefix, label);
+    let label = format!("{label_prefix}.{label}");
     let mut builder = metrics.incr_with_tags(&label);
     let tags = err.tags();
     for (key, val) in &tags {

--- a/autopush-common/src/reliability.rs
+++ b/autopush-common/src/reliability.rs
@@ -139,13 +139,13 @@ impl PushReliability {
             config
                 .builder()
                 .map_err(|e| {
-                    ApcErrorKind::GeneralError(format!("Could not config reliability pool {:?}", e))
+                    ApcErrorKind::GeneralError(format!("Could not config reliability pool {e:?}"))
                 })?
                 .create_timeout(Some(CONNECTION_EXPIRATION.to_std().unwrap()))
                 .runtime(deadpool::Runtime::Tokio1)
                 .build()
                 .map_err(|e| {
-                    ApcErrorKind::GeneralError(format!("Could not build reliability pool {:?}", e))
+                    ApcErrorKind::GeneralError(format!("Could not build reliability pool {e:?}"))
                 })?,
         );
 
@@ -339,7 +339,7 @@ impl PushReliability {
         if let Some(pool) = &self.pool {
             if let Ok(mut conn) = pool.get().await {
                 return Ok(conn.hgetall(COUNTS).await.map_err(|e| {
-                    ApcErrorKind::GeneralError(format!("Could not read report {:?}", e))
+                    ApcErrorKind::GeneralError(format!("Could not read report {e:?}"))
                 })?);
             }
         }
@@ -350,13 +350,12 @@ impl PushReliability {
         if let Some(pool) = &self.pool {
             let mut conn = pool.get().await.map_err(|e| {
                 ApcErrorKind::GeneralError(format!(
-                    "Could not connect to reliability datastore: {:?}",
-                    e,
+                    "Could not connect to reliability datastore: {e:?}"
                 ))
             })?;
             // Add a type here, even though we're tossing the value, in order to prevent the `FromRedisValue` warning.
             conn.ping::<()>().await.map_err(|e| {
-                ApcErrorKind::GeneralError(format!("Could not ping reliability datastore: {:?}", e))
+                ApcErrorKind::GeneralError(format!("Could not ping reliability datastore: {e:?}"))
             })?;
             Ok("OK")
         } else {
@@ -418,7 +417,7 @@ pub fn gen_report(values: HashMap<String, i32>) -> Result<String> {
     // Return the formatted string that Prometheus will eventually read.
     let mut encoded = String::new();
     encode(&mut encoded, &registry).map_err(|e| {
-        ApcErrorKind::GeneralError(format!("Could not generate Reliability report {:?}", e))
+        ApcErrorKind::GeneralError(format!("Could not generate Reliability report {e:?}"))
     })?;
     Ok(encoded)
 }

--- a/autopush-common/src/sentry.rs
+++ b/autopush-common/src/sentry.rs
@@ -80,7 +80,7 @@ fn exception_from_error<E>(err: &E) -> sentry::protocol::Exception
 where
     E: Error + ?Sized,
 {
-    let dbg = format!("{:?}", err);
+    let dbg = format!("{err:?}");
     sentry::protocol::Exception {
         ty: sentry::parse_type_from_debug(&dbg).to_owned(),
         value: Some(err.to_string()),


### PR DESCRIPTION
clippy now complains about non-inline variables in `format!()` macros