### PR TITLE
bug: Use new state if error in record_reliability

### DIFF
--- a/autopush-common/src/db/routing.rs
+++ b/autopush-common/src/db/routing.rs
@@ -1,3 +1,5 @@
+// Rust 1.89.0 flags `StorageType` as unused even with `bigtable` set as a default feature.
+#[allow(dead_code)]
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) enum StorageType {
     BigTable,

--- a/autopush-common/src/metrics.rs
+++ b/autopush-common/src/metrics.rs
@@ -16,7 +16,7 @@ pub trait StatsdClientExt {
     fn incr_raw(&self, metric: &str) -> MetricResult<Counter>;
 
     /// Start a counter with tags using a MetricName enum
-    fn incr_with_tags(&self, metric: MetricName) -> MetricBuilder<Counter>;
+    fn incr_with_tags(&self, metric: MetricName) -> MetricBuilder<'_, '_, Counter>;
 }
 
 impl StatsdClientExt for StatsdClient {
@@ -29,7 +29,7 @@ impl StatsdClientExt for StatsdClient {
         self.count(metric, 1)
     }
 
-    fn incr_with_tags(&self, metric: MetricName) -> MetricBuilder<Counter> {
+    fn incr_with_tags(&self, metric: MetricName) -> MetricBuilder<'_, '_, Counter> {
         let metric_tag: &'static str = metric.into();
         self.count_with_tags(metric_tag, 1)
     }

--- a/autopush-common/src/notification.rs
+++ b/autopush-common/src/notification.rs
@@ -94,7 +94,7 @@ impl Notification {
             .inspect_err(|e| {
                 warn!("🔍⚠️ Unable to record reliability state log: {:?}", e);
             })
-            .unwrap_or_default();
+            .unwrap_or(Some(state));
     }
 
     #[cfg(feature = "reliable_report")]


### PR DESCRIPTION
This includes some fix-ups for rust 1.89.0

Closes: PUSH-567