### PR TITLE
fix: filter non-state entries from report

### DIFF
--- a/autoendpoint/src/extractors/notification.rs
+++ b/autoendpoint/src/extractors/notification.rs
@@ -30,7 +30,6 @@ pub struct Notification {
     /// The current state the message was in (if tracked)
     pub reliable_state: Option<autopush_common::reliability::ReliabilityState>,
     #[cfg(feature = "reliable_report")]
-    #[cfg(feature = "reliable_report")]
     pub reliability_id: Option<String>,
 }
 


### PR DESCRIPTION
Due to a previous bug, invalid states were being recorded into redis.
This was causing too many metrics being created in prometheus. Add a
filter to prevent those invalid states from being reported.

In addition, autoendpoint would not properly start up due to timeouts
possibly related to frequent retries for reliability data. Instead of
retrying, just fail the operation and report the state transition to the
logs for further analysis.

Closes [PUSH-570](https://mozilla-hub.atlassian.net/browse/PUSH-570)

[PUSH-570]: https://mozilla-hub.atlassian.net/browse/PUSH-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ