### PR TITLE
feat: Added CI workflow to build and push autoconnect images when a pull request has a preview label

### DIFF
--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -1,0 +1,29 @@
+name: Build, Tag and Push Container Images to GAR Repository
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push-autoconnect:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'preview') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    secrets: inherit
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@78c0263d9e6c1d698fa7f4f5d76f5b1eb9dda69a # v4.5.0
+    with:
+      image_name: autoconnect
+      gar_name: autopush-prod
+      project_id: moz-fx-autopush-prod
+      docker_build_args: |
+        CRATE=autoconnect
+        BINARY=autoconnect


### PR DESCRIPTION
** CHANGES:** 
* Creating a new `mozcloud-publish` CI workflow, this is intended to build autoconnect and push an image to GAR matching the format (10-character SHA) 
* This workflow can be triggered manually for testing or automatically by adding the `preview` label to a pull request 
* Using the reusable `build-and-push` workflow from mozilla-it/deploy-actions, this covers several standard steps like generating version.json, authenticating to GAR, etc. 


Will follow up with the autoendpoint addition after testing. 