### PR TITLE
fix: updated mozcloud-publish workflow to new version that does not require artifact write permissions

### DIFF
--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@78c0263d9e6c1d698fa7f4f5d76f5b1eb9dda69a # v4.5.0
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
     with:
       image_name: autoconnect
       gar_name: autopush-prod
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@78c0263d9e6c1d698fa7f4f5d76f5b1eb9dda69a # v4.5.0
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
     with:
       image_name: autoendpoint
       gar_name: autopush-prod


### PR DESCRIPTION
**CHANGES:** 
* Updated to the latest build-and-push reusable workflow; the previous workflow required `package: write` and was failing. 
* That is only required if we are writing to the GitHub container registry as well as GAR, and has been removed as a requirement.  