### PR TITLE
feat: Make sentry reporting optional

### DIFF
--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -88,6 +88,8 @@ pub struct Settings {
     pub statsd_port: u16,
     /// The root label to apply to metrics.
     pub statsd_label: String,
+    /// Whether to disable Sentry error reporting
+    pub disable_sentry: Option<bool>,
     /// The DSN to connect to the storage engine (Used to select between storage systems)
     pub db_dsn: Option<String>,
     /// JSON set of specific database settings (See data storage engines)
@@ -143,6 +145,7 @@ impl Default for Settings {
             // Matches the legacy value
             statsd_label: "autoconnect".to_owned(),
             statsd_port: 8125,
+            disable_sentry: None,
             db_dsn: None,
             db_settings: "".to_owned(),
             megaphone_api_url: None,

--- a/autoconnect/autoconnect-web/src/lib.rs
+++ b/autoconnect/autoconnect-web/src/lib.rs
@@ -25,7 +25,7 @@ macro_rules! build_app {
             .wrap(autopush_common::middleware::sentry::SentryWrapper::<
                 $crate::error::ApiError,
             >::new(
-                $app_state.metrics.clone(), "error".to_owned()
+                $app_state.metrics.clone(), "error".to_owned(), $app_state.settings.disable_sentry.unwrap_or(false),
             ))
             .configure($config)
     };

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -192,6 +192,7 @@ impl Server {
                 .wrap(SentryWrapper::<ApiError>::new(
                     metrics.clone(),
                     "api_error".to_owned(),
+                    app_state.settings.disable_sentry.unwrap_or(false),
                 ))
                 .wrap(cors)
                 // Endpoints

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -55,6 +55,8 @@ pub struct Settings {
     pub statsd_port: u16,
     pub statsd_label: String,
 
+    pub disable_sentry: Option<bool>,
+
     pub fcm: FcmSettings,
     pub apns: ApnsSettings,
     #[cfg(feature = "stub")]
@@ -72,6 +74,7 @@ pub struct Settings {
     /// Max Notification Lifespan
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub max_notification_ttl: Duration,
+
 }
 
 impl Default for Settings {
@@ -108,6 +111,7 @@ impl Default for Settings {
             #[cfg(feature = "reliable_report")]
             reliability_retry_count: autopush_common::redis_util::MAX_TRANSACTION_LOOP,
             max_notification_ttl: Duration::from_secs(MAX_NOTIFICATION_TTL_SECS),
+            disable_sentry: None,
         }
     }
 }

--- a/autopush-common/src/middleware/sentry.rs
+++ b/autopush-common/src/middleware/sentry.rs
@@ -16,14 +16,16 @@ pub struct SentryWrapper<E> {
     metrics: Arc<StatsdClient>,
     metric_label: String,
     phantom: PhantomData<E>,
+    sentry_enabled: bool,
 }
 
 impl<E> SentryWrapper<E> {
-    pub fn new(metrics: Arc<StatsdClient>, metric_label: String) -> Self {
+    pub fn new(metrics: Arc<StatsdClient>, metric_label: String, sentry_enabled: bool) -> Self {
         Self {
             metrics,
             metric_label,
             phantom: PhantomData,
+            sentry_enabled
         }
     }
 }
@@ -46,6 +48,7 @@ where
             metrics: self.metrics.clone(),
             metric_label: self.metric_label.clone(),
             phantom: PhantomData,
+            sentry_enabled: self.sentry_enabled,
         })
     }
 }
@@ -56,6 +59,7 @@ pub struct SentryWrapperMiddleware<S, E> {
     metrics: Arc<StatsdClient>,
     metric_label: String,
     phantom: PhantomData<E>,
+    sentry_enabled: bool,
 }
 
 impl<S, B, E> Service<ServiceRequest> for SentryWrapperMiddleware<S, E>
@@ -70,8 +74,8 @@ where
 
     actix_web::dev::forward_ready!(service);
 
+    /// Set up the hub to add request data to events
     fn call(&self, sreq: ServiceRequest) -> Self::Future {
-        // Set up the hub to add request data to events
         let hub = Hub::new_from_top(Hub::main());
         let _ = hub.push_scope();
         let sentry_request = sentry_request_from_http(&sreq);
@@ -83,6 +87,7 @@ where
         let mut tags = Tags::from_request_head(sreq.head());
         let metrics = self.metrics.clone();
         let metric_label = self.metric_label.clone();
+        let sentry_enabled = self.sentry_enabled;
         if let Some(rtags) = sreq.request().extensions().get::<Tags>() {
             trace!("Sentry: found tags in request: {:?}", &rtags.tags);
             for (k, v) in rtags.tags.clone() {
@@ -111,8 +116,12 @@ where
                     };
                     debug!("Reporting error to Sentry (service error): {}", error);
                     let event = event_from_actix_error::<E>(&error);
-                    let event_id = hub.capture_event(event);
-                    trace!("event_id = {}", event_id);
+                    if sentry_enabled {
+                        let event_id = hub.capture_event(event);
+                        trace!("event_id = {}", event_id);
+                    } else {
+                        log_event(&event);
+                    }
                     return Err(error);
                 }
             };
@@ -134,6 +143,23 @@ where
         }
         .boxed_local()
     }
+}
+
+/// Log the Sentry event to STDERR. (This is copied from syncstorage-rs)
+fn log_event(event: &Event) {
+    let exception = event.exception.last();
+    let error_type = exception.map_or("UnknownError", |e| e.ty.as_str());
+    let error_value = exception
+        .and_then(|e| e.value.as_deref())
+        .unwrap_or("No error message");
+    error!("{}", error_value;
+        "error_type" => error_type,
+        "tags" => ?event.tags,
+        "extra" => ?event.extra,
+        "url" => event.request.as_ref().and_then(|r| r.url.as_ref()).map(|u| u.to_string()).unwrap_or_default(),
+        "method" => event.request.as_ref().and_then(|r| r.method.as_deref()).unwrap_or_default(),
+        "stacktrace" => exception.and_then(|e| e.stacktrace.as_ref()).map(|s| format!("{:?}", s.frames)).unwrap_or_default(),
+    );
 }
 
 /// Emit metrics when a [ReportableError::metric_label] is returned


### PR DESCRIPTION
Introduces a config new flag `disable_sentry` (default `false`) If enabled, sentry errors are reported via `error!()` to STDERR.

Closes #PUSH-1068