### PR TITLE
feat: Add metric for tracked vs untracked messages

### DIFF
--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -95,6 +95,11 @@ impl FromRequest for Subscription {
                     .then(|| app_state.reliability_filter.get_id(req.headers()))
             });
             trace!("🔍 track_id: {:?}", reliability_id);
+            app_state
+                .metrics
+                .incr_with_tags(MetricName::NotificationReceived)
+                .with_tag("trackable", &reliability_id.is_some().to_string())
+                .send();
             // Capturing the vapid sub right now will cause too much cardinality. Instead,
             // let's just capture if we have a valid VAPID, as well as what sort of bad sub
             // values we get.

--- a/autopush-common/src/metric_name.rs
+++ b/autopush-common/src/metric_name.rs
@@ -56,6 +56,9 @@ pub enum MetricName {
     //
     // Notification metrics
     //
+    #[strum(serialize = "notification.received")]
+    NotificationReceived,
+
     /// Notification authentication
     #[strum(serialize = "notification.auth")]
     NotificationAuth,


### PR DESCRIPTION
This counts messages for senders where we've previously registered the Vapid Public Key (e.g. the ones we generate via FxA) and the ones we don't.

The metric we're going to use is `*.notification.received` with the tag indicating if it's `trackable`.

Closes #PUSH-631