### PR TITLE
bug: fix restore missing suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,6 +412,10 @@ jobs:
           command: |
             mkdir -p /tmp/cache
             docker save -o /tmp/cache/<<parameters.image>>.tar "<<parameters.image>>"
+      - run:
+          name: List Docker images
+          command: |
+            docker image ls -a
             ls -l /tmp/cache
       - persist_to_workspace:
           root: /tmp/cache
@@ -532,10 +536,7 @@ jobs:
               source $BASH_ENV
               docker tag <<parameters.image>> $GAR_IMAGE:${GAR_TAG}<<parameters.suffix>>
               docker tag <<parameters.image>> $GAR_IMAGE:latest<<parameters.suffix>>
-<<<<<<< HEAD
               docker image ls -a
-=======
->>>>>>> 6dae0392e68e9c0ed5841c312efa35b780494c04
       # push-image parameters:
       # https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-push-image
       - gcp-gcr/push-image:


### PR DESCRIPTION
Missed adding a <suffix> for the restore, but that doesn't explain why the deploys without the suffix are failing.