### PR TITLE
fix: push enterprise gars via the GHA workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,26 +611,27 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build: # Enterprise
-          name: build-autoconnect-enterprise
-          image: autoconnect
-          crate: autoconnect
-          binary: autoconnect
-          suffix: "_enterprise"
-          build_args: "\"--no-default-features --features=enterprise\""
-          filters:
-            tags:
-              only: /.*/
-      - build: # Enterprise
-          name: build-autoendpoint-enterprise
-          image: autoendpoint
-          crate: autoendpoint
-          binary: autoendpoint
-          suffix: "_enterprise"
-          build_args: "\"--no-default-features --features=enterprise\""
-          filters:
-            tags:
-              only: /.*/
+# Moved to GHA
+#      - build: # Enterprise
+#          name: build-autoconnect-enterprise
+#          image: autoconnect
+#          crate: autoconnect
+#          binary: autoconnect
+#          suffix: "_enterprise"
+#          build_args: "\"--no-default-features --features=enterprise\""
+#          filters:
+#            tags:
+#              only: /.*/
+#      - build: # Enterprise
+#          name: build-autoendpoint-enterprise
+#          image: autoendpoint
+#          crate: autoendpoint
+#          binary: autoendpoint
+#          suffix: "_enterprise"
+#          build_args: "\"--no-default-features --features=enterprise\""
+#          filters:
+#            tags:
+#              only: /.*/
 
       - build-reliability-cron:
           name: build-reliability-cron
@@ -711,43 +712,43 @@ workflows:
             branches:
               only: master
 
-      - deploy:
-          name: deploy-autoconnect-enterprise
-          image: autoconnect
-          project_id: GCP_GAR_ENTERPRISE_PROJECT_ID
-          repo: GCP_GAR_ENTERPRISE_REPO
-          suffix: "_enterprise"
-          requires:
-            - build-autoconnect-enterprise
-            - Unit Tests
-            - Integration Tests
-            - Rust Formatting Check
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - master
-                - enterprise
+#      - deploy:
+#          name: deploy-autoconnect-enterprise
+#          image: autoconnect
+#          project_id: GCP_GAR_ENTERPRISE_PROJECT_ID
+#          repo: GCP_GAR_ENTERPRISE_REPO
+#          suffix: "_enterprise"
+#          requires:
+#            - build-autoconnect-enterprise
+#            - Unit Tests
+#            - Integration Tests
+#            - Rust Formatting Check
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              only:
+#                - master
+#                - enterprise
 
-      - deploy:
-          name: deploy-autoendpoint-enterprise
-          image: autoendpoint
-          project_id: GCP_GAR_ENTERPRISE_PROJECT_ID
-          repo: GCP_GAR_ENTERPRISE_REPO
-          suffix: "_enterprise"
-          requires:
-            - build-autoendpoint-enterprise
-            - Unit Tests
-            - Integration Tests
-            - Rust Formatting Check
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - master
-                - enterprise
+#      - deploy:
+#          name: deploy-autoendpoint-enterprise
+#          image: autoendpoint
+#          project_id: GCP_GAR_ENTERPRISE_PROJECT_ID
+#          repo: GCP_GAR_ENTERPRISE_REPO
+#          suffix: "_enterprise"
+#          requires:
+#            - build-autoendpoint-enterprise
+#            - Unit Tests
+#            - Integration Tests
+#            - Rust Formatting Check
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              only:
+#                - master
+#                - enterprise
 
       # ^^^^
       # End comment for local CircleCI testing.

--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -3,6 +3,11 @@ name: Build, Tag and Push Container Images to GAR Repository
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
   workflow_dispatch: {}
 
 jobs:
@@ -17,7 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
     with:
       image_name: autoconnect
       gar_name: autopush-prod
@@ -26,6 +31,32 @@ jobs:
       docker_build_args: |
         CRATE=autoconnect
         BINARY=autoconnect
+
+  build-and-push-autoconnect-enterprise:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        (github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/'))
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'preview') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    permissions:
+      contents: read
+      id-token: write
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
+    with:
+      image_name: autoconnect
+      gar_name: fx-enterprise-private
+      project_id: moz-fx-fx-enterprise-prod
+      docker_build_args: |
+        CRATE=autoconnect
+        BINARY=autoconnect
+        BUILD_ARGS=--no-default-features --features=enterprise
+
   build-and-push-autoendpoint:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -37,7 +68,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
     with:
       image_name: autoendpoint
       gar_name: autopush-prod
@@ -46,3 +77,28 @@ jobs:
       docker_build_args: |
         CRATE=autoendpoint
         BINARY=autoendpoint
+
+  build-and-push-autoendpoint-enterprise:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        (github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/'))
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'preview') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    permissions:
+      contents: read
+      id-token: write
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
+    with:
+      image_name: autoendpoint
+      gar_name: fx-enterprise-private
+      project_id: moz-fx-fx-enterprise-prod
+      docker_build_args: |
+        CRATE=autoendpoint
+        BINARY=autoendpoint
+        BUILD_ARGS=--no-default-features --features=enterprise


### PR DESCRIPTION
where the auth seems simpler than in circleci

Closes PUSH-679

(This seems like the easiest fix, as it works: my test branch https://github.com/mozilla-services/autopush-rs/actions/runs/23274825321/job/67675479316 successfully published)