### PR TITLE
chore: tag 1.80.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+<a name="1.80.1"></a>
+## 1.80.1 (2026-03-20)
+
+
+#### Chore
+
+*   tag 1.80.1 ([db8140f5](https://github.com/mozilla-services/autopush-rs/commit/db8140f5e7f8419a56393f7bf09d89a73de9ccfc))
+*   tag 1.80.0 (#1112) ([dfeed4a2](https://github.com/mozilla-services/autopush-rs/commit/dfeed4a2f9bb9107c917eb5a6f4783ee7e844893))
+
+#### Bug Fixes
+
+*   Fix tests and build.rs to allow multi-database configs (#1119) ([712f1a12](https://github.com/mozilla-services/autopush-rs/commit/712f1a12d8796b2a586030190bab67f85deeb1c3))
+*   push enterprise gars via the GHA workflow (#1125) ([4064a226](https://github.com/mozilla-services/autopush-rs/commit/4064a2268212e4a7a7027924df3b54c4fd472a4b))
+*   Ensure redis config ttls are not 0 (#1115) ([f7e58768](https://github.com/mozilla-services/autopush-rs/commit/f7e58768fd385b5e2c2556c529edf4f81ca535be))
+
+#### Doc
+
+*   re-init docker compose setup documentation with Redis (#1109) ([5fd7ef68](https://github.com/mozilla-services/autopush-rs/commit/5fd7ef68f8f29e82ee86c4b498129b7d1e7c7888))
+*   Add some clarity to options and requirements (#1117) ([8e5d850d](https://github.com/mozilla-services/autopush-rs/commit/8e5d850d5a99bf44c407174d2c95c3a5deea1c14))
+
+
+
 <a name="1.80.0"></a>
 ## 1.80.0 (2026-03-10)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autoconnect"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.80.0"
+version = "1.80.1"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.80.1 ([db8140f5](https://github.com/mozilla-services/autopush-rs/commit/db8140f5e7f8419a56393f7bf09d89a73de9ccfc))
*   tag 1.80.0 (#1112) ([dfeed4a2](https://github.com/mozilla-services/autopush-rs/commit/dfeed4a2f9bb9107c917eb5a6f4783ee7e844893))

#### Bug Fixes

*   Fix tests and build.rs to allow multi-database configs (#1119) ([712f1a12](https://github.com/mozilla-services/autopush-rs/commit/712f1a12d8796b2a586030190bab67f85deeb1c3))
*   push enterprise gars via the GHA workflow (#1125) ([4064a226](https://github.com/mozilla-services/autopush-rs/commit/4064a2268212e4a7a7027924df3b54c4fd472a4b))
*   Ensure redis config ttls are not 0 (#1115) ([f7e58768](https://github.com/mozilla-services/autopush-rs/commit/f7e58768fd385b5e2c2556c529edf4f81ca535be))

#### Doc

*   re-init docker compose setup documentation with Redis (#1109) ([5fd7ef68](https://github.com/mozilla-services/autopush-rs/commit/5fd7ef68f8f29e82ee86c4b498129b7d1e7c7888))
*   Add some clarity to options and requirements (#1117) ([8e5d850d](https://github.com/mozilla-services/autopush-rs/commit/8e5d850d5a99bf44c407174d2c95c3a5deea1c14))

