### PR TITLE
chore: tag 1.81.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="1.81.2"></a>
+## 1.81.2 (2026-04-09)
+
+
+#### Chore
+
+*   tag 1.81.1 (#1137) ([4837054c](https://github.com/mozilla-services/autopush-rs/commit/4837054c4a378548bf872eb3a2f42185c9422727))
+*   tag 1.81.0 (#1135) ([a4a88adc](https://github.com/mozilla-services/autopush-rs/commit/a4a88adc37262a93d5b9ba280614c01b22abca77))
+
+#### Features
+
+*   Make the kubernetes memory check optional (#1140) ([e4fca57d](https://github.com/mozilla-services/autopush-rs/commit/e4fca57dabe10d86bb6faffe5c16af29ed5db705))
+*   restore the "<release tag>_enterprise" tag w/ ent gar (#1136) ([4a6abdc6](https://github.com/mozilla-services/autopush-rs/commit/4a6abdc6424cb681ee7f4188b8ac29e40a661cd4))
+
+
+
 <a name="1.81.1"></a>
 ## 1.81.1 (2026-04-02)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autoconnect"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "a2",
  "actix-cors",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.81.1"
+version = "1.81.2"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Chore

*   tag 1.81.1 (#1137) ([4837054c](https://github.com/mozilla-services/autopush-rs/commit/4837054c4a378548bf872eb3a2f42185c9422727))
*   tag 1.81.0 (#1135) ([a4a88adc](https://github.com/mozilla-services/autopush-rs/commit/a4a88adc37262a93d5b9ba280614c01b22abca77))

#### Features

*   Make the kubernetes memory check optional (#1140) ([e4fca57d](https://github.com/mozilla-services/autopush-rs/commit/e4fca57dabe10d86bb6faffe5c16af29ed5db705))
*   restore the "<release tag>_enterprise" tag w/ ent gar (#1136) ([4a6abdc6](https://github.com/mozilla-services/autopush-rs/commit/4a6abdc6424cb681ee7f4188b8ac29e40a661cd4))