### PR TITLE
Add endpoint to forward push notifications to another push server

### DIFF
--- a/autoendpoint/src/extractors/forward_request.rs
+++ b/autoendpoint/src/extractors/forward_request.rs
@@ -1,0 +1,582 @@
+use std::str::FromStr;
+
+use actix_http::header::{self, HeaderMap};
+use actix_web::{FromRequest, HttpRequest, web::Data};
+use autopush_common::{
+    metric_name::MetricName, metrics::StatsdClientExt as _, util::b64_encode_url,
+};
+use cadence::StatsdClient;
+use futures::{FutureExt, future};
+use openssl::{ec::PointConversionForm, hash::MessageDigest};
+
+use crate::{
+    error::{ApiError, ApiErrorKind, ApiResult},
+    extractors::subscription::{decode_public_key, repad_base64, validate_vapid_jwt},
+    headers::vapid::{VapidClaims, VapidError, VapidHeader, VapidHeaderWithKey, VapidVersionData},
+    server::AppState,
+    settings::Settings,
+};
+
+/// Contains data extracted from the encrypted token and the request, required to push to the new endpoint
+#[derive(Debug)]
+struct ForwardData {
+    /// Endpoint to forward notifications
+    url: String,
+    /// VAPID claims from the incoming authorization header, reused for outgoing request
+    vapid_claims: Option<VapidClaims>,
+    /// VAPID private key for outgoing request
+    vapid_privkey: Option<[u8; 32]>,
+}
+
+/// Contains the [reqwest::RequestBuilder] made from data extracted from the encrypted token
+/// via [ForwardToken]
+pub struct ForwardRequest(pub reqwest::RequestBuilder);
+
+impl FromRequest for ForwardData {
+    type Error = ApiError;
+    type Future = future::LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut actix_http::Payload) -> Self::Future {
+        let req = req.clone();
+        async move {
+            let app_state: Data<AppState> =
+                Data::extract(&req).await.expect("No server state found");
+
+            let encoded_token = req
+                .match_info()
+                .get("token")
+                .expect("{token} must be part of the webpush path")
+                .to_string();
+
+            let raw_token = app_state
+                .fernet
+                .decrypt(&repad_base64(&encoded_token))
+                .map_err(|e| {
+                    // Since we're decrypting and endpoint, we get a lot of spam links.
+                    // This can fill our logs.
+                    trace!("🔐 fernet: {:?}", e.to_string());
+                    ApiErrorKind::InvalidToken
+                })?;
+            forward_data_from_token(
+                raw_token,
+                &req.headers(),
+                &app_state.settings,
+                &app_state.metrics,
+            )
+        }
+        .boxed_local()
+    }
+}
+
+/// Get the [ForwardData] from the token and the request headers
+fn forward_data_from_token(
+    token: Vec<u8>,
+    req_headers: &HeaderMap,
+    settings: &Settings,
+    metrics: &StatsdClient,
+) -> ApiResult<ForwardData> {
+    if token.len() < 64 {
+        trace!("⏩️forward: token shorter than 64 bytes");
+        Err(ApiErrorKind::InvalidToken)?;
+    }
+    let i_pubkey = token.len() - 64;
+    let i_privkey = i_pubkey + 32;
+
+    let url = String::from_utf8(token[..i_pubkey].to_vec())
+        .ok()
+        .map(|s| url::Url::parse(&s).ok())
+        .flatten()
+        .ok_or_else(|| ApiErrorKind::InvalidToken)?;
+
+    let pubkey_hash: Option<[u8; 32]> = if token[i_pubkey..i_privkey] == [0u8; 32] {
+        None
+    } else {
+        token[i_pubkey..i_privkey].try_into().ok()
+    };
+
+    let vapid_privkey: Option<[u8; 32]> = if token[i_privkey..] == [0u8; 32] {
+        None
+    } else {
+        token[i_privkey..].try_into().ok()
+    };
+
+    trace!(
+        "⏩️forward: new request to {}, inbound vapid {}, outboud vapid {}",
+        url,
+        pubkey_hash.is_some(),
+        vapid_privkey.is_some()
+    );
+
+    let vapid_claims = get_vapid_claims(
+        req_headers,
+        pubkey_hash,
+        url.origin().unicode_serialization(),
+        settings,
+        metrics,
+    )?;
+
+    Ok(ForwardData {
+        url: url.into(),
+        vapid_claims,
+        vapid_privkey,
+    })
+}
+
+/// Get VAPID claims, AUD edited for the forwarded url, if the token is configured to use VAPID
+///
+/// Fails if the token is configured to use VAPID, and the authorization doesn't succeed
+fn get_vapid_claims(
+    headers: &HeaderMap,
+    pubkey_hash: Option<[u8; 32]>,
+    forward_origin: String,
+    settings: &Settings,
+    metrics: &StatsdClient,
+) -> ApiResult<Option<VapidClaims>> {
+    if let Some(token_pubkey) = pubkey_hash {
+        match headers
+            .get("authorization")
+            .map(|h| h.to_str().ok())
+            .flatten()
+        {
+            None => {
+                let e = VapidError::MissingKey;
+                metrics
+                    .incr_with_tags(MetricName::NotificationAuthError)
+                    .with_tag("error", e.as_metric())
+                    .send();
+                Err(e)?
+            }
+            Some(auth_header) => {
+                let vapid = VapidHeader::parse(auth_header).inspect_err(|e| {
+                    metrics
+                        .incr_with_tags(MetricName::NotificationAuthError)
+                        .with_tag("error", e.as_metric())
+                        .send();
+                })?;
+                // We do not support old VAPID draft
+                let vapid = match &vapid.version_data {
+                    VapidVersionData::Version1 => Err(ApiErrorKind::InvalidAuthentication),
+                    VapidVersionData::Version2 { public_key } => {
+                        let public_key = public_key.clone();
+                        Ok(VapidHeaderWithKey { vapid, public_key })
+                    }
+                }?;
+                let public_key = decode_public_key(&vapid.public_key)?;
+                let key_hash = openssl::hash::hash(MessageDigest::sha256(), &public_key)
+                    .map_err(ApiErrorKind::TokenHashValidation)?;
+                if !openssl::memcmp::eq(&key_hash, &token_pubkey) {
+                    return Err(VapidError::KeyMismatch.into());
+                }
+                let mut claims = validate_vapid_jwt(&vapid, settings, metrics)?;
+                claims.aud = Some(forward_origin);
+                Ok(Some(claims))
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+impl FromRequest for ForwardRequest {
+    type Error = ApiError;
+    type Future = future::LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut actix_http::Payload) -> Self::Future {
+        let req = req.clone();
+        async move {
+            let mut in_headers = req.headers().clone();
+            check_content_encoding(&in_headers)?;
+
+            let app_state: Data<AppState> =
+                Data::extract(&req).await.expect("No server state found");
+            let data = ForwardData::extract(&req).await?;
+
+            if let Some(vapid_privkey) = data.vapid_privkey {
+                set_vapid_authorization(&mut in_headers, &data.vapid_claims, &vapid_privkey)?;
+            } else {
+                in_headers.remove(header::AUTHORIZATION);
+            }
+            in_headers.remove(header::HOST);
+            let req_headers = actix_to_reqwest_headers(in_headers);
+
+            // Note: we should not follow redirect. reqwest can't handle per-request
+            // redirect policy atm (https://github.com/seanmonstar/reqwest/issues/353).
+            // app_state.http is used only for webpush routers (which requests autopush nodes),
+            // we can probably change its redirect policy. Else we can create a new
+            // app_state.http_no_redir client
+            Ok(Self(app_state.http.post(data.url).headers(req_headers)))
+        }
+        .boxed_local()
+    }
+}
+
+fn check_content_encoding(in_headers: &HeaderMap) -> ApiResult<()> {
+    let encoding = in_headers
+        .get("Content-Encoding")
+        .ok_or_else(|| ApiErrorKind::InvalidEncryption("Missing Content-Encoding header".into()))?
+        .to_str()
+        .map_err(|_| ApiErrorKind::InvalidEncryption("Invalid Content-Encoding header".into()))?;
+    match encoding {
+        "aes128gcm" => Ok(()),
+        "aesgcm" => Err(ApiErrorKind::InvalidEncryption(
+            "Unsupported legacy encryption".into(),
+        )),
+        _ => Err(ApiErrorKind::InvalidEncryption(
+            "Unknown Content-Encoding header".into(),
+        )),
+    }?;
+    Ok(())
+}
+
+fn set_vapid_authorization(
+    in_headers: &mut HeaderMap,
+    claims: &Option<VapidClaims>,
+    vapid_privkey: &[u8; 32],
+) -> ApiResult<()> {
+    let key = private_bn_to_key_for_header(vapid_privkey)
+        .map_err(|_| ApiErrorKind::General("Invalid private key".into()))?;
+
+    let jwk_header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+    let enc_key = jsonwebtoken::EncodingKey::from_ec_der(&key.pkcs8_der);
+    let jwt = jsonwebtoken::encode(&jwk_header, claims, &enc_key)
+        .map_err(|_| ApiErrorKind::General("Error while signing JWT".into()))?;
+    in_headers.insert(
+        header::AUTHORIZATION,
+        format!("vapid t={},k={}", jwt, b64_encode_url(&key.public_fp))
+            .try_into()
+            .map_err(|_| ApiErrorKind::General("Couldn't create VAPID header value".into()))?,
+    );
+    Ok(())
+}
+
+fn actix_to_reqwest_headers(in_headers: HeaderMap) -> reqwest::header::HeaderMap {
+    let mut req_headers = reqwest::header::HeaderMap::new();
+    for (name, value) in in_headers {
+        if let Ok(name) = reqwest::header::HeaderName::from_str(name.as_str()) {
+            if let Ok(value) = value.as_bytes().try_into() {
+                req_headers.append(name, value);
+            } else {
+                trace!("⏩️forward: received invalid header value {value:?}");
+            }
+        } else {
+            trace!("⏩️forward: received invalid header {name}");
+        }
+    }
+    req_headers
+}
+
+struct VapidPrivateForHeader {
+    pkcs8_der: Vec<u8>,
+    public_fp: Vec<u8>,
+}
+
+fn private_bn_to_key_for_header(
+    vapid_privkey: &[u8],
+) -> Result<VapidPrivateForHeader, Box<dyn std::error::Error>> {
+    let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?;
+    let private_number = openssl::bn::BigNum::from_slice(vapid_privkey)?;
+    let mut ctx = openssl::bn::BigNumContext::new_secure()?;
+    let mut pub_point = openssl::ec::EcPoint::new(&group)?;
+    pub_point.mul_generator(&group, &private_number, &mut ctx)?;
+    let key = openssl::ec::EcKey::from_private_components(&group, &private_number, &pub_point)?;
+    let public_fp = uncompressed_form(key.public_key())?;
+    let pkey = openssl::pkey::PKey::from_ec_key(key)?;
+    Ok(VapidPrivateForHeader {
+        pkcs8_der: pkey.private_key_to_pkcs8()?,
+        public_fp,
+    })
+}
+
+pub fn uncompressed_form(
+    pubkey: &openssl::ec::EcPointRef,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?;
+    let mut ctx = openssl::bn::BigNumContext::new()?;
+    Ok(pubkey.to_bytes(&group, PointConversionForm::UNCOMPRESSED, &mut ctx)?)
+}
+
+#[cfg(test)]
+mod test {
+    use actix_http::header::{HeaderMap, HeaderName, HeaderValue};
+    use autopush_common::util::{b64_decode_url, b64_encode_std, b64_encode_url};
+    use lazy_static::lazy_static;
+
+    use crate::extractors::forward_request::forward_data_from_token;
+    use crate::metrics::Metrics;
+    use crate::{
+        extractors::{
+            forward_request::{
+                check_content_encoding, get_vapid_claims, private_bn_to_key_for_header,
+                set_vapid_authorization,
+            },
+            forward_token::digest_from_pubkey,
+        },
+        headers::vapid::VapidClaims,
+        settings::Settings,
+    };
+
+    pub const OUT_PRIV_KEY_DER: &str = "\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgZImOgpRszunnU3j1\
+oX5UQiX8KU4X2OdbENuvc/t8wpmhRANCAATN21Y1v8LmQueGpSG6o022gTbbYa4l\
+bXWZXITsjknW1WHmELtouYpyXX7e41FiAMuDvcRwW2Nfehn/taHW/IXb";
+    pub const OUT_PUB_KEY: &str =
+        "BM3bVjW_wuZC54alIbqjTbaBNtthriVtdZlchOyOSdbVYeYQu2i5inJdft7jUWIAy4O9xHBbY196Gf-1odb8hds";
+    pub const IN_PUB_KEY: &str =
+        "BAZOxJhHcrJ6DVhRzeccitRqBWEUkOUFJAFbpxR4d2QcKscpKd2OvvmIWof3R7SWgsFpmO9e0vTukAYTY6nQiY0";
+
+    lazy_static! {
+        static ref OUT_PRIVKEY_BN: [u8; 32] =
+            b64_decode_url("ZImOgpRszunnU3j1oX5UQiX8KU4X2OdbENuvc_t8wpk")
+                .expect("can't init PRIVKEY_BN")
+                .try_into()
+                .expect("can't cast PRIVKEY_BN");
+        /// This is used to generate incoming VAPID header for the test, this should normaly
+        /// never be known to us
+        static ref IN_PRIVKEY_BN: [u8; 32] =
+            b64_decode_url("avIkQ9fhUl9tds7FxVtMEioXCv6ffFdw_7UGIR8JXUE")
+                .expect("can't init PRIVKEY_BN")
+                .try_into()
+                .expect("can't cast PRIVKEY_BN");
+    }
+
+    #[test]
+    fn content_encoding() {
+        check_content_encoding(&HeaderMap::new())
+            .expect_err("request without content-encoding must be rejected");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("content-encoding"),
+            HeaderValue::from_static("aesgcm"),
+        );
+        headers.insert(
+            HeaderName::from_static("encryption"),
+            HeaderValue::from_static("salt=foo"),
+        );
+        headers.insert(
+            HeaderName::from_static("crypto-key"),
+            HeaderValue::from_static("dh=bar"),
+        );
+        check_content_encoding(&headers)
+            .expect_err("request with draft content-encoding must be rejected");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("content-encoding"),
+            HeaderValue::from_static("aes128gcm"),
+        );
+        check_content_encoding(&headers)
+            .expect("request with standard content-encoding must be accepted");
+    }
+
+    #[test]
+    fn bn_to_key_for_header() {
+        let key = private_bn_to_key_for_header(OUT_PRIVKEY_BN.as_ref())
+            .expect("couldn't extract key from big number");
+        assert_eq!(
+            "BM3bVjW_wuZC54alIbqjTbaBNtthriVtdZlchOyOSdbVYeYQu2i5inJdft7jUWIAy4O9xHBbY196Gf-1odb8hds",
+            b64_encode_url(&key.public_fp),
+            "public key mismatch"
+        );
+        assert_eq!(
+            OUT_PRIV_KEY_DER,
+            b64_encode_std(&key.pkcs8_der),
+            "private key DER mismatch"
+        );
+    }
+
+    #[test]
+    fn insert_vapid() {
+        let mut headers = HeaderMap::new();
+        let claims = VapidClaims {
+            aud: Some("https://target.example.tld".to_string()),
+            ..Default::default()
+        };
+        set_vapid_authorization(&mut headers, &Some(claims), &OUT_PRIVKEY_BN)
+            .expect("can't set vapid auth");
+        let auth = headers
+            .get("authorization")
+            .expect("authorization header not set");
+        let auth = auth.to_str().expect("can't extract string from auth");
+        assert!(
+            auth.starts_with("vapid t="),
+            "auth header doesn't start with `vapid t=`"
+        );
+        assert!(
+            auth.ends_with(&format!(",k={}", OUT_PUB_KEY)),
+            "auth header doesn't end with `,k=PUBKEY`"
+        );
+    }
+
+    #[test]
+    fn extracted_vapid_claims() {
+        let mut headers = HeaderMap::new();
+        let our_origin = "https://us.example.tld".to_string();
+        let forward_origin = "https://forward.example.tld".to_string();
+        let claims = VapidClaims {
+            aud: Some(our_origin.clone()),
+            ..Default::default()
+        };
+        let test_settings = Settings {
+            endpoint_url: our_origin,
+            ..Default::default()
+        };
+        set_vapid_authorization(&mut headers, &Some(claims), &OUT_PRIVKEY_BN)
+            .expect("can't set vapid auth");
+        // digest is the SHA256 hash of the pubkey of the key that signed the VAPID header
+        let digest = digest_from_pubkey(OUT_PUB_KEY)
+            .expect("can't get digest from pubkey")
+            .to_vec()
+            .try_into()
+            .expect("Can't cast DigestBytes to [u8; 32]");
+
+        let claims = get_vapid_claims(
+            &headers,
+            Some(digest),
+            forward_origin.clone(),
+            &test_settings,
+            &Metrics::sink(),
+        )
+        .expect("can't extract claims from headers with authorization")
+        .expect("no claims found, when authorization is set");
+
+        assert_eq!(
+            Some(&forward_origin),
+            claims.aud.as_ref(),
+            "VAPID aud claim not correctly replaced",
+        );
+
+        get_vapid_claims(
+            &HeaderMap::new(),
+            Some(digest),
+            forward_origin.clone(),
+            &test_settings,
+            &Metrics::sink(),
+        )
+        .expect_err("headers without vapid must fail if a pubkey digest is set");
+
+        let claims = get_vapid_claims(
+            &HeaderMap::new(),
+            None,
+            forward_origin,
+            &test_settings,
+            &Metrics::sink(),
+        )
+        .expect("can't extract claims from headers without authorization");
+        assert_eq!(
+            None, claims,
+            "no claims must be exported without authorization",
+        );
+    }
+
+    #[test]
+    fn forward_data_no_auth() {
+        let forward_url = "https://forward.domain.tld/abcd".to_string();
+        let test_settings = Settings {
+            endpoint_url: "https://us.domain.tld".to_string(),
+            ..Default::default()
+        };
+
+        let mut token = Vec::new();
+        token.extend_from_slice(forward_url.as_bytes());
+        token.extend_from_slice(&[0u8; 32]);
+        token.extend_from_slice(&[0u8; 32]);
+        let data =
+            forward_data_from_token(token, &HeaderMap::new(), &test_settings, &Metrics::sink())
+                .expect("can't extract data from token+headers without authentication");
+        assert_eq!(forward_url, data.url, "forward origin doesn't match");
+        assert_eq!(
+            None, data.vapid_claims,
+            "data must not have claims without authentication"
+        );
+        assert_eq!(None, data.vapid_privkey, "data must not have a private key");
+    }
+
+    #[test]
+    fn forward_data_auth_valid() {
+        let forward_url = "https://forward.domain.tld/abcd".to_string();
+        let our_origin = "https://us.domain.tld".to_string();
+        let test_settings = Settings {
+            endpoint_url: our_origin.clone(),
+            ..Default::default()
+        };
+        let mut headers = HeaderMap::new();
+        let claims = VapidClaims {
+            aud: Some(our_origin.clone()),
+            ..Default::default()
+        };
+        set_vapid_authorization(&mut headers, &Some(claims.clone()), &IN_PRIVKEY_BN)
+            .expect("can't init in_headers");
+
+        // without forward key
+        let mut token = Vec::new();
+        token.extend_from_slice(forward_url.as_bytes());
+        let digest = digest_from_pubkey(&IN_PUB_KEY).expect("cann't get digest from pubkey");
+        token.extend(digest.iter());
+        token.extend_from_slice(&[0u8; 32]);
+        let data = forward_data_from_token(token, &headers, &test_settings, &Metrics::sink())
+            .expect("can't extract data from token+headers with authentication");
+        assert_eq!(forward_url, data.url, "forward origin doesn't match");
+        assert_eq!(
+            data.vapid_claims.map(|c| c.aud).flatten(),
+            Some(
+                url::Url::parse(&forward_url)
+                    .expect("can't parse forward url")
+                    .origin()
+                    .unicode_serialization()
+            ),
+            "data claim doesn't have the forward_url audience"
+        );
+        assert_eq!(None, data.vapid_privkey, "data must not have a private key");
+
+        // with forward key
+        let mut token = Vec::new();
+        token.extend_from_slice(forward_url.as_bytes());
+        let digest = digest_from_pubkey(&IN_PUB_KEY).expect("cann't get digest from pubkey");
+        token.extend(digest.iter());
+        token.extend_from_slice(OUT_PRIVKEY_BN.as_ref());
+        let data = forward_data_from_token(token, &headers, &test_settings, &Metrics::sink())
+            .expect("can't extract data from token+headers with authentication");
+        assert_eq!(forward_url, data.url, "forward origin doesn't match");
+        assert_eq!(
+            data.vapid_claims.map(|c| c.aud).flatten(),
+            Some(
+                url::Url::parse(&forward_url)
+                    .expect("can't parse forward url")
+                    .origin()
+                    .unicode_serialization()
+            ),
+            "data claim doesn't have the forward_url audience"
+        );
+        assert_eq!(
+            Some(OUT_PRIVKEY_BN.to_vec()),
+            data.vapid_privkey.map(|v| v.to_vec()),
+            "private key doesn't match"
+        );
+    }
+
+    #[test]
+    fn forward_data_auth_invalid() {
+        let forward_url = "https://forward.domain.tld/abcd".to_string();
+        let our_origin = "https://us.domain.tld".to_string();
+        let test_settings = Settings {
+            endpoint_url: our_origin.clone(),
+            ..Default::default()
+        };
+        let mut headers = HeaderMap::new();
+        let claims = VapidClaims {
+            aud: Some(our_origin.clone()),
+            ..Default::default()
+        };
+        set_vapid_authorization(&mut headers, &Some(claims.clone()), &IN_PRIVKEY_BN)
+            .expect("can't init in_headers");
+
+        let mut token = Vec::new();
+        token.extend_from_slice(forward_url.as_bytes());
+        let digest = digest_from_pubkey(&IN_PUB_KEY).expect("cann't get digest from pubkey");
+        token.extend(digest.iter());
+        token.extend_from_slice(&[0u8; 32]);
+        forward_data_from_token(token, &HeaderMap::new(), &test_settings, &Metrics::sink())
+                .expect_err("extract data must not be possible when token has pubkey, but request doesn't have authorization");
+    }
+}

--- a/autoendpoint/src/extractors/forward_request.rs
+++ b/autoendpoint/src/extractors/forward_request.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use actix_http::header::{self, HeaderMap};
 use actix_web::{FromRequest, HttpRequest, web::Data};
 use autopush_common::{
@@ -8,6 +6,7 @@ use autopush_common::{
 use cadence::StatsdClient;
 use futures::{FutureExt, future};
 use openssl::{ec::PointConversionForm, hash::MessageDigest};
+use reqwest::header::HeaderValue;
 
 use crate::{
     error::{ApiError, ApiErrorKind, ApiResult},
@@ -196,7 +195,6 @@ impl FromRequest for ForwardRequest {
             } else {
                 in_headers.remove(header::AUTHORIZATION);
             }
-            in_headers.remove(header::HOST);
             let req_headers = actix_to_reqwest_headers(in_headers);
 
             // Note: we should not follow redirect. reqwest can't handle per-request
@@ -249,19 +247,26 @@ fn set_vapid_authorization(
     Ok(())
 }
 
+/// Make actix headers with TTL, Urgency, Topic, Authorization from the request
+///
+/// Set Content-Encoding to `application/octet-stream`
+///
+/// Authorization header must already be updated to target the forwarded endpoint
 fn actix_to_reqwest_headers(in_headers: HeaderMap) -> reqwest::header::HeaderMap {
     let mut req_headers = reqwest::header::HeaderMap::new();
-    for (name, value) in in_headers {
-        if let Ok(name) = reqwest::header::HeaderName::from_str(name.as_str()) {
+    for header_name in ["ttl", "urgency", "topic", "authorization"] {
+        if let Some(value) = in_headers.get(header_name) {
             if let Ok(value) = value.as_bytes().try_into() {
-                req_headers.append(name, value);
+                req_headers.insert(header_name, value);
             } else {
                 trace!("⏩️forward: received invalid header value {value:?}");
             }
-        } else {
-            trace!("⏩️forward: received invalid header {name}");
         }
     }
+    req_headers.insert(
+        "content-type",
+        HeaderValue::from_static("application/octet-stream"),
+    );
     req_headers
 }
 

--- a/autoendpoint/src/extractors/forward_token.rs
+++ b/autoendpoint/src/extractors/forward_token.rs
@@ -1,0 +1,294 @@
+use actix_web::{
+    FromRequest,
+    web::{Bytes, Data},
+};
+use autopush_common::util::b64_decode_url;
+use futures::{FutureExt, future};
+use openssl::hash::{self, DigestBytes};
+
+use crate::{
+    error::{ApiError, ApiErrorKind, ApiResult},
+    extractors::forward_request::uncompressed_form,
+    server::AppState,
+};
+
+pub struct ForwardToken(pub String);
+
+/// HTTP body in JSON sent to [new_forward_endpoint]
+#[derive(serde::Deserialize)]
+pub struct ForwardEndpointRequest {
+    /// URL to forward notifs to, must be HTTPS endpoint
+    url: String,
+    /// VAPID pubkey of incoming notifs, uncompressed format URL-safe Base64 encoded
+    server_pubkey: Option<String>,
+    /// VAPID privkey to outgoind notifs, PEM format - used only if server_pubkey is present
+    forward_privkey: Option<String>,
+}
+
+impl FromRequest for ForwardToken {
+    type Error = ApiError;
+    type Future = future::LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(
+        req: &actix_web::HttpRequest,
+        payload: &mut actix_http::Payload,
+    ) -> Self::Future {
+        let req = req.clone();
+        let mut payload = payload.take();
+        async move {
+            let app_state: Data<AppState> =
+                Data::extract(&req).await.expect("No server state found");
+            let data = Bytes::from_request(&req, &mut payload)
+                .await
+                .map_err(|e| ApiErrorKind::PayloadError(e))?;
+            let req: ForwardEndpointRequest = serde_json::from_slice(&data)?;
+            let root = url::Url::parse(&app_state.settings.endpoint_url).map_err(|e| {
+                ApiErrorKind::General(format!("Cannot parse settings endpoint_url: {e}"))
+            })?;
+
+            let forward_url = url::Url::parse(&req.url)
+                .map_err(|e| ApiErrorKind::General(format!("Cannot parse requested url: {e}")))?;
+
+            check_forward_scheme(&forward_url)?;
+            check_host(&root, &forward_url)?;
+
+            let clear_token = make_cleartext_token(req)?;
+            let token = app_state
+                .fernet
+                .encrypt(&clear_token)
+                .trim_matches('=')
+                .to_string();
+
+            Ok(ForwardToken(token))
+        }
+        .boxed_local()
+    }
+}
+
+/// Check that the forward URL is HTTPS
+///
+/// Debug builds also allow HTTP
+fn check_forward_scheme(url: &url::Url) -> ApiResult<()> {
+    // We allow http for debug build
+    #[cfg(debug_assertions)]
+    let invalid_scheme = url.scheme() != "https" && url.scheme() != "http";
+    #[cfg(not(debug_assertions))]
+    let invalid_scheme = url.scheme() != "https";
+
+    if invalid_scheme {
+        Err(ApiErrorKind::General(format!(
+            "Invalid scheme {}",
+            url.scheme()
+        )))?
+    }
+    Ok(())
+}
+
+/// Make token from [ForwardEndpointRequest], must be fernet-encrypted
+///
+/// Contains: `{url: Vec<u8>}{pubkey_digest: [u8; 32]}{privkey_big_number: [u8; 32]}`
+fn make_cleartext_token(req: ForwardEndpointRequest) -> ApiResult<Vec<u8>> {
+    let mut clear_token = req.url.into_bytes();
+    let server_pubkey_digest = if let Some(k) = req.server_pubkey {
+        let digest = digest_from_pubkey(&k)?;
+        clear_token.extend(digest.iter());
+        Some(digest)
+    } else {
+        clear_token.extend([0u8; 32].iter());
+        None
+    };
+    if let Some(der) = req.forward_privkey {
+        let privkey = checked_privkey_from_der(&der, server_pubkey_digest)?;
+        clear_token.extend(privkey.iter());
+    } else {
+        clear_token.extend([0u8; 32].iter());
+    };
+    Ok(clear_token)
+}
+
+/// Check that the forward URL isn't us
+fn check_host(root: &url::Url, forward_url: &url::Url) -> ApiResult<()> {
+    if forward_url.host() == root.host() {
+        Err(ApiErrorKind::General(format!(
+            "Cannot push to ourselves {}",
+            forward_url.host_str().unwrap_or("None")
+        )))?;
+    }
+    Ok(())
+}
+
+/// Get SHA256 digest of the pubkey
+///
+/// [pubkey] must be in the uncompress format, URL-safe Base64 encoded
+pub fn digest_from_pubkey(pubkey: &str) -> ApiResult<hash::DigestBytes> {
+    let raw_key = b64_decode_url(pubkey).map_err(|e| {
+        warn!("Payload: error decoding user provided VAPID key:{:?}", e);
+        ApiErrorKind::General("Error decoding VAPID key".to_owned())
+    })?;
+    let digest = hash::hash(hash::MessageDigest::sha256(), &raw_key).map_err(|e| {
+        warn!("Payload: Error creating digest for VAPID key: {:?}", e);
+        ApiErrorKind::General("Error creating message digest for key".to_owned())
+    })?;
+    Ok(digest)
+}
+
+/// Get private key big number, 32 bytes long Vec<u8>,
+/// if the key is valid, and its public key isn't the server pubkey
+///
+/// [server_pubkey_digest]: SHA256 digest of the server_pubkey, uncompressed format
+fn checked_privkey_from_der(
+    der: &str,
+    server_pubkey_digest: Option<DigestBytes>,
+) -> ApiResult<Vec<u8>> {
+    let server_pubkey_digest = server_pubkey_digest.ok_or_else(|| {
+        ApiErrorKind::General(
+        "The forward VAPID key can't be set without a server pubkey, used to get the VAPID claims."
+            .into(),
+    )
+    })?;
+    let eckey = openssl::ec::EcKey::private_key_from_pem(der.as_bytes()).map_err(|e| {
+        warn!(
+            "Payload: error decoding user provided outgoind VAPID key:{:?}",
+            e
+        );
+        ApiErrorKind::General(format!(
+            "Error decoding VAPID private key. It should be a valid PEM format: {e}"
+        ))
+    })?;
+
+    eckey
+        .check_key()
+        .map_err(|e| ApiErrorKind::General(format!("Invalid VAPID private key: {e}")))?;
+
+    let bytes_key = eckey
+        .private_key()
+        .to_vec_padded(32)
+        .map_err(|e| ApiErrorKind::General(format!("Invalid VAPID private key length: {e}")))?;
+
+    // Verify that the public key isn't for this private key's:
+    // The private key must be a new one only to forward notifications!
+    let uncompress_pubkey = uncompressed_form(eckey.public_key())
+        .map_err(|_| ApiErrorKind::General("Error while checking public key".into()))?;
+
+    let digest = hash::hash(hash::MessageDigest::sha256(), &uncompress_pubkey).map_err(|e| {
+        warn!("Payload: Error creating digest for VAPID key: {:?}", e);
+        ApiErrorKind::General("Error creating message digest for key".to_owned())
+    })?;
+
+    if openssl::memcmp::eq(&digest, &server_pubkey_digest) {
+        Err(ApiErrorKind::General(
+            "VAPID app_server public key must not be forward_key's public key".into(),
+        ))?;
+    }
+    Ok(bytes_key)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::extractors::forward_token::{
+        ForwardEndpointRequest, check_forward_scheme, check_host, checked_privkey_from_der,
+        digest_from_pubkey, make_cleartext_token,
+    };
+
+    pub const PRIV_KEY_DER: &str = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgZImOgpRszunnU3j1
+oX5UQiX8KU4X2OdbENuvc/t8wpmhRANCAATN21Y1v8LmQueGpSG6o022gTbbYa4l
+bXWZXITsjknW1WHmELtouYpyXX7e41FiAMuDvcRwW2Nfehn/taHW/IXb
+-----END PRIVATE KEY-----";
+    pub const PUB_KEY_FOR_PRIVATE: &str =
+        "BM3bVjW_wuZC54alIbqjTbaBNtthriVtdZlchOyOSdbVYeYQu2i5inJdft7jUWIAy4O9xHBbY196Gf-1odb8hds";
+    pub const ANOTHER_PUB_KEY: &str =
+        "BA1Hxzyi1RUM1b5wjxsn7nGxAszw2u61m164i3MrAIxHF6YK5h4SDYic-dRuU_RcPcfA5aq9ojSwk5Y2EmclBPs";
+
+    #[test]
+    fn validate_scheme() {
+        let url = url::Url::parse("unix:///run/test").expect("can't parse URL");
+
+        check_forward_scheme(&url).expect_err("non-https scheme must not be accepted");
+        let url = url::Url::parse("https://example.tld").expect("can't parse URL");
+        check_forward_scheme(&url).expect("https scheme must be accepted");
+    }
+
+    #[test]
+    fn validate_host() {
+        let root = url::Url::parse("https:/update.example.tld").expect("can't parse URL");
+        let url = url::Url::parse("https:/update.example.tld").expect("can't parse URL");
+
+        check_host(&root, &url).expect_err("forward to our own host must be rejected");
+        let url = url::Url::parse("https:/update2.example.tld").expect("can't parse URL");
+        check_host(&root, &url).expect("forward to another host must be accepted");
+    }
+
+    #[test]
+    fn extract_checked_bn() {
+        checked_privkey_from_der(PRIV_KEY_DER, None).expect_err(
+            "extracting privkey big number shouldn't be possible without a incoming VAPID pubkey",
+        );
+
+        let digest =
+            digest_from_pubkey(PUB_KEY_FOR_PRIVATE).expect("can't extract digest from pubkey");
+        checked_privkey_from_der(PRIV_KEY_DER, Some(digest)).expect_err("extracting privkey big number shouldn't be possible if incoming VAPID pubkey matches the forwaring private key");
+
+        let digest = digest_from_pubkey(ANOTHER_PUB_KEY).expect("can't extract digest from pubkey");
+        let bn = checked_privkey_from_der(PRIV_KEY_DER, Some(digest))
+            .expect("can't extract privkey big number");
+        assert_eq!(32, bn.len(), "extracted big number doesn't match length");
+    }
+
+    #[test]
+    fn cleartext_token() {
+        let req = ForwardEndpointRequest {
+            url: "https://a/".into(),
+            server_pubkey: None,
+            forward_privkey: None,
+        };
+        let token = make_cleartext_token(req).expect("couldn't make token from request");
+        assert_eq!(74, token.len(), "token length mismatch");
+        assert_eq!(
+            [0u8; 32],
+            token[10..42],
+            "digest section mismatch without pubkey"
+        );
+        assert_eq!(
+            [0u8; 32],
+            token[42..74],
+            "digest section mismatch without privkey der"
+        );
+
+        let req = ForwardEndpointRequest {
+            url: "https://a/".into(),
+            server_pubkey: Some(ANOTHER_PUB_KEY.to_string()),
+            forward_privkey: None,
+        };
+        let token = make_cleartext_token(req).expect("couldn't make token from request");
+        assert_eq!(74, token.len(), "token length mismatch");
+        assert_ne!(
+            [0u8; 32],
+            token[10..42],
+            "digest section mismatch with pubkey"
+        );
+        assert_eq!(
+            [0u8; 32],
+            token[42..74],
+            "digest section mismatch without privkey der"
+        );
+
+        let req = ForwardEndpointRequest {
+            url: "https://a/".into(),
+            server_pubkey: Some(ANOTHER_PUB_KEY.to_string()),
+            forward_privkey: Some(PRIV_KEY_DER.to_string()),
+        };
+        let token = make_cleartext_token(req).expect("couldn't make token from request");
+        assert_eq!(74, token.len(), "token length mismatch");
+        assert_ne!(
+            [0u8; 32],
+            token[10..42],
+            "digest section mismatch with pubkey"
+        );
+        assert_ne!(
+            [0u8; 32],
+            token[42..74],
+            "digest section mismatch with privkey der"
+        );
+    }
+}

--- a/autoendpoint/src/extractors/mod.rs
+++ b/autoendpoint/src/extractors/mod.rs
@@ -2,6 +2,8 @@
 //! the incoming request data.
 
 pub mod authorization_check;
+pub mod forward_request;
+pub mod forward_token;
 pub mod message_id;
 pub mod new_channel_data;
 pub mod notification;

--- a/autoendpoint/src/extractors/subscription.rs
+++ b/autoendpoint/src/extractors/subscription.rs
@@ -160,7 +160,7 @@ impl FromRequest for Subscription {
 }
 
 /// Add back padding to a base64 string
-fn repad_base64(data: &str) -> Cow<'_, str> {
+pub fn repad_base64(data: &str) -> Cow<'_, str> {
     let trailing_chars = data.len() % 4;
 
     if trailing_chars != 0 {
@@ -240,7 +240,7 @@ fn version_1_validation(token: &[u8]) -> ApiResult<()> {
 /// NOTE: Some customers send a VAPID public key with incorrect padding and
 /// in standard base64 encoding. (Both of these violate the VAPID RFC)
 /// Prior python versions ignored these errors, so we should too.
-fn decode_public_key(public_key: &str) -> ApiResult<Vec<u8>> {
+pub fn decode_public_key(public_key: &str) -> ApiResult<Vec<u8>> {
     if public_key.contains(['/', '+']) {
         b64_decode_std(public_key.trim_end_matches('='))
     } else {
@@ -295,7 +295,7 @@ fn term_to_label(term: &str) -> String {
 /// - Make sure the expiration isn't too far into the future
 ///
 /// This is mostly taken care of by the jsonwebtoken library
-fn validate_vapid_jwt(
+pub fn validate_vapid_jwt(
     vapid: &VapidHeaderWithKey,
     settings: &Settings,
     metrics: &StatsdClient,

--- a/autoendpoint/src/routes/forward.rs
+++ b/autoendpoint/src/routes/forward.rs
@@ -1,0 +1,76 @@
+use actix_http::StatusCode;
+use actix_web::{
+    HttpResponse, HttpResponseBuilder,
+    web::{Bytes, Data},
+};
+
+use crate::{
+    error::{ApiError, ApiErrorKind, ApiResult},
+    extractors::{forward_request::ForwardRequest, forward_token::ForwardToken},
+    routers::RouterError,
+    server::AppState,
+};
+
+/// Forward request to the endpoint stored in the encrypted token
+pub async fn forward_route(
+    forward_req: ForwardRequest,
+    data: Bytes,
+    _app_state: Data<AppState>,
+) -> ApiResult<HttpResponse> {
+    if data.is_empty() {
+        return Ok(HttpResponse::Ok().finish());
+    }
+    let data_len = data.len();
+    if data_len > 4096 {
+        return Err(ApiError::from(RouterError::TooMuchData(data_len)));
+    }
+    let ret = forward_req
+        .0
+        .body(data)
+        .send()
+        .await
+        .map_err(|e| e.without_url())?;
+    Ok(HttpResponseBuilder::new(
+        // we could probably unwrap, as from_u16 can't have an invalid status code
+        StatusCode::from_u16(ret.status().as_u16())
+            .map_err(|_| ApiErrorKind::General("Unknown status code".into()))?,
+    )
+    .json(serde_json::json!({"msg": "upstream status code"})))
+}
+
+/// Creates an endpoint to forward notifications to another webpush server
+///
+/// The request body is a JSON deserialized to [ForwardEndpointRequest], containing:
+/// - url: URL to forward notifs to, must be HTTPS
+/// - server_pubkey: (optional) VAPID pubkey of the application server - uncompressed format URL-safe Base64 encoded
+/// - forward_privkey: (optional, requires server_pubkey): VAPID privkey to authorize forwarded requests, PEM format
+///
+/// **Example:**
+///
+/// ```json
+/// {
+///   "url": "https://myowndomain.tld/random1",
+///   "server_pubkey": "BA1Hxzyi1RUM1b5wjxsn7nGxAszw2u61m164i3MrAIxHF6YK5h4SDYic-dRuU_RcPcfA5aq9ojSwk5Y2EmclBPs",
+///   "forward_privkey": "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgZImOgpRszunnU3j1\noX5UQiX8KU4X2OdbENuvc/t8wpmhRANCAATN21Y1v8LmQueGpSG6o022gTbbYa4l\nbXWZXITsjknW1WHmELtouYpyXX7e41FiAMuDvcRwW2Nfehn/taHW/IXb\n-----END PRIVATE KEY-----"
+/// }
+/// ```
+///
+/// The endpoint contains an encrypted token which contains:
+/// - the push endpoint
+/// - the hash of the application server VAPID public key - or [0u8; 32]
+/// - the VAPID private key to authorize the outgoing request - or [0u8; 32]
+///
+/// The token contains a VAPID private key because:
+/// - We want to use VAPID on the receiving server
+/// - We can't use the same VAPID key for all outgoint requests, anyone who knows an endpoint
+///   authorized to receive push notifications from us would be able to push to that endpoint
+/// - So we need a different key for all endpoints
+pub async fn new_forward_endpoint_route(
+    token: ForwardToken,
+    app_state: Data<AppState>,
+) -> ApiResult<HttpResponse> {
+    let mut root = url::Url::parse(&app_state.settings.endpoint_url)
+        .map_err(|e| ApiErrorKind::General(format!("Cannot parse settings endpoint_url: {e}")))?;
+    root.set_path(&format!("/fpush/v1/{}", token.0));
+    Ok(HttpResponse::Ok().json(serde_json::json!({"url": root})))
+}

--- a/autoendpoint/src/routes/mod.rs
+++ b/autoendpoint/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod forward;
 pub mod health;
 pub mod registration;
 #[cfg(feature = "reliable_report")]

--- a/autoendpoint/src/server.rs
+++ b/autoendpoint/src/server.rs
@@ -31,7 +31,9 @@ use crate::metrics;
 #[cfg(feature = "stub")]
 use crate::routers::stub::router::StubRouter;
 use crate::routers::{apns::router::ApnsRouter, fcm::router::FcmRouter};
+use crate::routes::forward::new_forward_endpoint_route;
 use crate::routes::{
+    forward::forward_route,
     health::{health_route, lb_heartbeat_route, log_check, status_route, version_route},
     registration::{
         get_channels_route, new_channel_route, register_uaid_route, unregister_channel_route,
@@ -290,6 +292,11 @@ impl Server {
                     web::resource(["/wpush/{api_version}/{token}", "/wpush/{token}"])
                         .route(web::post().to(webpush_route)),
                 )
+                .service(
+                    web::resource("/fpush/v1/new")
+                        .route(web::post().to(new_forward_endpoint_route)),
+                )
+                .service(web::resource("/fpush/v1/{token}").route(web::post().to(forward_route)))
                 .service(
                     web::resource("/m/{message_id}")
                         .route(web::delete().to(delete_notification_route)),


### PR DESCRIPTION
For the context: #1114

This PR adds 2 endpoints:
- one to create a *forward endpoint*. It takes a JSON in input, with 3 parameters to the forward endpoint (cf. bellow)
- and the forward endpoint, to proxy the notification

The forward endpoint contains a fernet-encrypted token, that contains the targeted URL, the digest of the appserver public key (uncompressed format), and a private key (cf bellow)

It contains a private key to sign outgoing VAPID authorizations, because:
- we can't simply forward the incoming VAPID authorization header (different audience)
- we must use different VAPID key for all endpoints, else it would be possible to request any endpoint configured to work with autopush as soon as we know the (targeted) endpoint.

The private key is tested to not be the one used to send from the server, to avoid applications leaking their keys.

I've added tests for the 2 extractors.

I've some pending questions:
- Should I create a new ApiErrorKind for the endpoint to create new forward endpoints ? I often use ApiErrorKind::General there.
- Is it OK to disable redirections for app_state.http ? The redirection policy can't be set per-request for now, and it is only used for webpush requests to our own nodes.
- Should we had some metrics ?

The PR is a bit long, but half of the lines are the tests/documentation. I'm happy to edit the patch, and answer any question. I hope it will be considered, it answers a real need :)