### PR TITLE
feat: Add var prefixer to resolve grpcio builds under trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 FROM rust:1.91-bookworm AS builder
 ARG CRATE
 ARG BUILD_ARGS
+ARG CXXFLAGS
+ARG CMAKE_POLICY_VERSION_MINIMUM
 
 ADD . /app
 WORKDIR /app
@@ -17,7 +19,7 @@ RUN \
     cargo --version && \
     rustc --version && \
     mkdir -m 755 bin && \
-    cargo install --path $CRATE $BUILD_ARGS --locked --root /app
+    CXXFLAGS="$CXXFLAGS" CMAKE_POLICY_VERSION_MINIMUM="$CMAKE_POLICY_VERSION_MINIMUM" cargo install --path $CRATE $BUILD_ARGS --locked --root /app
 
 
 FROM debian:bookworm-slim

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ INSTALL_STAMP := .install.stamp
 
 .PHONY: docker-dev-build
 docker-dev-build:
+	echo $(CMAKE_POLICY_VERSION_MINIMUM)
 	docker build -f Dockerfile-dev -t autopush-dev .
 
 .PHONY: docker-init
@@ -105,7 +106,10 @@ notification-test-clean:
 
 .PHONY: build-profile
 build-profile: ##  Run the profiler with the `profile` profile. See Cargo.toml for details.
-	RUSTFLAGS="-C force-frame-pointers=yes" cargo build --profile profile
+    # `prefix_build_flags.py` is a hack to work around the fact that we need to set some platform specific env vars for the build, 
+	# but doing so in a Makefile is a nightmare. This way, we can just call this script with the same args we would 
+	# normally call cargo with, and it will add the necessary env vars before running the command.
+	python3 scripts/prefix_build_flags.py RUSTFLAGS="-C force-frame-pointers=yes" cargo build --profile profile
 
 .PHONY: format
 format: $(INSTALL_STAMP)  ##  Sort imports and reformats code

--- a/scripts/prefix_build_flags.py
+++ b/scripts/prefix_build_flags.py
@@ -1,0 +1,47 @@
+#! python3
+
+# If we are running on trixie+ we need to add a few env vars
+# to the build. Bash does not make this easy. So for now
+# we'll use this ugly hack script to check the version,
+# append the right flags, and run whatever you ask us to.
+import sys
+import os
+
+RUN = " ".join(sys.argv[1:])
+PREFIX = ""
+
+try:
+    # The version file is either a numeric (e.g. "12.3") or
+    # a codename (e.g."bookworm/sid")
+    # Since AFAIK, this only impact debian, skip if we don't have a debian version file.
+    with open("/etc/debian_version") as f:
+        version = f.read().strip().lower()
+        try:
+            # First try to parse as numeric
+            major_version = int(version.split(".")[0])
+        except ValueError:
+            # That didn't work, so try codename.
+            major_version = version.split("/")[0].lower()
+            match major_version:
+                case "bookworm":
+                    major_version = 12
+                case "bullseye":
+                    major_version = 11
+                case "buster":
+                    major_version = 10
+                case "stretch":
+                    major_version = 9
+                case "jessie":
+                    major_version = 8
+                case _:
+                    # Honestly, we don't care if it's older than bookworm.
+                    major_version = 13
+        if major_version > 12:
+            os.environ["CXXFLAGS"] = "-include cstdint"
+            os.environ["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
+            PREFIX = f"""CXXFLAGS='-include cstdint' CMAKE_POLICY_VERSION_MINIMUM=3.5"""
+except Exception as e:
+    print(f"Error: {e}", file=sys.stderr)
+
+print(f"""{PREFIX} {RUN}""")
+os.system(f"""{PREFIX} {RUN}""")


### PR DESCRIPTION
This is not a full fix, but rather a bandaid. This will allow builds to run on debian trixie (and hopefully later builds).

I am not fond of this hack, but it should apply the correct flags to the cargo builds, only when needed (to prevent other complications.)

Issue [PUSH-582](https://mozilla-hub.atlassian.net/browse/PUSH-582)

[PUSH-582]: https://mozilla-hub.atlassian.net/browse/PUSH-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ