### PR TITLE
chore(grpc): Replace grpcio with tonic

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,5 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0437", # Bound by grpcio 0.13
     "RUSTSEC-2023-0071", # Bound by jsonwebtoken 10.3.0
     "RUSTSEC-2026-0049", # Bound by rustls 0.22.4, bound by tokio-rustls 0.25, hyper-rustls 0.26, and a2 0.10
     "RUSTSEC-2026-0098", # Bound by rustls 0.22.4, bound by tokio-rustls 0.25, hyper-rustls 0.26, and a2 0.10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,15 +373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,7 +532,7 @@ dependencies = [
  "autoconnect_ws",
  "autopush_common",
  "docopt",
- "env_logger 0.11.10",
+ "env_logger",
  "mimalloc",
  "sentry",
  "serde",
@@ -728,17 +719,15 @@ dependencies = [
  "form_urlencoded",
  "futures 0.3.32",
  "futures-util",
+ "gcp_auth",
  "gethostname",
- "google-cloud-rust-raw",
- "grpcio",
- "grpcio-sys",
+ "googleapis-tonic-google-bigtable-v2",
  "lazy_static",
  "mockall",
  "mockito 0.31.1",
  "num_cpus",
  "openssl",
  "prometheus-client",
- "protobuf",
  "rand 0.10.1",
  "redis",
  "redis-module",
@@ -762,6 +751,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
  "url",
  "uuid",
  "woothee",
@@ -823,6 +813,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,29 +893,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "clap",
- "env_logger 0.9.3",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote 1.0.45",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "which",
-]
 
 [[package]]
 name = "bindgen"
@@ -938,15 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "boringssl-src"
-version = "0.6.0+e46383f"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edec42197c014d84ea2396589f0da14b2257f63f319442b5e8475a077b90457"
-dependencies = [
- "cmake",
 ]
 
 [[package]]
@@ -1085,21 +1086,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -1828,19 +1814,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
@@ -2143,6 +2116,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcp_auth"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,14 +2227,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "google-cloud-rust-raw"
-version = "0.16.1"
+name = "googleapis-tonic-google-api"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864a48916c62ddbd1dc289be6d041d8ca61160c9c6169298e5cf3da11baf8370"
+checksum = "f4411485f14b532ed4a23fa143a355e9ff148def1727c18d262eceb0ceccea90"
 dependencies = [
- "futures 0.3.32",
- "grpcio",
- "protobuf",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-bigtable-v2"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18c5c00569b5ea5ab8997e68bd4e88e77a32fe54b12f1a0df00f1d44bea2353"
+dependencies = [
+ "googleapis-tonic-google-api",
+ "googleapis-tonic-google-rpc",
+ "googleapis-tonic-google-type",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-rpc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f48f43a381f9a1b6dab85d87635a255602a516a2d691fa372c5bb340a3659d6"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-type"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2e3893709d3cca36dfc480a3f1d75e40872779d202514a41dc6b0415757381"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -2247,37 +2286,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "grpcio"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e398946b5721d72478eb647260a1b7c1d5f70f0de35399846c3913bd369a33e"
-dependencies = [
- "futures-executor",
- "futures-util",
- "grpcio-sys",
- "libc",
- "log",
- "parking_lot 0.12.5",
- "protobuf",
-]
-
-[[package]]
-name = "grpcio-sys"
-version = "0.13.0+1.56.2-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dae9132320ae1b03ea55b5ddc88ca72a31fb85fa631a241a40157f5feffe43"
-dependencies = [
- "bindgen 0.59.2",
- "boringssl-src",
- "cc",
- "cmake",
- "libc",
- "libz-sys",
- "pkg-config",
- "walkdir",
 ]
 
 [[package]]
@@ -2506,12 +2514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2590,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2845,6 +2860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,18 +3080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linkme"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,6 +3160,12 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3857,6 +3875,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,10 +4078,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
+name = "prost"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
 
 [[package]]
 name = "quinn"
@@ -4274,7 +4338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d3b95d9fe5b8681bacea6532bbc7632590ae4499cecc8e019685b515fddda71"
 dependencies = [
  "backtrace",
- "bindgen 0.66.1",
+ "bindgen",
  "bitflags 2.11.1",
  "cc",
  "cfg-if 1.0.4",
@@ -4635,6 +4699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5495,12 +5560,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -5691,28 +5750,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -5946,6 +5987,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "socket2 0.6.3",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5953,11 +6036,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6021,6 +6108,16 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -6097,12 +6194,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -6234,12 +6325,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -52,14 +52,15 @@ woothee = "0.13"
 tokio = { workspace = true, features = ["macros", "sync" ] }
 
 # #[cfg(bigtable)] for this section.
-# the following three crates must match what is specifed in google-cloud-rust-raw's dependencies
-google-cloud-rust-raw = { version = "0.16", default-features = false, features = [
-    "bigtable",
+# Pre-generated tonic/prost stubs for the `google.bigtable.v2` API.
+googleapis-tonic-google-bigtable-v2 = { version = "0.38", optional = true }
+tonic = { version = "0.14", features = [
+    "tls-ring",
+    "tls-native-roots",
 ], optional = true }
-grpcio = { version = "=0.13.0", features = ["openssl"], optional = true }
-grpcio-sys = { version = "=0.13.0", optional = true }
+# Application Default Credentials (ADC) token provider for Google APIs.
+gcp_auth = { version = "0.12", optional = true }
 prometheus-client = { version = "0.24", optional = true }
-protobuf = { version = "=2.28.0", optional = true } # grpcio does not support protobuf 3+
 form_urlencoded = { version = "1.2", optional = true }
 
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"], optional = true }
@@ -78,10 +79,9 @@ tempfile = "3.2.0"
 # NOTE: Do not set a `default` here, rather specify them in the calling library.
 # This is to reduce complexity around feature specification.
 bigtable = [
-    "dep:google-cloud-rust-raw",
-    "dep:grpcio",
-    "dep:grpcio-sys",
-    "dep:protobuf",
+    "dep:googleapis-tonic-google-bigtable-v2",
+    "dep:tonic",
+    "dep:gcp_auth",
     "dep:form_urlencoded",
 ]
 # used for testing big table, requires an external bigtable emulator running.

--- a/autopush-common/src/db/bigtable/bigtable_client/error.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/error.rs
@@ -100,30 +100,30 @@ impl MutateRowStatus {
 #[derive(Debug, Error)]
 pub enum BigTableError {
     #[error("Invalid Row Response: {0}")]
-    InvalidRowResponse(#[source] grpcio::Error),
+    InvalidRowResponse(#[source] tonic::Status),
 
     #[error("Invalid Chunk")]
     InvalidChunk(String),
 
     #[error("BigTable read error: {0}")]
-    Read(#[source] grpcio::Error),
+    Read(#[source] tonic::Status),
 
     #[error("BigTable write timestamp error: {0}")]
     WriteTime(#[source] std::time::SystemTimeError),
 
     #[error("Bigtable write error: {0}")]
-    Write(#[source] grpcio::Error),
+    Write(#[source] tonic::Status),
 
-    #[error("GRPC Error: {0}")]
-    GRPC(#[source] grpcio::Error),
+    #[error("BigTable connection error: {0}")]
+    Connect(#[source] tonic::transport::Error),
+
+    #[error("BigTable authentication error: {0}")]
+    Auth(#[source] gcp_auth::Error),
 
     /// Return a GRPC status code and any message.
     /// See https://grpc.github.io/grpc/core/md_doc_statuscodes.html
     #[error("Bigtable status response: {0:?}")]
     Status(MutateRowStatus, String),
-
-    #[error("BigTable Admin Error: {0}")]
-    Admin(String, Option<String>),
 
     /// General Pool errors
     #[error("Pool Error: {0}")]
@@ -167,12 +167,12 @@ impl ReportableError for BigTableError {
             BigTableError::InvalidChunk(_) => "storage.bigtable.error.invalid_chunk",
             BigTableError::Read(_) => "storage.bigtable.error.read",
             BigTableError::Write(_) => "storage.bigtable.error.write",
+            BigTableError::Connect(_) => "storage.bigtable.error.connect",
+            BigTableError::Auth(_) => "storage.bigtable.error.auth",
             BigTableError::Status(_, _) => "storage.bigtable.error.status",
             BigTableError::WriteTime(_) => "storage.bigtable.error.writetime",
-            BigTableError::Admin(_, _) => "storage.bigtable.error.admin",
             BigTableError::Pool(_) => "storage.bigtable.error.pool",
             BigTableError::PoolTimeout(_) => "storage.bigtable.error.pool_timeout",
-            BigTableError::GRPC(_) => "storage.bigtable.error.grpc",
             BigTableError::Config(_) => "storage.bigtable.error.config",
             BigTableError::CircuitBreakerOpen => "storage.bigtable.error.circuit_breaker",
         };
@@ -191,20 +191,14 @@ impl ReportableError for BigTableError {
         match self {
             BigTableError::InvalidRowResponse(s) => vec![("error", s.to_string())],
             BigTableError::InvalidChunk(s) => vec![("error", s.to_string())],
-            BigTableError::GRPC(s) => vec![("error", s.to_string())],
             BigTableError::Read(s) => vec![("error", s.to_string())],
             BigTableError::Write(s) => vec![("error", s.to_string())],
+            BigTableError::Connect(e) => vec![("error", e.to_string())],
+            BigTableError::Auth(e) => vec![("error", e.to_string())],
             BigTableError::Status(code, s) => {
                 vec![("code", code.to_string()), ("error", s.to_string())]
             }
             BigTableError::WriteTime(s) => vec![("error", s.to_string())],
-            BigTableError::Admin(s, raw) => {
-                let mut x = vec![("error", s.to_owned())];
-                if let Some(raw) = raw {
-                    x.push(("raw", raw.to_string()));
-                };
-                x
-            }
             BigTableError::Pool(e) => vec![("error", e.to_string())],
             _ => vec![],
         }

--- a/autopush-common/src/db/bigtable/bigtable_client/merge.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/merge.rs
@@ -2,9 +2,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::mem;
 use std::time::{Duration, SystemTime};
 
-use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::ReadRowsResponse;
-use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::CellChunk;
-use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::cell_chunk::RowStatus;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::{
+    ReadRowsResponse,
+    read_rows_response::{CellChunk, cell_chunk::RowStatus},
+};
 use tonic::Streaming;
 
 use super::{FamilyId, Qualifier, RowKey, cell::Cell, error::BigTableError, row::Row};

--- a/autopush-common/src/db/bigtable/bigtable_client/merge.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/merge.rs
@@ -2,11 +2,22 @@ use std::collections::{BTreeMap, HashMap};
 use std::mem;
 use std::time::{Duration, SystemTime};
 
-use futures::StreamExt;
-use google_cloud_rust_raw::bigtable::v2::bigtable::{ReadRowsResponse, ReadRowsResponse_CellChunk};
-use grpcio::ClientSStreamReceiver;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::ReadRowsResponse;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::CellChunk;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::cell_chunk::RowStatus;
+use tonic::Streaming;
 
 use super::{FamilyId, Qualifier, RowKey, cell::Cell, error::BigTableError, row::Row};
+
+/// Return whether this chunk signals a row reset.
+fn is_reset_row(chunk: &CellChunk) -> bool {
+    matches!(chunk.row_status, Some(RowStatus::ResetRow(true)))
+}
+
+/// Return whether this chunk commits the row.
+fn has_commit_row(chunk: &CellChunk) -> bool {
+    matches!(chunk.row_status, Some(RowStatus::CommitRow(_)))
+}
 
 /// List of the potential states when we are reading each value from the
 /// returned stream and composing a "row"
@@ -88,7 +99,7 @@ pub struct RowMerger {
 
 impl RowMerger {
     /// discard data so far and return to a neutral state.
-    fn reset_row(&mut self, chunk: ReadRowsResponse_CellChunk) -> Result<&mut Self, BigTableError> {
+    fn reset_row(&mut self, chunk: CellChunk) -> Result<&mut Self, BigTableError> {
         if self.state == ReadState::RowStart {
             return Err(BigTableError::InvalidChunk("Bare Reset".to_owned()));
         };
@@ -97,12 +108,12 @@ impl RowMerger {
                 "Reset chunk has a row key".to_owned(),
             ));
         };
-        if chunk.has_family_name() {
+        if chunk.family_name.is_some() {
             return Err(BigTableError::InvalidChunk(
                 "Reset chunk has a family_name".to_owned(),
             ));
         }
-        if chunk.has_qualifier() {
+        if chunk.qualifier.is_some() {
             return Err(BigTableError::InvalidChunk(
                 "Reset chunk has a qualifier".to_owned(),
             ));
@@ -112,7 +123,7 @@ impl RowMerger {
                 "Reset chunk has a timestamp".to_owned(),
             ));
         }
-        if !chunk.get_labels().is_empty() {
+        if !chunk.labels.is_empty() {
             return Err(BigTableError::InvalidChunk(
                 "Reset chunk has a labels".to_owned(),
             ));
@@ -130,22 +141,19 @@ impl RowMerger {
 
     /// The initial row contains the first cell data. There may be additional data that we
     /// have to use later, so capture that as well.
-    fn row_start(
-        &mut self,
-        chunk: &mut ReadRowsResponse_CellChunk,
-    ) -> Result<&Self, BigTableError> {
+    fn row_start(&mut self, chunk: &mut CellChunk) -> Result<&Self, BigTableError> {
         if chunk.row_key.is_empty() {
             return Err(BigTableError::InvalidChunk(
                 "New row is missing a row key".to_owned(),
             ));
         }
-        if chunk.has_family_name() {
+        if let Some(family_name) = &chunk.family_name {
             info!(
                 "👪Family name: {}: {:?}",
                 String::from_utf8(chunk.row_key.clone()).unwrap_or_default(),
-                &chunk.get_family_name()
+                family_name
             );
-            self.last_seen_cell_family = Some(chunk.get_family_name().get_value().to_owned());
+            self.last_seen_cell_family = Some(family_name.clone());
         }
         if let Some(last_key) = self.last_seen_row_key.clone()
             && last_key.as_bytes().to_vec() >= chunk.row_key
@@ -166,17 +174,13 @@ impl RowMerger {
 
     /// cell_start seems to be the main worker. It starts a new cell value (rows contain cells, which
     /// can have multiple versions).
-    fn cell_start(
-        &mut self,
-        chunk: &mut ReadRowsResponse_CellChunk,
-    ) -> Result<&Self, BigTableError> {
+    fn cell_start(&mut self, chunk: &mut CellChunk) -> Result<&Self, BigTableError> {
         // cells must have qualifiers.
-        if !chunk.has_qualifier() {
+        let Some(qualifier) = chunk.qualifier.take() else {
             self.state = ReadState::CellComplete;
             return Ok(self);
             // return Err(BigTableError::InvalidChunk("Cell missing qualifier for new cell".to_owned()))
-        }
-        let qualifier = chunk.take_qualifier().get_value().to_vec();
+        };
         let row = &mut self.row_in_progress;
 
         if !row.cells.is_empty()
@@ -189,11 +193,8 @@ impl RowMerger {
         }
 
         let cell = &mut row.cell_in_progress;
-        if chunk.has_family_name() {
-            chunk
-                .take_family_name()
-                .get_value()
-                .clone_into(&mut cell.family);
+        if let Some(family_name) = chunk.family_name.take() {
+            cell.family = family_name;
         } else {
             if self.last_seen_cell_family.is_none() {
                 return Err(BigTableError::InvalidChunk(
@@ -213,11 +214,7 @@ impl RowMerger {
             SystemTime::UNIX_EPOCH + Duration::from_micros(chunk.timestamp_micros as u64);
 
         // If there are additional labels for this cell, record them.
-        // can't call map, so do this the semi-hard way
-        let mut labels = chunk.take_labels();
-        while let Some(label) = labels.pop() {
-            cell.labels.push(label)
-        }
+        cell.labels.append(&mut chunk.labels);
 
         // Pre-allocate space for this cell version data. The data will be delivered in
         // multiple chunks. (Not strictly neccessary, but can save us some future allocs)
@@ -235,10 +232,7 @@ impl RowMerger {
 
     /// Continue adding data to the cell version. Cell data may exceed a chunk's max size,
     /// so we contine feeding data into it.
-    fn cell_in_progress(
-        &mut self,
-        chunk: &mut ReadRowsResponse_CellChunk,
-    ) -> Result<&Self, BigTableError> {
+    fn cell_in_progress(&mut self, chunk: &mut CellChunk) -> Result<&Self, BigTableError> {
         let row = &mut self.row_in_progress;
         let cell = &mut row.cell_in_progress;
 
@@ -249,29 +243,29 @@ impl RowMerger {
                     "Found row key mid cell".to_owned(),
                 ));
             }
-            if chunk.has_family_name() {
+            if chunk.family_name.is_some() {
                 return Err(BigTableError::InvalidChunk(
                     "Found family name mid cell".to_owned(),
                 ));
             }
-            if chunk.has_qualifier() {
+            if chunk.qualifier.is_some() {
                 return Err(BigTableError::InvalidChunk(
                     "Found qualifier mid cell".to_owned(),
                 ));
             }
-            if chunk.get_timestamp_micros() > 0 {
+            if chunk.timestamp_micros > 0 {
                 return Err(BigTableError::InvalidChunk(
                     "Found timestamp mid cell".to_owned(),
                 ));
             }
-            if chunk.get_labels().is_empty() {
+            if chunk.labels.is_empty() {
                 return Err(BigTableError::InvalidChunk(
                     "Found labels mid cell".to_owned(),
                 ));
             }
         }
 
-        let mut val = chunk.take_value();
+        let mut val = mem::take(&mut chunk.value);
         cell.value_index += val.len();
         cell.value.append(&mut val);
 
@@ -285,10 +279,7 @@ impl RowMerger {
     }
 
     /// Wrap up a cell that's been in progress.
-    fn cell_complete(
-        &mut self,
-        chunk: &mut ReadRowsResponse_CellChunk,
-    ) -> Result<&Self, BigTableError> {
+    fn cell_complete(&mut self, chunk: &mut CellChunk) -> Result<&Self, BigTableError> {
         let row_in_progress = &mut self.row_in_progress;
         let cell_in_progress = &mut row_in_progress.cell_in_progress;
 
@@ -340,7 +331,7 @@ impl RowMerger {
         cell_in_progress.value_index = 0;
 
         // If this isn't the last item in the row, keep going.
-        self.state = if !chunk.has_commit_row() {
+        self.state = if !has_commit_row(chunk) {
             ReadState::CellStart
         } else {
             ReadState::RowComplete
@@ -350,10 +341,7 @@ impl RowMerger {
     }
 
     /// wrap up a row, reinitialize our state to read the next row.
-    fn row_complete(
-        &mut self,
-        _chunk: &mut ReadRowsResponse_CellChunk,
-    ) -> Result<Row, BigTableError> {
+    fn row_complete(&mut self, _chunk: &mut CellChunk) -> Result<Row, BigTableError> {
         // now that we're done, write a clean version.
         let row = mem::take(&mut self.row_in_progress);
         self.state = ReadState::RowStart;
@@ -377,7 +365,7 @@ impl RowMerger {
 
     /// Iterate through all the returned chunks and compile them into a hash of finished cells indexed by row_key
     pub async fn process_chunks(
-        mut stream: ClientSStreamReceiver<ReadRowsResponse>,
+        mut stream: Streaming<ReadRowsResponse>,
     ) -> Result<BTreeMap<RowKey, Row>, BigTableError> {
         // Work object
         let mut merger = Self::default();
@@ -385,25 +373,15 @@ impl RowMerger {
         // finished collection
         let mut rows = BTreeMap::<RowKey, Row>::new();
 
-        while let (Some(row_resp_res), s) = StreamExt::into_future(stream).await {
-            stream = s;
-
-            // Bigtable's responses are not reliable.
-            // A read can fail for any number of reasons and return either 500 class errors or a corrupted data block,
-            // depending on what system failed on the Bigtable side.
-            // We want to retry the read in those cases and pick up from where we left off.
-            let row = match row_resp_res {
-                Ok(v) => v,
-                Err(e) => return Err(BigTableError::InvalidRowResponse(e)),
-            };
-            /*
-            ReadRowsResponse:
-                pub chunks: ::protobuf::RepeatedField<ReadRowsResponse_CellChunk>,
-                pub last_scanned_row_key: ::std::vec::Vec<u8>,
-                // special fields
-                pub unknown_fields: ::protobuf::UnknownFields,
-                pub cached_size: ::protobuf::CachedSize,
-            */
+        // Bigtable's responses are not reliable.
+        // A read can fail for any number of reasons and return either 500 class errors or a corrupted data block,
+        // depending on what system failed on the Bigtable side.
+        // We want to retry the read in those cases and pick up from where we left off.
+        while let Some(row) = stream
+            .message()
+            .await
+            .map_err(BigTableError::InvalidRowResponse)?
+        {
             if !row.last_scanned_row_key.is_empty() {
                 let row_key = String::from_utf8(row.last_scanned_row_key).unwrap_or_default();
                 if merger.last_seen_row_key.clone().unwrap_or_default() >= row_key {
@@ -416,7 +394,7 @@ impl RowMerger {
 
             for mut chunk in row.chunks {
                 debug!("🧩 Chunk >> {:?}", &chunk);
-                if chunk.get_reset_row() {
+                if is_reset_row(&chunk) {
                     debug!("‼ resetting row");
                     merger.reset_row(chunk)?;
                     continue;
@@ -427,7 +405,7 @@ impl RowMerger {
                     merger.row_start(&mut chunk)?;
                 }
                 if merger.state == ReadState::CellStart {
-                    debug!("🟡   cell start {:?}", chunk.get_qualifier());
+                    debug!("🟡   cell start {:?}", chunk.qualifier);
                     merger.cell_start(&mut chunk)?;
                 }
                 if merger.state == ReadState::CellInProgress {
@@ -442,7 +420,7 @@ impl RowMerger {
                     debug! {"🟧 row complete"};
                     let finished_row = merger.row_complete(&mut chunk)?;
                     rows.insert(finished_row.row_key.clone(), finished_row);
-                } else if chunk.has_commit_row() {
+                } else if has_commit_row(&chunk) {
                     return Err(BigTableError::InvalidChunk(format!(
                         "Chunk tried to commit in row in wrong state {:?}",
                         merger.state

--- a/autopush-common/src/db/bigtable/bigtable_client/metadata.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/metadata.rs
@@ -1,3 +1,7 @@
+use tonic::metadata::{AsciiMetadataValue, MetadataMap};
+
+use super::error::BigTableError;
+
 /// gRPC metadata Resource prefix header
 ///
 /// Generic across Google APIs. This "improves routing by the backend" as
@@ -31,7 +35,7 @@ const LEADER_AWARE_KEY: &str = "x-goog-spanner-route-to-leader";
 /// Its meaning is not to be known to the uninitiated.
 const USER_AGENT: &str = "gl-external/1.0 gccl/1.0";
 
-/// Builds the [grpcio::Metadata] for all db operations
+/// Builds the [tonic::metadata::MetadataMap] for all db operations
 #[derive(Default)]
 pub struct MetadataBuilder<'a> {
     prefix: &'a str,
@@ -62,19 +66,25 @@ impl<'a> MetadataBuilder<'a> {
         self
     }
 
-    /// Build the [grpcio::Metadata]
-    pub fn build(self) -> Result<grpcio::Metadata, grpcio::Error> {
-        let mut meta = grpcio::MetadataBuilder::new();
+    /// Build the [MetadataMap]
+    pub fn build(self) -> Result<MetadataMap, BigTableError> {
+        let mut meta = MetadataMap::new();
 
-        meta.add_str(PREFIX_KEY, self.prefix)?;
-        meta.add_str(METRICS_KEY, USER_AGENT)?;
+        meta.insert(PREFIX_KEY, Self::value(self.prefix)?);
+        meta.insert(METRICS_KEY, Self::value(USER_AGENT)?);
         if self.route_to_leader {
-            meta.add_str(LEADER_AWARE_KEY, "true")?;
+            meta.insert(LEADER_AWARE_KEY, Self::value("true")?);
         }
         if !self.routing_params.is_empty() {
-            meta.add_str(ROUTING_KEY, &self.routing_header())?;
+            let routing_header = self.routing_header();
+            meta.insert(ROUTING_KEY, Self::value(&routing_header)?);
         }
-        Ok(meta.build())
+        Ok(meta)
+    }
+
+    fn value(val: &str) -> Result<AsciiMetadataValue, BigTableError> {
+        AsciiMetadataValue::try_from(val)
+            .map_err(|e| BigTableError::Config(format!("Invalid gRPC metadata value: {e}")))
     }
 
     fn routing_header(self) -> String {
@@ -90,8 +100,6 @@ impl<'a> MetadataBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str};
-
     use super::{
         LEADER_AWARE_KEY, METRICS_KEY, MetadataBuilder, PREFIX_KEY, ROUTING_KEY, USER_AGENT,
     };
@@ -107,16 +115,12 @@ mod tests {
             .routing_param("foo", "bar baz")
             .build()
             .unwrap();
-        let meta: HashMap<_, _> = meta.into_iter().collect();
 
         assert_eq!(meta.len(), 3);
-        assert_eq!(str::from_utf8(meta.get(PREFIX_KEY).unwrap()).unwrap(), DB);
+        assert_eq!(meta.get(PREFIX_KEY).unwrap().to_str().unwrap(), DB);
+        assert_eq!(meta.get(METRICS_KEY).unwrap().to_str().unwrap(), USER_AGENT);
         assert_eq!(
-            str::from_utf8(meta.get(METRICS_KEY).unwrap()).unwrap(),
-            USER_AGENT
-        );
-        assert_eq!(
-            str::from_utf8(meta.get(ROUTING_KEY).unwrap()).unwrap(),
+            meta.get(ROUTING_KEY).unwrap().to_str().unwrap(),
             format!("session={SESSION}&foo=bar+baz")
         );
     }
@@ -127,11 +131,10 @@ mod tests {
             .route_to_leader(true)
             .build()
             .unwrap();
-        let meta: HashMap<_, _> = meta.into_iter().collect();
 
         assert_eq!(meta.len(), 3);
         assert_eq!(
-            str::from_utf8(meta.get(LEADER_AWARE_KEY).unwrap()).unwrap(),
+            meta.get(LEADER_AWARE_KEY).unwrap().to_str().unwrap(),
             "true"
         );
     }

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -13,11 +13,7 @@ use cadence::StatsdClient;
 #[cfg(feature = "reliable_report")]
 use chrono::TimeDelta;
 use gcp_auth::TokenProvider;
-// The generated stubs keep both the service requests/responses and the data
-// types in a single `v2` module. Alias it twice to retain the historical
-// `bigtable::` (requests) and `data::` (row/filter/mutation types) split.
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2 as bigtable;
-use googleapis_tonic_google_bigtable_v2::google::bigtable::v2 as data;
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::bigtable_client::BigtableClient;
 use serde_json::{from_str, json};
 use tonic::metadata::{AsciiMetadataValue, MetadataMap};
@@ -172,22 +168,22 @@ pub struct BigTableClientImpl {
 }
 
 /// Return a a RowFilter matching the GC policy of the router Column Family
-fn router_gc_policy_filter() -> data::RowFilter {
-    data::RowFilter {
-        filter: Some(data::row_filter::Filter::CellsPerColumnLimitFilter(1)),
+fn router_gc_policy_filter() -> bigtable::RowFilter {
+    bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::CellsPerColumnLimitFilter(1)),
     }
 }
 
 /// Return a chain of RowFilters matching the GC policy of the message Column
 /// Families
-fn message_gc_policy_filter() -> Result<Vec<data::RowFilter>, error::BigTableError> {
+fn message_gc_policy_filter() -> Result<Vec<bigtable::RowFilter>, error::BigTableError> {
     let bt_now: i64 = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(error::BigTableError::WriteTime)?
         .as_millis() as i64;
-    let timestamp_filter = data::RowFilter {
-        filter: Some(data::row_filter::Filter::TimestampRangeFilter(
-            data::TimestampRange {
+    let timestamp_filter = bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::TimestampRangeFilter(
+            bigtable::TimestampRange {
                 start_timestamp_micros: bt_now * 1000,
                 end_timestamp_micros: 0,
             },
@@ -198,9 +194,9 @@ fn message_gc_policy_filter() -> Result<Vec<data::RowFilter>, error::BigTableErr
 }
 
 /// Return a Column family regex RowFilter
-fn family_filter(regex: String) -> data::RowFilter {
-    data::RowFilter {
-        filter: Some(data::row_filter::Filter::FamilyNameRegexFilter(regex)),
+fn family_filter(regex: String) -> bigtable::RowFilter {
+    bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::FamilyNameRegexFilter(regex)),
     }
 }
 
@@ -228,16 +224,16 @@ fn escape_bytes(bytes: &[u8]) -> Vec<u8> {
 
 /// Return a chain of RowFilters limiting to a match of the specified
 /// `version`'s column value
-fn version_filter(version: &Uuid) -> Vec<data::RowFilter> {
-    let cq_filter = data::RowFilter {
-        filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+fn version_filter(version: &Uuid) -> Vec<bigtable::RowFilter> {
+    let cq_filter = bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::ColumnQualifierRegexFilter(
             "^version$".as_bytes().to_vec(),
         )),
     };
-    let value_filter = data::RowFilter {
-        filter: Some(data::row_filter::Filter::ValueRegexFilter(escape_bytes(
-            version.as_bytes(),
-        ))),
+    let value_filter = bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::ValueRegexFilter(
+            escape_bytes(version.as_bytes()),
+        )),
     };
 
     vec![
@@ -258,11 +254,11 @@ fn new_version_cell(timestamp: SystemTime) -> cell::Cell {
 }
 
 /// Return a RowFilter chain from multiple RowFilters
-fn filter_chain(filters: Vec<data::RowFilter>) -> data::RowFilter {
-    data::RowFilter {
-        filter: Some(data::row_filter::Filter::Chain(data::row_filter::Chain {
-            filters,
-        })),
+fn filter_chain(filters: Vec<bigtable::RowFilter>) -> bigtable::RowFilter {
+    bigtable::RowFilter {
+        filter: Some(bigtable::row_filter::Filter::Chain(
+            bigtable::row_filter::Chain { filters },
+        )),
     }
 }
 
@@ -275,7 +271,7 @@ fn read_row_request(
     bigtable::ReadRowsRequest {
         table_name: table_name.to_owned(),
         app_profile_id: app_profile_id.to_owned(),
-        rows: Some(data::RowSet {
+        rows: Some(bigtable::RowSet {
             row_keys: vec![row_key.as_bytes().to_vec()],
             row_ranges: Vec::new(),
         }),
@@ -595,7 +591,7 @@ impl BigTableClientImpl {
     fn get_mutations(
         &self,
         cells: HashMap<FamilyId, Vec<crate::db::bigtable::bigtable_client::cell::Cell>>,
-    ) -> Result<Vec<data::Mutation>, error::BigTableError> {
+    ) -> Result<Vec<bigtable::Mutation>, error::BigTableError> {
         let mut mutations = Vec::new();
         for (family_id, cells) in cells {
             for cell in cells {
@@ -604,15 +600,18 @@ impl BigTableClientImpl {
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .map_err(error::BigTableError::WriteTime)?;
                 debug!("🉑 expiring in {:?}", timestamp.as_millis());
-                mutations.push(data::Mutation {
-                    mutation: Some(data::mutation::Mutation::SetCell(data::mutation::SetCell {
-                        family_name: family_id.clone(),
-                        column_qualifier: cell.qualifier.clone().into_bytes(),
-                        // Yes, this is passing milli bounded time as a micro. Otherwise I get
-                        // a `Timestamp granularity mismatch` error
-                        timestamp_micros: (timestamp.as_millis() * 1000) as i64,
-                        value: cell.value,
-                    })),
+                mutations.push(bigtable::Mutation {
+                    mutation: Some(bigtable::mutation::Mutation::SetCell(
+                        bigtable::mutation::SetCell {
+                            family_name: family_id.clone(),
+                            column_qualifier: cell.qualifier.clone().into_bytes(),
+                            // Bigtable tables use millisecond cell-timestamp granularity;
+                            // timestamp_micros must be a multiple of 1,000 or the server
+                            // rejects the mutation with a granularity mismatch.
+                            timestamp_micros: (timestamp.as_millis() * 1000) as i64,
+                            value: cell.value,
+                        },
+                    )),
                 });
             }
         }
@@ -629,7 +628,7 @@ impl BigTableClientImpl {
     async fn check_and_mutate_row(
         &self,
         row: row::Row,
-        filter: data::RowFilter,
+        filter: bigtable::RowFilter,
         state: bool,
     ) -> Result<bool, error::BigTableError> {
         let mut req = self.check_and_mutate_row_request(&row.row_key);
@@ -671,16 +670,16 @@ impl BigTableClientImpl {
         &self,
         family: &str,
         column_names: &[&str],
-        time_range: Option<&data::TimestampRange>,
-    ) -> Result<Vec<data::Mutation>, error::BigTableError> {
+        time_range: Option<&bigtable::TimestampRange>,
+    ) -> Result<Vec<bigtable::Mutation>, error::BigTableError> {
         let mut mutations = Vec::new();
         for column in column_names {
             // DeleteFromRow -- Delete all cells for a given row.
             // DeleteFromFamily -- Delete all cells from a family for a given row.
             // DeleteFromColumn -- Delete all cells from a column name for a given row, restricted by timestamp range.
-            mutations.push(data::Mutation {
-                mutation: Some(data::mutation::Mutation::DeleteFromColumn(
-                    data::mutation::DeleteFromColumn {
+            mutations.push(bigtable::Mutation {
+                mutation: Some(bigtable::mutation::Mutation::DeleteFromColumn(
+                    bigtable::mutation::DeleteFromColumn {
                         family_name: family.to_owned(),
                         column_qualifier: column.as_bytes().to_vec(),
                         time_range: time_range.cloned(),
@@ -694,9 +693,9 @@ impl BigTableClientImpl {
     /// Delete all the cells for the given row. NOTE: This will drop the row.
     async fn delete_row(&self, row_key: &str) -> Result<(), error::BigTableError> {
         let mut req = self.mutate_row_request(row_key);
-        req.mutations = vec![data::Mutation {
-            mutation: Some(data::mutation::Mutation::DeleteFromRow(
-                data::mutation::DeleteFromRow {},
+        req.mutations = vec![bigtable::Mutation {
+            mutation: Some(bigtable::mutation::Mutation::DeleteFromRow(
+                bigtable::mutation::DeleteFromRow {},
             )),
         }];
         self.mutate_row(req).await
@@ -923,8 +922,8 @@ impl BigtableDb {
         // other than it does not return an error.
         let random_uaid = Uuid::new_v4().simple().to_string();
         let mut req = read_row_request(&self.table_name, app_profile_id, &random_uaid);
-        req.filter = Some(data::RowFilter {
-            filter: Some(data::row_filter::Filter::BlockAllFilter(true)),
+        req.filter = Some(bigtable::RowFilter {
+            filter: Some(bigtable::row_filter::Filter::BlockAllFilter(true)),
         });
         let _r = retry_policy(RETRY_COUNT)
             .retry_if(
@@ -958,8 +957,8 @@ impl DbClient for BigTableClientImpl {
         let row = self.user_to_row(user, version);
 
         // Only add when the user doesn't already exist
-        let row_key_filter = data::RowFilter {
-            filter: Some(data::row_filter::Filter::RowKeyRegexFilter(
+        let row_key_filter = bigtable::RowFilter {
+            filter: Some(bigtable::row_filter::Filter::RowKeyRegexFilter(
                 format!("^{}$", row.row_key).into_bytes(),
             )),
         };
@@ -1127,8 +1126,8 @@ impl DbClient for BigTableClientImpl {
         let row_key = uaid.simple().to_string();
         let mut req = self.read_row_request(&row_key);
 
-        let cq_filter = data::RowFilter {
-            filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+        let cq_filter = bigtable::RowFilter {
+            filter: Some(bigtable::row_filter::Filter::ColumnQualifierRegexFilter(
                 "^chid:.*$".as_bytes().to_vec(),
             )),
         };
@@ -1161,8 +1160,8 @@ impl DbClient for BigTableClientImpl {
         mutations.extend(self.get_mutations(row.cells)?);
 
         // check if the channel existed/was actually removed
-        let cq_filter = data::RowFilter {
-            filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+        let cq_filter = bigtable::RowFilter {
+            filter: Some(bigtable::row_filter::Filter::ColumnQualifierRegexFilter(
                 format!("^{column}$").into_bytes(),
             )),
         };
@@ -1378,13 +1377,15 @@ impl DbClient for BigTableClientImpl {
         let mut req = bigtable::ReadRowsRequest {
             table_name: self.settings.table_name.clone(),
             app_profile_id: self.settings.app_profile_id.clone(),
-            rows: Some(data::RowSet {
+            rows: Some(bigtable::RowSet {
                 row_keys: Vec::new(),
-                row_ranges: vec![data::RowRange {
-                    start_key: Some(data::row_range::StartKey::StartKeyOpen(
+                row_ranges: vec![bigtable::RowRange {
+                    start_key: Some(bigtable::row_range::StartKey::StartKeyOpen(
                         start_key.into_bytes(),
                     )),
-                    end_key: Some(data::row_range::EndKey::EndKeyOpen(end_key.into_bytes())),
+                    end_key: Some(bigtable::row_range::EndKey::EndKeyOpen(
+                        end_key.into_bytes(),
+                    )),
                 }],
             }),
             ..Default::default()
@@ -1435,13 +1436,15 @@ impl DbClient for BigTableClientImpl {
         let mut req = bigtable::ReadRowsRequest {
             table_name: self.settings.table_name.clone(),
             app_profile_id: self.settings.app_profile_id.clone(),
-            rows: Some(data::RowSet {
+            rows: Some(bigtable::RowSet {
                 row_keys: Vec::new(),
-                row_ranges: vec![data::RowRange {
-                    start_key: Some(data::row_range::StartKey::StartKeyOpen(
+                row_ranges: vec![bigtable::RowRange {
+                    start_key: Some(bigtable::row_range::StartKey::StartKeyOpen(
                         start_key.into_bytes(),
                     )),
-                    end_key: Some(data::row_range::EndKey::EndKeyOpen(end_key.into_bytes())),
+                    end_key: Some(bigtable::row_range::EndKey::EndKeyOpen(
+                        end_key.into_bytes(),
+                    )),
                 }],
             }),
             ..Default::default()
@@ -1614,6 +1617,35 @@ mod tests {
         let result = client.health_check().await;
         assert!(result.is_ok());
         assert!(result.unwrap());
+    }
+
+    /// Bigtable rejects SetCell timestamps that are not aligned to the table's
+    /// millisecond granularity (timestamp_micros must be a multiple of 1,000).
+    #[actix_rt::test]
+    async fn timestamp_granularity_rejects_sub_millisecond_micros() {
+        let client = new_client().unwrap();
+        let uaid = gen_test_uaid();
+        let row_key = uaid.simple().to_string();
+        let _ = client.remove_user(&uaid).await;
+
+        let mut req = client.mutate_row_request(&row_key);
+        req.mutations = vec![bigtable::Mutation {
+            mutation: Some(bigtable::mutation::Mutation::SetCell(
+                bigtable::mutation::SetCell {
+                    family_name: ROUTER_FAMILY.to_owned(),
+                    column_qualifier: b"granularity_probe".to_vec(),
+                    timestamp_micros: 1,
+                    value: b"x".to_vec(),
+                },
+            )),
+        }];
+
+        assert!(
+            client.mutate_row(req).await.is_err(),
+            "expected granularity mismatch for timestamp_micros=1"
+        );
+
+        let _ = client.remove_user(&uaid).await;
     }
 
     /// run a gauntlet of testing. These are a bit linear because they need

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -12,16 +12,17 @@ use async_trait::async_trait;
 use cadence::StatsdClient;
 #[cfg(feature = "reliable_report")]
 use chrono::TimeDelta;
-use futures_util::StreamExt;
-use google_cloud_rust_raw::bigtable::admin::v2::bigtable_table_admin::DropRowRangeRequest;
-use google_cloud_rust_raw::bigtable::admin::v2::bigtable_table_admin_grpc::BigtableTableAdminClient;
-use google_cloud_rust_raw::bigtable::v2::bigtable::ReadRowsRequest;
-use google_cloud_rust_raw::bigtable::v2::bigtable_grpc::BigtableClient;
-use google_cloud_rust_raw::bigtable::v2::data::{RowFilter, RowFilter_Chain};
-use google_cloud_rust_raw::bigtable::v2::{bigtable, data};
-use grpcio::{Channel, Metadata, RpcStatus, RpcStatusCode};
-use protobuf::RepeatedField;
+use gcp_auth::TokenProvider;
+// The generated stubs keep both the service requests/responses and the data
+// types in a single `v2` module. Alias it twice to retain the historical
+// `bigtable::` (requests) and `data::` (row/filter/mutation types) split.
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2 as bigtable;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2 as data;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::bigtable_client::BigtableClient;
 use serde_json::{from_str, json};
+use tonic::metadata::{AsciiMetadataValue, MetadataMap};
+use tonic::transport::Channel;
+use tonic::{Code, Request, Status};
 use uuid::Uuid;
 
 use crate::MAX_ROUTER_TTL_SECS;
@@ -66,6 +67,12 @@ const RELIABLE_LOG_FAMILY: &str = "reliability";
 pub const RELIABLE_LOG_TTL: TimeDelta = TimeDelta::days(60);
 
 pub(crate) const RETRY_COUNT: usize = 5;
+
+/// Maximum gRPC message size (256MB), matching the prior grpcio configuration.
+const MAX_MESSAGE_LEN: usize = 1 << 28;
+
+/// OAuth2 scopes requested for the Bigtable data API.
+const BIGTABLE_DATA_SCOPES: &[&str] = &["https://www.googleapis.com/auth/bigtable.data"];
 
 /// Simple circuit breaker to prevent retry storms during BigTable outages.
 ///
@@ -159,39 +166,42 @@ pub struct BigTableClientImpl {
     metrics: Arc<StatsdClient>,
     /// Connection Channel (used for alternate calls)
     pool: BigTablePool,
-    metadata: Metadata,
-    admin_metadata: Metadata,
+    metadata: MetadataMap,
     /// Circuit breaker to prevent retry storms during BigTable outages
     circuit_breaker: Arc<CircuitBreaker>,
 }
 
 /// Return a a RowFilter matching the GC policy of the router Column Family
 fn router_gc_policy_filter() -> data::RowFilter {
-    let mut latest_cell_filter = data::RowFilter::default();
-    latest_cell_filter.set_cells_per_column_limit_filter(1);
-    latest_cell_filter
+    data::RowFilter {
+        filter: Some(data::row_filter::Filter::CellsPerColumnLimitFilter(1)),
+    }
 }
 
 /// Return a chain of RowFilters matching the GC policy of the message Column
 /// Families
 fn message_gc_policy_filter() -> Result<Vec<data::RowFilter>, error::BigTableError> {
-    let mut timestamp_filter = data::RowFilter::default();
     let bt_now: i64 = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(error::BigTableError::WriteTime)?
         .as_millis() as i64;
-    let mut range_filter = data::TimestampRange::default();
-    range_filter.set_start_timestamp_micros(bt_now * 1000);
-    timestamp_filter.set_timestamp_range_filter(range_filter);
+    let timestamp_filter = data::RowFilter {
+        filter: Some(data::row_filter::Filter::TimestampRangeFilter(
+            data::TimestampRange {
+                start_timestamp_micros: bt_now * 1000,
+                end_timestamp_micros: 0,
+            },
+        )),
+    };
 
     Ok(vec![router_gc_policy_filter(), timestamp_filter])
 }
 
 /// Return a Column family regex RowFilter
 fn family_filter(regex: String) -> data::RowFilter {
-    let mut filter = data::RowFilter::default();
-    filter.set_family_name_regex_filter(regex);
-    filter
+    data::RowFilter {
+        filter: Some(data::row_filter::Filter::FamilyNameRegexFilter(regex)),
+    }
 }
 
 /// Escape bytes for RE values
@@ -219,11 +229,16 @@ fn escape_bytes(bytes: &[u8]) -> Vec<u8> {
 /// Return a chain of RowFilters limiting to a match of the specified
 /// `version`'s column value
 fn version_filter(version: &Uuid) -> Vec<data::RowFilter> {
-    let mut cq_filter = data::RowFilter::default();
-    cq_filter.set_column_qualifier_regex_filter("^version$".as_bytes().to_vec());
-
-    let mut value_filter = data::RowFilter::default();
-    value_filter.set_value_regex_filter(escape_bytes(version.as_bytes()));
+    let cq_filter = data::RowFilter {
+        filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+            "^version$".as_bytes().to_vec(),
+        )),
+    };
+    let value_filter = data::RowFilter {
+        filter: Some(data::row_filter::Filter::ValueRegexFilter(escape_bytes(
+            version.as_bytes(),
+        ))),
+    };
 
     vec![
         family_filter(format!("^{ROUTER_FAMILY}$")),
@@ -243,12 +258,12 @@ fn new_version_cell(timestamp: SystemTime) -> cell::Cell {
 }
 
 /// Return a RowFilter chain from multiple RowFilters
-fn filter_chain(filters: impl Into<RepeatedField<RowFilter>>) -> RowFilter {
-    let mut chain = RowFilter_Chain::default();
-    chain.set_filters(filters.into());
-    let mut filter = RowFilter::default();
-    filter.set_chain(chain);
-    filter
+fn filter_chain(filters: Vec<data::RowFilter>) -> data::RowFilter {
+    data::RowFilter {
+        filter: Some(data::row_filter::Filter::Chain(data::row_filter::Chain {
+            filters,
+        })),
+    }
 }
 
 /// Return a ReadRowsRequest against table for a given row key
@@ -257,17 +272,15 @@ fn read_row_request(
     app_profile_id: &str,
     row_key: &str,
 ) -> bigtable::ReadRowsRequest {
-    let mut req = bigtable::ReadRowsRequest::default();
-    req.set_table_name(table_name.to_owned());
-    req.set_app_profile_id(app_profile_id.to_owned());
-
-    let mut row_keys = RepeatedField::default();
-    row_keys.push(row_key.as_bytes().to_vec());
-    let mut row_set = data::RowSet::default();
-    row_set.set_row_keys(row_keys);
-    req.set_rows(row_set);
-
-    req
+    bigtable::ReadRowsRequest {
+        table_name: table_name.to_owned(),
+        app_profile_id: app_profile_id.to_owned(),
+        rows: Some(data::RowSet {
+            row_keys: vec![row_key.as_bytes().to_vec()],
+            row_ranges: Vec::new(),
+        }),
+        ..Default::default()
+    }
 }
 
 fn to_u64(value: Vec<u8>, name: &str) -> Result<u64, DbError> {
@@ -330,18 +343,18 @@ pub fn retry_policy(max: usize) -> RetryPolicy {
         .with_jitter(true)
 }
 
-fn retryable_internal_err(status: &RpcStatus) -> bool {
+fn retryable_internal_err(status: &Status) -> bool {
     match status.code() {
-        RpcStatusCode::UNKNOWN => status
-            .message()
-            .eq_ignore_ascii_case("error occurred when fetching oauth2 token."),
-        RpcStatusCode::INTERNAL => [
+        // tonic surfaces transport-level failures (connection resets, etc.)
+        // as `Unknown`.
+        Code::Unknown => true,
+        Code::Internal => [
             "rst_stream",
             "rst stream",
             "received unexpected eos on data frame from server",
         ]
         .contains(&status.message().to_lowercase().as_str()),
-        RpcStatusCode::UNAVAILABLE | RpcStatusCode::DEADLINE_EXCEEDED => true,
+        Code::Unavailable | Code::DeadlineExceeded => true,
         _ => false,
     }
 }
@@ -357,37 +370,14 @@ pub fn metric(metrics: &Arc<StatsdClient>, err_type: &str, code: Option<&str>) {
     metric.send();
 }
 
-pub fn retryable_grpcio_err(metrics: &Arc<StatsdClient>) -> impl Fn(&grpcio::Error) -> bool + '_ {
-    move |err| {
-        debug!("🉑 Checking grpcio::Error...{err}");
-        match err {
-            grpcio::Error::RpcFailure(status) => {
-                info!("GRPC Failure :{:?}", status);
-                let retry = retryable_internal_err(status);
-                if retry {
-                    metric(metrics, "RpcFailure", Some(&status.code().to_string()));
-                }
-                retry
-            }
-            grpcio::Error::BindFail(_) => {
-                metric(metrics, "BindFail", None);
-                true
-            }
-            // The parameter here is a [grpcio_sys::grpc_call_error] enum
-            // Not all of these are retryable.
-            grpcio::Error::CallFailure(grpc_call_status) => {
-                let retry = grpc_call_status == &grpcio_sys::grpc_call_error::GRPC_CALL_ERROR;
-                if retry {
-                    metric(
-                        metrics,
-                        "CallFailure",
-                        Some(&format!("{grpc_call_status:?}")),
-                    );
-                }
-                retry
-            }
-            _ => false,
+pub fn retryable_status(metrics: &Arc<StatsdClient>) -> impl Fn(&Status) -> bool + '_ {
+    move |status| {
+        info!("GRPC Failure: {:?}", status);
+        let retry = retryable_internal_err(status);
+        if retry {
+            metric(metrics, "RpcFailure", Some(&format!("{:?}", status.code())));
         }
+        retry
     }
 }
 
@@ -397,10 +387,16 @@ pub fn retryable_bt_err(
     move |err| {
         debug!("🉑 Checking BigTableError...{err}");
         match err {
-            error::BigTableError::InvalidRowResponse(e)
-            | error::BigTableError::Read(e)
-            | error::BigTableError::Write(e)
-            | error::BigTableError::GRPC(e) => retryable_grpcio_err(metrics)(e),
+            error::BigTableError::InvalidRowResponse(s)
+            | error::BigTableError::Read(s)
+            | error::BigTableError::Write(s) => retryable_status(metrics)(s),
+            // Failures to fetch an OAuth token (e.g. a transient metadata
+            // server hiccup) are retryable, matching the prior behavior of
+            // retrying grpcio's oauth token fetch errors.
+            error::BigTableError::Auth(_) => {
+                metric(metrics, "Auth", None);
+                true
+            }
             _ => false,
         }
     }
@@ -423,10 +419,6 @@ fn is_incomplete_router_record(cells: &RowCells) -> bool {
     cells
         .keys()
         .all(|k| ["current_timestamp", "version"].contains(&k.as_str()) || k.starts_with("chid:"))
-}
-
-fn call_opts(metadata: Metadata) -> ::grpcio::CallOption {
-    ::grpcio::CallOption::default().headers(metadata)
 }
 
 /// Connect to a BigTable storage model.
@@ -455,7 +447,6 @@ fn call_opts(metadata: Metadata) -> ::grpcio::CallOption {
 ///
 impl BigTableClientImpl {
     pub fn new(metrics: Arc<StatsdClient>, settings: &DbSettings) -> DbResult<Self> {
-        // let env = Arc::new(EnvBuilder::new().build());
         debug!("🏊 BT Pool new");
         let db_settings = BigTableDbSettings::try_from(settings.db_settings.as_ref())?;
         info!("🉑 {:#?}", db_settings);
@@ -463,12 +454,10 @@ impl BigTableClientImpl {
 
         // create the metadata header blocks required by Google for accessing GRPC resources.
         let metadata = db_settings.metadata()?;
-        let admin_metadata = db_settings.admin_metadata()?;
         Ok(Self {
             settings: db_settings,
             metrics,
             metadata,
-            admin_metadata,
             pool,
             circuit_breaker: Arc::new(CircuitBreaker::default()),
         })
@@ -496,20 +485,22 @@ impl BigTableClientImpl {
 
     /// Return a MutateRowRequest for a given row key
     fn mutate_row_request(&self, row_key: &str) -> bigtable::MutateRowRequest {
-        let mut req = bigtable::MutateRowRequest::default();
-        req.set_table_name(self.settings.table_name.clone());
-        req.set_app_profile_id(self.settings.app_profile_id.clone());
-        req.set_row_key(row_key.as_bytes().to_vec());
-        req
+        bigtable::MutateRowRequest {
+            table_name: self.settings.table_name.clone(),
+            app_profile_id: self.settings.app_profile_id.clone(),
+            row_key: row_key.as_bytes().to_vec(),
+            ..Default::default()
+        }
     }
 
     /// Return a CheckAndMutateRowRequest for a given row key
     fn check_and_mutate_row_request(&self, row_key: &str) -> bigtable::CheckAndMutateRowRequest {
-        let mut req = bigtable::CheckAndMutateRowRequest::default();
-        req.set_table_name(self.settings.table_name.clone());
-        req.set_app_profile_id(self.settings.app_profile_id.clone());
-        req.set_row_key(row_key.as_bytes().to_vec());
-        req
+        bigtable::CheckAndMutateRowRequest {
+            table_name: self.settings.table_name.clone(),
+            app_profile_id: self.settings.app_profile_id.clone(),
+            row_key: row_key.as_bytes().to_vec(),
+            ..Default::default()
+        }
     }
 
     /// Read a given row from the row key.
@@ -524,81 +515,23 @@ impl BigTableClientImpl {
         let result = retry_policy(self.settings.retry_count)
             .retry_if(
                 || async {
+                    let request = bigtable.request(req.clone(), &self.metadata).await?;
                     bigtable
                         .conn
-                        .mutate_row_opt(&req, call_opts(self.metadata.clone()))
+                        .clone()
+                        .mutate_row(request)
+                        .await
+                        .map_err(error::BigTableError::Write)?;
+                    Ok(())
                 },
-                retryable_grpcio_err(&self.metrics),
+                retryable_bt_err(&self.metrics),
             )
             .await;
         match &result {
-            Ok(_) => self.circuit_breaker.record_success(),
+            Ok(()) => self.circuit_breaker.record_success(),
             Err(_) => self.circuit_breaker.record_failure(),
         }
-        result.map_err(error::BigTableError::Write)?;
-        Ok(())
-    }
-
-    /// Perform a MutateRowsRequest
-    #[allow(unused)]
-    async fn mutate_rows(
-        &self,
-        req: bigtable::MutateRowsRequest,
-    ) -> Result<(), error::BigTableError> {
-        let bigtable = self.pool.get().await?;
-        // ClientSStreamReceiver will cancel an operation if it's dropped before it's done.
-        let resp = retry_policy(self.settings.retry_count)
-            .retry_if(
-                || async {
-                    bigtable
-                        .conn
-                        .mutate_rows_opt(&req, call_opts(self.metadata.clone()))
-                },
-                retryable_grpcio_err(&self.metrics),
-            )
-            .await
-            .map_err(error::BigTableError::Write)?;
-
-        // Scan the returned stream looking for errors.
-        // As I understand, the returned stream contains chunked MutateRowsResponse structs. Each
-        // struct contains the result of the row mutation, and contains a `status` (non-zero on error)
-        // and an optional message string (empty if none).
-        // The structure also contains an overall `status` but that does not appear to be exposed.
-        // Status codes are defined at https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-        let mut stream = Box::pin(resp);
-        let mut cnt = 0;
-        loop {
-            let (result, remainder) = StreamExt::into_future(stream).await;
-            if let Some(result) = result {
-                debug!("🎏 Result block: {}", cnt);
-                match result {
-                    Ok(r) => {
-                        for e in r.get_entries() {
-                            if e.has_status() {
-                                let status = e.get_status();
-                                // See status code definitions: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-                                let code = error::MutateRowStatus::from(status.get_code());
-                                if !code.is_ok() {
-                                    return Err(error::BigTableError::Status(
-                                        code,
-                                        status.get_message().to_owned(),
-                                    ));
-                                }
-                                debug!("🎏 Response: {} OK", e.index);
-                            }
-                        }
-                    }
-                    Err(e) => return Err(error::BigTableError::Write(e)),
-                };
-                cnt += 1;
-            } else {
-                debug!("🎏 Done!");
-                break;
-            }
-            stream = remainder;
-        }
-
-        Ok(())
+        result
     }
 
     /// Read one row for the [ReadRowsRequest] (assuming only a single row was requested).
@@ -615,7 +548,7 @@ impl BigTableClientImpl {
     ///
     async fn read_rows(
         &self,
-        req: ReadRowsRequest,
+        req: bigtable::ReadRowsRequest,
     ) -> Result<BTreeMap<RowKey, row::Row>, error::BigTableError> {
         if !self.circuit_breaker.allow_request() {
             return Err(error::BigTableError::CircuitBreakerOpen);
@@ -624,10 +557,14 @@ impl BigTableClientImpl {
         let result = retry_policy(self.settings.retry_count)
             .retry_if(
                 || async {
-                    let resp: grpcio::ClientSStreamReceiver<bigtable::ReadRowsResponse> = bigtable
+                    let request = bigtable.request(req.clone(), &self.metadata).await?;
+                    let resp = bigtable
                         .conn
-                        .read_rows_opt(&req, call_opts(self.metadata.clone()))
-                        .map_err(error::BigTableError::Read)?;
+                        .clone()
+                        .read_rows(request)
+                        .await
+                        .map_err(error::BigTableError::Read)?
+                        .into_inner();
                     merge::RowMerger::process_chunks(resp).await
                 },
                 retryable_bt_err(&self.metrics),
@@ -649,8 +586,7 @@ impl BigTableClientImpl {
         // It's possible to do a lot here, including altering in process
         // mutations, clearing them, etc. It's all up for grabs until we commit
         // below. For now, let's just presume a write and be done.
-        let mutations = self.get_mutations(row.cells)?;
-        req.set_mutations(mutations);
+        req.mutations = self.get_mutations(row.cells)?;
         self.mutate_row(req).await?;
         Ok(())
     }
@@ -659,25 +595,25 @@ impl BigTableClientImpl {
     fn get_mutations(
         &self,
         cells: HashMap<FamilyId, Vec<crate::db::bigtable::bigtable_client::cell::Cell>>,
-    ) -> Result<protobuf::RepeatedField<data::Mutation>, error::BigTableError> {
-        let mut mutations = protobuf::RepeatedField::default();
+    ) -> Result<Vec<data::Mutation>, error::BigTableError> {
+        let mut mutations = Vec::new();
         for (family_id, cells) in cells {
             for cell in cells {
-                let mut mutation = data::Mutation::default();
-                let mut set_cell = data::Mutation_SetCell::default();
                 let timestamp = cell
                     .timestamp
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .map_err(error::BigTableError::WriteTime)?;
-                set_cell.family_name.clone_from(&family_id);
-                set_cell.set_column_qualifier(cell.qualifier.clone().into_bytes());
-                set_cell.set_value(cell.value);
-                // Yes, this is passing milli bounded time as a micro. Otherwise I get
-                // a `Timestamp granularity mismatch` error
-                set_cell.set_timestamp_micros((timestamp.as_millis() * 1000) as i64);
                 debug!("🉑 expiring in {:?}", timestamp.as_millis());
-                mutation.set_set_cell(set_cell);
-                mutations.push(mutation);
+                mutations.push(data::Mutation {
+                    mutation: Some(data::mutation::Mutation::SetCell(data::mutation::SetCell {
+                        family_name: family_id.clone(),
+                        column_qualifier: cell.qualifier.clone().into_bytes(),
+                        // Yes, this is passing milli bounded time as a micro. Otherwise I get
+                        // a `Timestamp granularity mismatch` error
+                        timestamp_micros: (timestamp.as_millis() * 1000) as i64,
+                        value: cell.value,
+                    })),
+                });
             }
         }
         Ok(mutations)
@@ -693,16 +629,16 @@ impl BigTableClientImpl {
     async fn check_and_mutate_row(
         &self,
         row: row::Row,
-        filter: RowFilter,
+        filter: data::RowFilter,
         state: bool,
     ) -> Result<bool, error::BigTableError> {
         let mut req = self.check_and_mutate_row_request(&row.row_key);
         let mutations = self.get_mutations(row.cells)?;
-        req.set_predicate_filter(filter);
+        req.predicate_filter = Some(filter);
         if state {
-            req.set_true_mutations(mutations);
+            req.true_mutations = mutations;
         } else {
-            req.set_false_mutations(mutations);
+            req.false_mutations = mutations;
         }
         self.check_and_mutate(req).await
     }
@@ -715,18 +651,20 @@ impl BigTableClientImpl {
         let resp = retry_policy(self.settings.retry_count)
             .retry_if(
                 || async {
-                    // Note: check_and_mutate_row_async may return before the row
-                    // is written, which can cause race conditions for reads
+                    let request = bigtable.request(req.clone(), &self.metadata).await?;
                     bigtable
                         .conn
-                        .check_and_mutate_row_opt(&req, call_opts(self.metadata.clone()))
+                        .clone()
+                        .check_and_mutate_row(request)
+                        .await
+                        .map_err(error::BigTableError::Write)
                 },
-                retryable_grpcio_err(&self.metrics),
+                retryable_bt_err(&self.metrics),
             )
-            .await
-            .map_err(error::BigTableError::Write)?;
-        debug!("🉑 Predicate Matched: {}", &resp.get_predicate_matched(),);
-        Ok(resp.get_predicate_matched())
+            .await?
+            .into_inner();
+        debug!("🉑 Predicate Matched: {}", &resp.predicate_matched);
+        Ok(resp.predicate_matched)
     }
 
     fn get_delete_mutations(
@@ -734,87 +672,34 @@ impl BigTableClientImpl {
         family: &str,
         column_names: &[&str],
         time_range: Option<&data::TimestampRange>,
-    ) -> Result<protobuf::RepeatedField<data::Mutation>, error::BigTableError> {
-        let mut mutations = protobuf::RepeatedField::default();
+    ) -> Result<Vec<data::Mutation>, error::BigTableError> {
+        let mut mutations = Vec::new();
         for column in column_names {
-            let mut mutation = data::Mutation::default();
-            // Mutation_DeleteFromRow -- Delete all cells for a given row.
-            // Mutation_DeleteFromFamily -- Delete all cells from a family for a given row.
-            // Mutation_DeleteFromColumn -- Delete all cells from a column name for a given row, restricted by timestamp range.
-            let mut del_cell = data::Mutation_DeleteFromColumn::default();
-            del_cell.set_family_name(family.to_owned());
-            del_cell.set_column_qualifier(column.as_bytes().to_vec());
-            if let Some(range) = time_range {
-                del_cell.set_time_range(range.clone());
-            }
-            mutation.set_delete_from_column(del_cell);
-            mutations.push(mutation);
+            // DeleteFromRow -- Delete all cells for a given row.
+            // DeleteFromFamily -- Delete all cells from a family for a given row.
+            // DeleteFromColumn -- Delete all cells from a column name for a given row, restricted by timestamp range.
+            mutations.push(data::Mutation {
+                mutation: Some(data::mutation::Mutation::DeleteFromColumn(
+                    data::mutation::DeleteFromColumn {
+                        family_name: family.to_owned(),
+                        column_qualifier: column.as_bytes().to_vec(),
+                        time_range: time_range.cloned(),
+                    },
+                )),
+            });
         }
         Ok(mutations)
-    }
-
-    #[allow(unused)]
-    /// Delete all cell data from the specified columns with the optional time range.
-    #[allow(unused)]
-    async fn delete_cells(
-        &self,
-        row_key: &str,
-        family: &str,
-        column_names: &[&str],
-        time_range: Option<&data::TimestampRange>,
-    ) -> Result<(), error::BigTableError> {
-        let mut req = self.mutate_row_request(row_key);
-        req.set_mutations(self.get_delete_mutations(family, column_names, time_range)?);
-        self.mutate_row(req).await
     }
 
     /// Delete all the cells for the given row. NOTE: This will drop the row.
     async fn delete_row(&self, row_key: &str) -> Result<(), error::BigTableError> {
         let mut req = self.mutate_row_request(row_key);
-        let mut mutations = protobuf::RepeatedField::default();
-        let mut mutation = data::Mutation::default();
-        mutation.set_delete_from_row(data::Mutation_DeleteFromRow::default());
-        mutations.push(mutation);
-        req.set_mutations(mutations);
+        req.mutations = vec![data::Mutation {
+            mutation: Some(data::mutation::Mutation::DeleteFromRow(
+                data::mutation::DeleteFromRow {},
+            )),
+        }];
         self.mutate_row(req).await
-    }
-
-    /// This uses the admin interface to drop row ranges.
-    /// This will drop ALL data associated with these rows.
-    /// Note that deletion may take up to a week to occur.
-    /// see https://cloud.google.com/php/docs/reference/cloud-bigtable/latest/Admin.V2.DropRowRangeRequest
-    #[allow(unused)]
-    async fn delete_rows(&self, row_key: &str) -> Result<bool, error::BigTableError> {
-        let admin = BigtableTableAdminClient::new(self.pool.get_channel()?);
-        let mut req = DropRowRangeRequest::new();
-        req.set_name(self.settings.table_name.clone());
-        req.set_row_key_prefix(row_key.as_bytes().to_vec());
-
-        admin
-            .drop_row_range_async_opt(&req, call_opts(self.admin_metadata.clone()))
-            .map_err(|e| {
-                error!("{:?}", e);
-                error::BigTableError::Admin(
-                    format!(
-                        "Could not send delete command for {}",
-                        &self.settings.table_name
-                    ),
-                    Some(e.to_string()),
-                )
-            })?
-            .await
-            .map_err(|e| {
-                error!("post await: {:?}", e);
-                error::BigTableError::Admin(
-                    format!(
-                        "Could not delete data from table {}",
-                        &self.settings.table_name
-                    ),
-                    Some(e.to_string()),
-                )
-            })?;
-
-        Ok(true)
     }
 
     fn rows_to_notifications(
@@ -966,19 +851,59 @@ impl BigTableClientImpl {
 
 #[derive(Clone)]
 pub struct BigtableDb {
-    pub(super) conn: BigtableClient,
-    pub(super) health_metadata: Metadata,
+    pub(super) conn: BigtableClient<Channel>,
+    pub(super) health_metadata: MetadataMap,
+    /// Application Default Credentials token provider, shared across the
+    /// pool. `None` when running against the emulator (which needs no
+    /// credentials).
+    auth_provider: Option<Arc<dyn TokenProvider>>,
     table_name: String,
 }
 
 impl BigtableDb {
-    pub fn new(channel: Channel, health_metadata: &Metadata, table_name: &str) -> Self {
+    pub fn new(
+        channel: Channel,
+        auth_provider: Option<Arc<dyn TokenProvider>>,
+        health_metadata: &MetadataMap,
+        table_name: &str,
+    ) -> Self {
         Self {
-            conn: BigtableClient::new(channel),
+            conn: BigtableClient::new(channel)
+                .max_decoding_message_size(MAX_MESSAGE_LEN)
+                .max_encoding_message_size(MAX_MESSAGE_LEN),
             health_metadata: health_metadata.clone(),
+            auth_provider,
             table_name: table_name.to_owned(),
         }
     }
+
+    /// Build a [tonic::Request] for the given message, attaching the standard
+    /// Google routing metadata and (outside of the emulator) an OAuth2
+    /// `authorization` token from the Application Default Credentials.
+    ///
+    /// The token provider caches tokens internally, so this is cheap to call
+    /// per-request (and per retry attempt, where it transparently picks up a
+    /// fresh token if the prior one expired).
+    pub(super) async fn request<T>(
+        &self,
+        msg: T,
+        metadata: &MetadataMap,
+    ) -> Result<Request<T>, error::BigTableError> {
+        let mut request = Request::new(msg);
+        *request.metadata_mut() = metadata.clone();
+        if let Some(provider) = &self.auth_provider {
+            let token = provider
+                .token(BIGTABLE_DATA_SCOPES)
+                .await
+                .map_err(error::BigTableError::Auth)?;
+            let value: AsciiMetadataValue = format!("Bearer {}", token.as_str())
+                .parse()
+                .map_err(|e| error::BigTableError::Config(format!("Invalid auth token: {e}")))?;
+            request.metadata_mut().insert("authorization", value);
+        }
+        Ok(request)
+    }
+
     /// Perform a simple connectivity check. This should return no actual results
     /// but should verify that the connection is valid. We use this for the
     /// Recycle check as well, so it has to be fairly low in the implementation
@@ -998,19 +923,22 @@ impl BigtableDb {
         // other than it does not return an error.
         let random_uaid = Uuid::new_v4().simple().to_string();
         let mut req = read_row_request(&self.table_name, app_profile_id, &random_uaid);
-        let mut filter = data::RowFilter::default();
-        filter.set_block_all_filter(true);
-        req.set_filter(filter);
+        req.filter = Some(data::RowFilter {
+            filter: Some(data::row_filter::Filter::BlockAllFilter(true)),
+        });
         let _r = retry_policy(RETRY_COUNT)
             .retry_if(
                 || async {
+                    let request = self.request(req.clone(), &self.health_metadata).await?;
                     self.conn
-                        .read_rows_opt(&req, call_opts(self.health_metadata.clone()))
+                        .clone()
+                        .read_rows(request)
+                        .await
+                        .map_err(error::BigTableError::Read)
                 },
-                retryable_grpcio_err(metrics),
+                retryable_bt_err(metrics),
             )
-            .await
-            .map_err(error::BigTableError::Read)?;
+            .await?;
 
         debug!("🉑 health check");
         Ok(true)
@@ -1030,8 +958,11 @@ impl DbClient for BigTableClientImpl {
         let row = self.user_to_row(user, version);
 
         // Only add when the user doesn't already exist
-        let mut row_key_filter = RowFilter::default();
-        row_key_filter.set_row_key_regex_filter(format!("^{}$", row.row_key).into_bytes());
+        let row_key_filter = data::RowFilter {
+            filter: Some(data::row_filter::Filter::RowKeyRegexFilter(
+                format!("^{}$", row.row_key).into_bytes(),
+            )),
+        };
         let filter = filter_chain(vec![router_gc_policy_filter(), row_key_filter]);
 
         if self.check_and_mutate_row(row, filter, false).await? {
@@ -1080,7 +1011,7 @@ impl DbClient for BigTableClientImpl {
         let mut req = self.read_row_request(&row_key);
         let mut filters = vec![router_gc_policy_filter()];
         filters.push(family_filter(format!("^{ROUTER_FAMILY}$")));
-        req.set_filter(filter_chain(filters));
+        req.filter = Some(filter_chain(filters));
         let Some(mut row) = self.read_row(req).await? else {
             return Ok(None);
         };
@@ -1196,9 +1127,12 @@ impl DbClient for BigTableClientImpl {
         let row_key = uaid.simple().to_string();
         let mut req = self.read_row_request(&row_key);
 
-        let mut cq_filter = data::RowFilter::default();
-        cq_filter.set_column_qualifier_regex_filter("^chid:.*$".as_bytes().to_vec());
-        req.set_filter(filter_chain(vec![
+        let cq_filter = data::RowFilter {
+            filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+                "^chid:.*$".as_bytes().to_vec(),
+            )),
+        };
+        req.filter = Some(filter_chain(vec![
             router_gc_policy_filter(),
             family_filter(format!("^{ROUTER_FAMILY}$")),
             cq_filter,
@@ -1227,10 +1161,13 @@ impl DbClient for BigTableClientImpl {
         mutations.extend(self.get_mutations(row.cells)?);
 
         // check if the channel existed/was actually removed
-        let mut cq_filter = data::RowFilter::default();
-        cq_filter.set_column_qualifier_regex_filter(format!("^{column}$").into_bytes());
-        req.set_predicate_filter(filter_chain(vec![router_gc_policy_filter(), cq_filter]));
-        req.set_true_mutations(mutations);
+        let cq_filter = data::RowFilter {
+            filter: Some(data::row_filter::Filter::ColumnQualifierRegexFilter(
+                format!("^{column}$").into_bytes(),
+            )),
+        };
+        req.predicate_filter = Some(filter_chain(vec![router_gc_policy_filter(), cq_filter]));
+        req.true_mutations = mutations;
 
         Ok(self.check_and_mutate(req).await?)
     }
@@ -1253,8 +1190,8 @@ impl DbClient for BigTableClientImpl {
 
         let mut filters = vec![router_gc_policy_filter()];
         filters.extend(version_filter(version));
-        req.set_predicate_filter(filter_chain(filters));
-        req.set_true_mutations(self.get_delete_mutations(ROUTER_FAMILY, &["node_id"], None)?);
+        req.predicate_filter = Some(filter_chain(filters));
+        req.true_mutations = self.get_delete_mutations(ROUTER_FAMILY, &["node_id"], None)?;
 
         Ok(self.check_and_mutate(req).await?)
     }
@@ -1436,28 +1373,30 @@ impl DbClient for BigTableClientImpl {
         uaid: &Uuid,
         limit: usize,
     ) -> DbResult<FetchMessageResponse> {
-        let mut req = ReadRowsRequest::default();
-        req.set_table_name(self.settings.table_name.clone());
-        req.set_app_profile_id(self.settings.app_profile_id.clone());
-
         let start_key = format!("{}#01:", uaid.simple());
         let end_key = format!("{}#02:", uaid.simple());
-        let mut rows = data::RowSet::default();
-        let mut row_range = data::RowRange::default();
-        row_range.set_start_key_open(start_key.into_bytes());
-        row_range.set_end_key_open(end_key.into_bytes());
-        let mut row_ranges = RepeatedField::default();
-        row_ranges.push(row_range);
-        rows.set_row_ranges(row_ranges);
-        req.set_rows(rows);
+        let mut req = bigtable::ReadRowsRequest {
+            table_name: self.settings.table_name.clone(),
+            app_profile_id: self.settings.app_profile_id.clone(),
+            rows: Some(data::RowSet {
+                row_keys: Vec::new(),
+                row_ranges: vec![data::RowRange {
+                    start_key: Some(data::row_range::StartKey::StartKeyOpen(
+                        start_key.into_bytes(),
+                    )),
+                    end_key: Some(data::row_range::EndKey::EndKeyOpen(end_key.into_bytes())),
+                }],
+            }),
+            ..Default::default()
+        };
 
         let mut filters = message_gc_policy_filter()?;
         filters.push(family_filter(format!("^{MESSAGE_TOPIC_FAMILY}$")));
 
-        req.set_filter(filter_chain(filters));
+        req.filter = Some(filter_chain(filters));
         if limit > 0 {
             trace!("🉑 Setting limit to {limit}");
-            req.set_rows_limit(limit as i64);
+            req.rows_limit = limit as i64;
         }
         let rows = self.read_rows(req).await?;
         debug!(
@@ -1485,13 +1424,6 @@ impl DbClient for BigTableClientImpl {
         timestamp: Option<u64>,
         limit: usize,
     ) -> DbResult<FetchMessageResponse> {
-        let mut req = ReadRowsRequest::default();
-        req.set_table_name(self.settings.table_name.clone());
-        req.set_app_profile_id(self.settings.app_profile_id.clone());
-
-        let mut rows = data::RowSet::default();
-        let mut row_range = data::RowRange::default();
-
         let start_key = if let Some(ts) = timestamp {
             // Fetch everything after the last message with timestamp: the "z"
             // moves past the last message's channel_id's 1st hex digit
@@ -1500,13 +1432,20 @@ impl DbClient for BigTableClientImpl {
             format!("{}#02:", uaid.simple())
         };
         let end_key = format!("{}#03:", uaid.simple());
-        row_range.set_start_key_open(start_key.into_bytes());
-        row_range.set_end_key_open(end_key.into_bytes());
-
-        let mut row_ranges = RepeatedField::default();
-        row_ranges.push(row_range);
-        rows.set_row_ranges(row_ranges);
-        req.set_rows(rows);
+        let mut req = bigtable::ReadRowsRequest {
+            table_name: self.settings.table_name.clone(),
+            app_profile_id: self.settings.app_profile_id.clone(),
+            rows: Some(data::RowSet {
+                row_keys: Vec::new(),
+                row_ranges: vec![data::RowRange {
+                    start_key: Some(data::row_range::StartKey::StartKeyOpen(
+                        start_key.into_bytes(),
+                    )),
+                    end_key: Some(data::row_range::EndKey::EndKeyOpen(end_key.into_bytes())),
+                }],
+            }),
+            ..Default::default()
+        };
 
         // We can fetch data and do [some remote filtering](https://cloud.google.com/bigtable/docs/filters),
         // unfortunately I don't think the filtering we need will be super helpful.
@@ -1524,9 +1463,9 @@ impl DbClient for BigTableClientImpl {
         let mut filters = message_gc_policy_filter()?;
         filters.push(family_filter(format!("^{MESSAGE_FAMILY}$")));
 
-        req.set_filter(filter_chain(filters));
+        req.filter = Some(filter_chain(filters));
         if limit > 0 {
-            req.set_rows_limit(limit as i64);
+            req.rows_limit = limit as i64;
         }
         let rows = self.read_rows(req).await?;
         debug!(

--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -25,9 +25,9 @@ mod pool;
 pub use bigtable_client::BigTableClientImpl;
 pub use bigtable_client::error::BigTableError;
 
-use grpcio::Metadata;
 use serde::Deserialize;
 use std::time::Duration;
+use tonic::metadata::MetadataMap;
 
 use crate::db::bigtable::bigtable_client::MetadataBuilder;
 use crate::db::error::DbError;
@@ -119,32 +119,16 @@ impl Default for BigTableDbSettings {
 }
 
 impl BigTableDbSettings {
-    pub fn metadata(&self) -> Result<Metadata, BigTableError> {
+    pub fn metadata(&self) -> Result<MetadataMap, BigTableError> {
         MetadataBuilder::with_prefix(&self.table_name)
             .routing_param("table_name", &self.table_name)
             .route_to_leader(self.route_to_leader)
             .build()
-            .map_err(BigTableError::GRPC)
     }
 
     // Health may require a different metadata declaration.
-    pub fn health_metadata(&self) -> Result<Metadata, BigTableError> {
+    pub fn health_metadata(&self) -> Result<MetadataMap, BigTableError> {
         self.metadata()
-    }
-
-    pub fn admin_metadata(&self) -> Result<Metadata, BigTableError> {
-        // Admin calls use a slightly different routing param and a truncated prefix
-        // See https://github.com/googleapis/google-cloud-cpp/issues/190#issuecomment-370520185
-        let Some(admin_prefix) = self.table_name.split_once("/tables/").map(|v| v.0) else {
-            return Err(BigTableError::Config(
-                "Invalid table name specified".to_owned(),
-            ));
-        };
-        MetadataBuilder::with_prefix(admin_prefix)
-            .routing_param("name", &self.table_name)
-            .route_to_leader(self.route_to_leader)
-            .build()
-            .map_err(BigTableError::GRPC)
     }
 
     pub fn get_instance_name(&self) -> Result<String, BigTableError> {

--- a/autopush-common/src/db/bigtable/pool.rs
+++ b/autopush-common/src/db/bigtable/pool.rs
@@ -7,21 +7,20 @@ use std::{
 use actix_web::rt;
 use cadence::StatsdClient;
 use deadpool::managed::{Manager, PoolConfig, PoolError, QueueMode, RecycleError, Timeouts};
-use grpcio::{Channel, ChannelBuilder, ChannelCredentials, EnvBuilder};
+use gcp_auth::TokenProvider;
+use tokio::sync::OnceCell;
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::db::DbSettings;
 use crate::db::bigtable::{BigTableDbSettings, BigTableError, bigtable_client::BigtableDb};
 use crate::db::error::{DbError, DbResult};
 
-const MAX_MESSAGE_LEN: i32 = 1 << 28; // 268,435,456 bytes
 const DEFAULT_GRPC_PORT: u16 = 443;
 
 /// The pool of BigTable Clients.
 /// Note: BigTable uses HTTP/2 as the backbone, so the only really important bit
 /// that we have control over is the "channel". For now, we're using the ClientManager to
 /// create new Bigtable clients, which have channels associated with them.
-/// The Manager also has the ability to return a channel, which is useful for
-/// Bigtable administrative calls, which use their own channel.
 #[derive(Clone)]
 pub struct BigTablePool {
     /// Pool of db connections
@@ -48,11 +47,6 @@ impl BigTablePool {
         })?;
         debug!("🉑 Got db from pool");
         Ok(obj)
-    }
-
-    /// Get the pools manager, because we would like to talk to them.
-    pub fn get_channel(&self) -> Result<Channel, BigTableError> {
-        self.pool.manager().get_channel()
     }
 
     /// Creates a new pool of BigTable db connections.
@@ -145,6 +139,11 @@ pub struct BigtableClientManager {
     dsn: Option<String>,
     connection: String,
     metrics: Arc<StatsdClient>,
+    /// Lazily initialized Application Default Credentials (ADC) token
+    /// provider, shared across all pooled connections (it caches and
+    /// refreshes tokens internally). `None` until first used; never
+    /// initialized when running against the emulator.
+    auth_provider: OnceCell<Arc<dyn TokenProvider>>,
 }
 
 impl BigtableClientManager {
@@ -159,7 +158,32 @@ impl BigtableClientManager {
             dsn,
             connection,
             metrics,
+            auth_provider: OnceCell::new(),
         })
+    }
+
+    /// Are we running against a local Bigtable emulator?
+    fn is_emulator(&self) -> bool {
+        self.dsn
+            .as_ref()
+            .map(|v| v.contains("localhost"))
+            .unwrap_or(false)
+            || std::env::var("BIGTABLE_EMULATOR_HOST").is_ok()
+    }
+
+    /// Return the shared ADC token provider, or `None` when running against
+    /// the emulator (which requires no credentials).
+    async fn token_provider(&self) -> Result<Option<Arc<dyn TokenProvider>>, BigTableError> {
+        if self.is_emulator() {
+            debug!("🉑 Using emulator");
+            return Ok(None);
+        }
+        debug!("🉑 Using real");
+        let provider = self
+            .auth_provider
+            .get_or_try_init(|| async { gcp_auth::provider().await.map_err(BigTableError::Auth) })
+            .await?;
+        Ok(Some(provider.clone()))
     }
 }
 
@@ -180,7 +204,8 @@ impl Manager for BigtableClientManager {
     async fn create(&self) -> Result<BigtableDb, Self::Error> {
         debug!("🏊 Create a new pool entry.");
         let entry = BigtableDb::new(
-            self.get_channel()?,
+            self.get_channel().await?,
+            self.token_provider().await?,
             &self.settings.health_metadata()?,
             &self.settings.table_name,
         );
@@ -223,27 +248,26 @@ impl Manager for BigtableClientManager {
 
 impl BigtableClientManager {
     /// Get a new Channel, based on the application settings.
-    pub fn get_channel(&self) -> Result<Channel, BigTableError> {
-        Ok(Self::create_channel(self.dsn.clone())?.connect(self.connection.as_str()))
+    pub async fn get_channel(&self) -> Result<Channel, BigTableError> {
+        Self::create_channel(&self.connection, self.is_emulator()).await
     }
-    /// Channels are GRPCIO constructs that contain the actual command data paths.
-    /// Channels seem to be fairly light weight.
-    pub fn create_channel(dsn: Option<String>) -> Result<ChannelBuilder, BigTableError> {
+
+    /// Channels are the tonic transport constructs that contain the actual
+    /// HTTP/2 connection. Channels are fairly light weight.
+    pub async fn create_channel(
+        connection: &str,
+        is_emulator: bool,
+    ) -> Result<Channel, BigTableError> {
         debug!("🏊 Creating new channel...");
-        let mut chan = ChannelBuilder::new(Arc::new(EnvBuilder::new().build()))
-            .max_send_message_len(MAX_MESSAGE_LEN)
-            .max_receive_message_len(MAX_MESSAGE_LEN);
-        // Don't get the credentials if we are running in the emulator
-        if dsn.map(|v| v.contains("localhost")).unwrap_or(false)
-            || std::env::var("BIGTABLE_EMULATOR_HOST").is_ok()
-        {
-            debug!("🉑 Using emulator");
-        } else {
-            chan = chan.set_credentials(
-                ChannelCredentials::google_default_credentials().map_err(BigTableError::GRPC)?,
-            );
-            debug!("🉑 Using real");
+        // The emulator runs plain HTTP/2 without TLS or credentials.
+        let scheme = if is_emulator { "http" } else { "https" };
+        let mut endpoint = Endpoint::from_shared(format!("{scheme}://{connection}"))
+            .map_err(BigTableError::Connect)?;
+        if !is_emulator {
+            endpoint = endpoint
+                .tls_config(ClientTlsConfig::new().with_native_roots())
+                .map_err(BigTableError::Connect)?;
         }
-        Ok(chan)
+        endpoint.connect().await.map_err(BigTableError::Connect)
     }
 }


### PR DESCRIPTION
This PR attempts to fix the ongoing `grpcio` issues. Example:
https://github.com/mozilla-services/autopush-rs/issues/898

We cannot build Push on macOS for example, because of the `grpcio` dependency. This is needed, because we communicate via gRPC to Googles BigTable. 

The types come from https://crates.io/crates/googleapis-tonic-google-bigtable-v2 crate. 
How it works:

* The crate is auto-generated from Google's official [googleapis](https://github.com/googleapis/googleapis) proto definitions (google/bigtable/v2/*.proto) using tonic-build + prost. It's published from [bouzuya/googleapis-tonic](https://github.com/bouzuya/googleapis-tonic), which regenerates the whole `googleapis` surface as individual crates and is what `bigtable_rs` uses under the hood as well.
* It ships the prost message types (`RowFilter`, `Mutation`, `ReadRowsRequest`, ...) and the tonic client stub (BigtableClient) pre-compiled as Rust source, so cargo build just compiles Rust, which is why the macOS cc-rs/cmake breakage is gone.

It also removes dead code: `mutate_rows`, `delete_cells`, the admin-API `delete_rows` (plus `BigtableTableAdminClient`, `admin_metadata()`, the admin channel accessor, and the `Admin` error variant). None had callers.

To test: clone the repo and checkout the PR locally on macOS, and run `cargo check` or `cargo build`, and it should all be green. 

### How to test

1. Start docker 
2. Run `gcloud beta emulators bigtable start` 
3. In another terminal, set `BIGTABLE_EMULATOR_HOST` to `localhost:8086`
4. And then `./scripts/setup_bt.sh` 

Then you can 
1. `cd autopush-common` 
2. `cargo test --features=emulator,bigtable -- db::bigtable --nocapture` 
