### PR TITLE
fix: install rustls CryptoProvider to prevent startup panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "redis-module",
  "redis-test",
  "regex",
+ "rustls 0.23.41",
  "sentry",
  "sentry-backtrace",
  "serde",

--- a/autoconnect/src/main.rs
+++ b/autoconnect/src/main.rs
@@ -38,6 +38,11 @@ struct Args {
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    // Must run before any TLS use. reqwest (e.g. the megaphone/remote-settings
+    // HTTPS fetch on the actix arbiter threads) builds its rustls config via the
+    // default provider and panics if none is installed when multiple providers
+    // are compiled in; tonic/bigtable adopts whatever we install here.
+    autopush_common::tls::install_crypto_provider();
     env_logger::init();
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -37,6 +37,11 @@ struct Args {
 
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    // Must run before any TLS use: reqwest (outbound HTTPS to push services)
+    // builds its rustls config via the default provider and panics if none is
+    // installed when multiple providers are compiled in; tonic/bigtable adopts
+    // whatever we install here.
+    autopush_common::tls::install_crypto_provider();
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -45,6 +45,14 @@ url.workspace = true
 
 again = "0.1"
 async-trait = "0.1"
+# Used solely to install a process-level rustls CryptoProvider. In the bigtable
+# build, transitive deps unify onto a single rustls 0.23 with *both* the `ring`
+# (tonic's `tls-ring`) and `aws-lc-rs` (reqwest) provider features enabled, so
+# rustls can't pick one automatically and panics at first TLS use. We pin
+# `aws-lc-rs` because reqwest already pulls it into *every* build (redis,
+# postgres, bigtable); picking `ring` would instead force a second provider
+# into the otherwise single-provider redis/postgres builds.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
 derive_builder = "0.20"
 gethostname = "1.0"
 num_cpus = "1.16"

--- a/autopush-common/src/lib.rs
+++ b/autopush-common/src/lib.rs
@@ -21,6 +21,7 @@ pub mod reliability;
 pub mod sentry;
 pub mod tags;
 pub mod test_support;
+pub mod tls;
 
 #[macro_use]
 pub mod util;

--- a/autopush-common/src/tls.rs
+++ b/autopush-common/src/tls.rs
@@ -1,0 +1,66 @@
+//! TLS / rustls process setup.
+
+/// Install a process-level rustls [`CryptoProvider`] so that rustls 0.23 has an
+/// unambiguous default.
+///
+/// In the bigtable build our dependency graph unifies onto a single `rustls`
+/// 0.23 build that has *both* the `ring` and `aws-lc-rs` provider features
+/// compiled in (`ring` via tonic's `tls-ring` and gcp_auth; `aws-lc-rs` via
+/// reqwest). When more than one provider is present, any library that builds a
+/// rustls config through the default path — e.g. reqwest, on the actix arbiter
+/// threads at startup — panics because rustls can't pick a provider. (tonic
+/// itself doesn't panic: it falls back to `ring`, but it adopts whatever
+/// default we install here.)
+///
+/// We install `aws-lc-rs` because reqwest pulls it into every build, so this
+/// never introduces a second provider into the otherwise single-provider
+/// redis/postgres builds.
+///
+/// Call this once, as early as possible in `main()`, before any TLS use. It is
+/// idempotent: a second call (or a provider installed by another crate) is
+/// ignored.
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+pub fn install_crypto_provider() {
+    if rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .is_err()
+    {
+        // A provider was already installed for this process; nothing to do.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the fix for the ambiguous-`CryptoProvider` startup panic.
+    ///
+    /// In any build that compiles in more than one rustls provider (the
+    /// `bigtable` build pulls `ring` via tonic *and* `aws-lc-rs` via reqwest),
+    /// `rustls::ClientConfig::builder()` resolves `CryptoProvider::get_default()`
+    /// and panics with "Could not automatically determine the process-level
+    /// CryptoProvider" unless a default has been installed first.
+    ///
+    /// This asserts that [`install_crypto_provider`] makes that resolution
+    /// succeed, so the clients that use rustls's default-provider path (reqwest,
+    /// sqlx) no longer panic. tonic doesn't hit this path — it falls back to
+    /// `ring` — but it adopts whatever default we install for the bigtable
+    /// connection.
+    #[test]
+    fn install_resolves_crypto_provider() {
+        install_crypto_provider();
+
+        // Idempotent: a second call must not panic.
+        install_crypto_provider();
+
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "no process-level CryptoProvider after install"
+        );
+
+        // The exact call that panics pre-fix when multiple providers are
+        // compiled in. It must not panic now.
+        let _ = rustls::ClientConfig::builder();
+    }
+}


### PR DESCRIPTION
The dependency bumps unified ring (via tonic's tls-ring, the bigtable path) and aws-lc-rs (via reqwest) onto one rustls 0.23 build. With both providers compiled in, rustls can't auto-select one and panics at first TLS use. Installing a default provider at startup restores working behavior.