### PR TITLE
chore: tag 1.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="1.82.1"></a>
+## 1.82.1 (2026-06-24)
+
+
+#### Bug Fixes
+
+*   install rustls CryptoProvider to prevent startup panic (#1174) ([b3e7a8b](https://github.com/mozilla-services/autopush-rs/pull/1174))
+
+#### Chore
+
+*   tag 1.82.0 (#1168) ([5c32e76](https://github.com/mozilla-services/autopush-rs/pull/1168))
+
+
 <a name="1.82.0"></a>
 ## 1.82.0 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+<a name="1.82.0"></a>
+## 1.82.0 (2026-06-23)
+
+
+#### Features
+
+*   Add var prefixer to resolve grpcio builds under trixie (#1162) ([3c594792](https://github.com/mozilla-services/autopush-rs/commit/3c594792277dc367b79046be673c7b8ba489a3d0))
+
+#### Bug Fixes
+
+*   defaults for explicitly null keys in settings (#1156) ([ec675ffe](https://github.com/mozilla-services/autopush-rs/commit/ec675ffecc7cf1bf198e2859f5b7c860da71b7ad))
+
+#### Chore
+
+*   tag 1.81.3 (#1151) ([202f78b3](https://github.com/mozilla-services/autopush-rs/commit/202f78b3b297d1b4ad8f05af607c7a1eb4835017))
+*   remove token auth (#1153) ([ffc7fa4b](https://github.com/mozilla-services/autopush-rs/commit/ffc7fa4b5376c77574c84b43aaccacb5f4a714bb))
+*   apply zizmor autofixes (#1158) ([ca4dfd2e](https://github.com/mozilla-services/autopush-rs/commit/ca4dfd2e84c7b22a0402c8f6ad7c1cb0a2b4232c))
+*   Add APNs cert update docs and scripts (#1161) ([702d0658](https://github.com/mozilla-services/autopush-rs/commit/702d06581066e244d5954c980c6a335089781776))
+*   Replace grpcio with tonic (#1165) ([d1c8d22e](https://github.com/mozilla-services/autopush-rs/commit/d1c8d22e78069232b087a701ccbd9c019017fbee))
+*   Updates for 06/2026 (#1164) ([4ef7531c](https://github.com/mozilla-services/autopush-rs/commit/4ef7531cd384e2fe57d9989bd96f40cfec4f2574))
+
+
+
 <a name="1.81.3"></a>
 ## 1.81.3 (2026-04-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autoconnect"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.81.3"
+version = "1.82.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1081,9 +1081,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
@@ -3063,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -3174,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+checksum = "24670b639492630905459a6c7d47f063d33c2d4fcd5362f6e5827c5613976c9f"
 
 [[package]]
 name = "linkme"
@@ -6351,9 +6351,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6450,9 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -6463,9 +6463,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6473,9 +6473,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote 1.0.46",
  "wasm-bindgen-macro-support",
@@ -6483,9 +6483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6496,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -6520,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.81.3"
+version = "1.82.1"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
#### Bug Fixes

*   install rustls CryptoProvider to prevent startup panic (#1174) ([b3e7a8b](https://github.com/mozilla-services/autopush-rs/pull/1174))

#### Chore

*   tag 1.82.0 (#1168) ([5c32e76](https://github.com/mozilla-services/autopush-rs/pull/1168))