### PR TITLE
docs: update release process

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,95 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }} \
+            ([{{ commit.id | truncate(length=8, end="") }}](<REPO>/commit/{{ commit.id }}))\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    { pattern = '<REPO>', replace = "https://github.com/mozilla-services/autopush-rs" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->Refactor" },
+    { message = "^style", group = "<!-- 5 -->Styling" },
+    { message = "^test", group = "<!-- 6 -->Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->Chore" },
+    { body = ".*security", group = "<!-- 8 -->Security" },
+    { message = "^revert", group = "<!-- 9 -->Revert" },
+    { message = ".*", group = "<!-- 10 -->Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# Fail on a commit that is not matched by any commit parser.
+fail_on_unmatched_commit = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order commits topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false

--- a/docs/src/releasing.md
+++ b/docs/src/releasing.md
@@ -1,5 +1,4 @@
-Release Process {#releasing}
-===============
+# Release Process {#releasing}
 
 <div style="color:red;border:2px solid red;padding:5px; margin:10px 5px ">
 <b><i>NOTE</i></b> This page is outdated, however the "Release Steps" are still a useful checklist.
@@ -10,36 +9,31 @@ developer and QA availability. The developer creating a release should
 handle all aspects of the following process as they\'re done closely in
 order and time.
 
-Versions
---------
+## Versions
 
-Autopush uses a `{major}.{minor}.{patch}` version scheme, new `{major}`
-versions are only issued if backwards compatibility is affected. Patch
-versions are used if a critical bug occurs after production deployment
-that requires a bug fix immediately.
+Autopush uses a `{major}.{minor}.{patch}` version scheme (see [semver.org](https://semver.org/) for more info). New `{major}` versions are only issued if backwards compatibility is affected.
+Minor versions are used to indicate new backwards compatible features. Patch
+versions are for backwards-compatible bug fixes.
 
-Dev Releases
-------------
+## Dev Releases
 
-When changes are committed to the `master` branch, an operations Jenkins
-instance will build and deploy the code automatically to the dev
-environment.
+When changes are committed to the `master` branch, a github action will build and deploy the code automatically. The new image is pushed to Google Artifact Registry with the "latest" tag,
+which is automatically synced in autopush dev namespace by ArgoCD.
 
 The development environment can be verified at its endpoint/wss
 endpoints:
 
-* Websocket: <wss://autopush.dev.mozaws.net/>
-* Endpoint: <https://updates-autopush.dev.mozaws.net/>
+- Websocket: <wss://autoconnect.dev.mozaws.net/>
+- Endpoint: <https://updates-autopush.dev.mozaws.net/>
 
-Stage/Production Releases
--------------------------
+## Stage/Production Releases
 
 ### Pre-Requisites
 
 To create a release, you will need appropriate access to the autopush
 GitHub repository with push permission.
 
-You will also need [clog](https://github.com/clog-tool/clog-cli)
+You will also need [git-cliff](https://git-cliff.org/docs/installation/)
 installed to create the `CHANGELOG.md` update.
 
 ### Release Steps
@@ -53,62 +47,41 @@ i.e. If a new minor version is being released after `1.21.0`, the
 1. Switch to the `master` branch of autopush.
 2. `git pull` to ensure the local copy is completely up-to-date.
 3. `git diff origin/master` to ensure there are no local staged or
-    uncommited changes.
-4. Run `tox` locally to ensure no artifacts or other local changes that
-    might break tests have been introduced.
-5. Change to the release branch.
+   uncommited changes.
+4. Create the release branch from `master`:
+   `git checkout -b release/{version}`.
 
-    If this is a new major/minor release,
-    `git checkout -b release/{major}.{minor}` to create a new release
-    branch.
+   The branch name includes the full `{major}.{minor}.{patch}` version,
+   so every release (major, minor, or patch) gets its own branch off the
+   current `master`.
 
-    If this is a new patch release, you will first need to ensure you
-    have the minor release branch checked out, then:
-
-    > 1.  `git checkout release/{major}.{minor}`
-    > 2.  `git pull` to ensure the branch is up-to-date.
-    > 3.  `git merge master` to merge the new changes into the release
-    >     branch.
-
-    **Note that the release branch does not include a \`\`{patch}\`\`
-    component**.
-
-6. Edit `autopush/__init__.py` so that the version number reflects the
-    desired release version.
-7. Run `clog --setversion {version}`, verify changes were properly
-    accounted for in `CHANGELOG.md`.
-8. `git add CHANGELOG.md autopush/__init__.py` to add the two changes
-    to the new release commit.
+5. Edit `Cargo.toml` `version` key so that the version number reflects the
+   desired release version.
+6. Regenerate the Cargo lockfile by running `cargo generate-lockfile`,
+   and ensure there are no unwanted changes.
+7. Generate a changelog with `git cliff --latest`, and coy into `CHANGELOG.md`
+8. `git add CHANGELOG.md Cargo*` to add the changes
+   to the new release commit.
 9. `git commit -m "chore: tag {version}"` to commit the new version and
-    record of changes.
-10. `git tag -s -m "chore: tag {version}" {version}` to create a signed
-    tag of the current HEAD commit for release.
-11. `git push --set-upstream origin release/{major}.{minor}` to push the
+   record of changes.
+10. `git push --set-upstream origin release/{version}` to push the
     commits to a new origin release branch.
-12. `git push --tags origin release/{major}.{minor}` to push the tags to
-    the release branch.
-13. Submit a pull request on github to merge the release branch to
+11. Submit a pull request on github to merge the release branch to
     master.
-14. Go to the [autopush releases
+12. Once merged, `git checkout master && git pull` to fast-forward to current head.
+13. Get the merge commit SHA, either from the PR page ("merged commit `abc1234` into master")
+    or programmatically with `gh pr view <pr-number> --json mergeCommit --jq '.mergeCommit.oid'`
+14. Run `git tag -s -m "chore: tag {version}" {version} <merge-commit-sha>` to tag the commit that actually landed on `master`.
+15. Push the tag with `git push origin {version}`; this is what triggers the deployment in CircleCI.
+16. Go to the [autopush releases
     page](https://github.com/mozilla-services/autopush/releases), you
     should see the new tag with no release information under it.
-15. Click the `Draft a new release` button.
-16. Enter the tag for `Tag version`.
-17. Copy/paste the changes from `CHANGELOG.md` into the release
+17. Click the `Draft a new release` button.
+18. Enter the tag for `Tag version`.
+19. Copy/paste the changes from `CHANGELOG.md` into the release
     description omitting the top 2 lines (the a name HTML and the
     version) of the file.
-
-    Keep these changes handy, you\'ll need them again shortly.
-
-18. Once the release branch pull request is approved and merged, click
-    `Publish Release`.
-19. File a bug for stage deployment in Bugzilla, in the `Cloud Services`
-    product, under the `Operations: Deployment Requests` component. It
-    should be titled `Please deploy autopush {major}.{minor} to STAGE`
-    and include the changes in the Description along with any additional
-    instructions to operations regarding deployment changes and special
-    test cases if needed for QA to verify.
-
-At this point, QA will take-over, verify stage, and create a production
-deployment Bugzilla ticket. QA will also schedule production deployment
-for the release.
+20. Staging is auto-synced. Verify that the deployment is successful by testing the staging endpoints:
+    - Websocket: <wss://autoconnect.stage.mozaws.net/>
+    - Endpoint: <https://updates-autopush.stage.mozaws.net/>
+21. Once staging is verified, you may release to production. See [internal documentation](https://mozilla-hub.atlassian.net/wiki/spaces/CLOUDSERVICES/pages/1025736721/Push+service+developer+documentation#Releasing-to-Production%3A) for production release process.


### PR DESCRIPTION
Update release process docs:

* Update versioning instructions for rust (from python)
* Update changelog tool to git-clif and add config to reproduce the changelog format (`clog` seems abandoned and generated empty notes for me, an upvoted reported issue)
* Update tag and release instructions 
* Update tooling to reflect current state (github actions, circleci, argocd)

Jira: https://mozilla-hub.atlassian.net/browse/PUSH-611