### PR TITLE
fix(grpc): PUSH-746 Use connect_lazy for BigTable connections

### DIFF
--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -62,7 +62,7 @@ const RELIABLE_LOG_FAMILY: &str = "reliability";
 /// /// In most use cases, converted to seconds through .num_seconds().
 pub const RELIABLE_LOG_TTL: TimeDelta = TimeDelta::days(60);
 
-pub(crate) const RETRY_COUNT: usize = 5;
+pub(crate) const RETRY_COUNT: usize = 2;
 
 /// Maximum gRPC message size (256MB), matching the prior grpcio configuration.
 const MAX_MESSAGE_LEN: usize = 1 << 28;
@@ -341,9 +341,13 @@ pub fn retry_policy(max: usize) -> RetryPolicy {
 
 fn retryable_internal_err(status: &Status) -> bool {
     match status.code() {
-        // tonic surfaces transport-level failures (connection resets, etc.)
-        // as `Unknown`.
-        Code::Unknown => true,
+        // Generated tonic clients synthesize this status when the Channel is
+        // not ready, before sending the RPC. Other Unknown statuses are
+        // ambiguous and must not be replayed indiscriminately.
+        Code::Unknown => status
+            .message()
+            .to_ascii_lowercase()
+            .starts_with("service was not ready:"),
         Code::Internal => [
             "rst_stream",
             "rst stream",
@@ -352,6 +356,95 @@ fn retryable_internal_err(status: &Status) -> bool {
         .contains(&status.message().to_lowercase().as_str()),
         Code::Unavailable | Code::DeadlineExceeded => true,
         _ => false,
+    }
+}
+
+/// Return whether a failed read is safe to retry.
+///
+/// In addition to the statuses that are retryable for every operation, tonic
+/// can surface HTTP/2 connection retirement as either:
+///
+/// - `Internal("h2 protocol error: http2 error")` for a remote GOAWAY, or
+/// - `Cancelled("operation was canceled")` when hyper closes the connection.
+///
+/// Reads are idempotent, so replaying these bounded attempts is safe.
+/// A write may have reached Bigtable before its connection closed,
+/// making its outcome ambiguous.
+fn retryable_read_err(status: &Status) -> bool {
+    if retryable_internal_err(status) {
+        return true;
+    }
+
+    match status.code() {
+        Code::Internal => status
+            .message()
+            .eq_ignore_ascii_case("h2 protocol error: http2 error"),
+        Code::Cancelled => status
+            .message()
+            .eq_ignore_ascii_case("operation was canceled"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+
+    #[test]
+    fn retries_tonic_pre_send_readiness_errors() {
+        let status = Status::unknown("Service was not ready: transport error");
+        assert!(retryable_internal_err(&status));
+    }
+
+    #[test]
+    fn does_not_retry_arbitrary_unknown_errors() {
+        let status = Status::unknown("operation outcome is unknown");
+        assert!(!retryable_internal_err(&status));
+    }
+
+    #[test]
+    fn retries_transient_bigtable_statuses() {
+        assert!(retryable_internal_err(&Status::unavailable(
+            "No zones were available"
+        )));
+        assert!(retryable_internal_err(&Status::deadline_exceeded(
+            "deadline exceeded"
+        )));
+    }
+
+    #[test]
+    fn retries_observed_tonic_transport_failures_for_reads() {
+        let metrics = Arc::new(StatsdClient::builder("", cadence::NopMetricSink).build());
+
+        let goaway = Status::internal("h2 protocol error: http2 error");
+        assert!(retryable_read_err(&goaway));
+        assert!(retryable_bt_err(&metrics)(&error::BigTableError::Read(
+            goaway
+        )));
+
+        let connection_closed = Status::cancelled("operation was canceled");
+        assert!(retryable_read_err(&connection_closed));
+        assert!(retryable_bt_err(&metrics)(&error::BigTableError::Read(
+            connection_closed
+        )));
+    }
+
+    #[test]
+    fn does_not_replay_writes_for_observed_tonic_transport_failures() {
+        let metrics = Arc::new(StatsdClient::builder("", cadence::NopMetricSink).build());
+
+        let goaway =
+            error::BigTableError::Write(Status::internal("h2 protocol error: http2 error"));
+        assert!(!retryable_bt_err(&metrics)(&goaway));
+
+        let connection_closed =
+            error::BigTableError::Write(Status::cancelled("operation was canceled"));
+        assert!(!retryable_bt_err(&metrics)(&connection_closed));
+    }
+
+    #[test]
+    fn default_retry_budget_is_bounded() {
+        assert_eq!(RETRY_COUNT, 2);
     }
 }
 
@@ -377,15 +470,27 @@ pub fn retryable_status(metrics: &Arc<StatsdClient>) -> impl Fn(&Status) -> bool
     }
 }
 
+pub fn retryable_read_status(metrics: &Arc<StatsdClient>) -> impl Fn(&Status) -> bool + '_ {
+    move |status| {
+        info!("GRPC read failure: {:?}", status);
+        let retry = retryable_read_err(status);
+        if retry {
+            metric(metrics, "RpcFailure", Some(&format!("{:?}", status.code())));
+        }
+        retry
+    }
+}
+
 pub fn retryable_bt_err(
     metrics: &Arc<StatsdClient>,
 ) -> impl Fn(&error::BigTableError) -> bool + '_ {
     move |err| {
         debug!("🉑 Checking BigTableError...{err}");
         match err {
-            error::BigTableError::InvalidRowResponse(s)
-            | error::BigTableError::Read(s)
-            | error::BigTableError::Write(s) => retryable_status(metrics)(s),
+            error::BigTableError::InvalidRowResponse(s) | error::BigTableError::Read(s) => {
+                retryable_read_status(metrics)(s)
+            }
+            error::BigTableError::Write(s) => retryable_status(metrics)(s),
             // Failures to fetch an OAuth token (e.g. a transient metadata
             // server hiccup) are retryable, matching the prior behavior of
             // retrying grpcio's oauth token fetch errors.

--- a/autopush-common/src/db/bigtable/bigtable_client/mod.rs
+++ b/autopush-common/src/db/bigtable/bigtable_client/mod.rs
@@ -62,6 +62,12 @@ const RELIABLE_LOG_FAMILY: &str = "reliability";
 /// /// In most use cases, converted to seconds through .num_seconds().
 pub const RELIABLE_LOG_TTL: TimeDelta = TimeDelta::days(60);
 
+/// Default number of retries after the initial Bigtable RPC attempt.
+///
+/// So a connectivity failure cannot fan out into a
+/// retry storm, we try to keep this number small.
+/// Can be overriden through `db_settings`.retry_count`;
+/// health checks use this default directly.
 pub(crate) const RETRY_COUNT: usize = 2;
 
 /// Maximum gRPC message size (256MB), matching the prior grpcio configuration.
@@ -459,47 +465,31 @@ pub fn metric(metrics: &Arc<StatsdClient>, err_type: &str, code: Option<&str>) {
     metric.send();
 }
 
-pub fn retryable_status(metrics: &Arc<StatsdClient>) -> impl Fn(&Status) -> bool + '_ {
-    move |status| {
-        info!("GRPC Failure: {:?}", status);
-        let retry = retryable_internal_err(status);
-        if retry {
-            metric(metrics, "RpcFailure", Some(&format!("{:?}", status.code())));
-        }
-        retry
-    }
-}
-
-pub fn retryable_read_status(metrics: &Arc<StatsdClient>) -> impl Fn(&Status) -> bool + '_ {
-    move |status| {
-        info!("GRPC read failure: {:?}", status);
-        let retry = retryable_read_err(status);
-        if retry {
-            metric(metrics, "RpcFailure", Some(&format!("{:?}", status.code())));
-        }
-        retry
-    }
-}
-
 pub fn retryable_bt_err(
     metrics: &Arc<StatsdClient>,
 ) -> impl Fn(&error::BigTableError) -> bool + '_ {
     move |err| {
         debug!("🉑 Checking BigTableError...{err}");
-        match err {
+        let (status, retry) = match err {
             error::BigTableError::InvalidRowResponse(s) | error::BigTableError::Read(s) => {
-                retryable_read_status(metrics)(s)
+                (s, retryable_read_err(s))
             }
-            error::BigTableError::Write(s) => retryable_status(metrics)(s),
+            error::BigTableError::Write(s) => (s, retryable_internal_err(s)),
             // Failures to fetch an OAuth token (e.g. a transient metadata
             // server hiccup) are retryable, matching the prior behavior of
             // retrying grpcio's oauth token fetch errors.
             error::BigTableError::Auth(_) => {
                 metric(metrics, "Auth", None);
-                true
+                return true;
             }
-            _ => false,
+            _ => return false,
+        };
+
+        info!("GRPC Failure: {:?}", status);
+        if retry {
+            metric(metrics, "RpcFailure", Some(&format!("{:?}", status.code())));
         }
+        retry
     }
 }
 

--- a/autopush-common/src/db/bigtable/mod.rs
+++ b/autopush-common/src/db/bigtable/mod.rs
@@ -83,7 +83,9 @@ pub struct BigTableDbSettings {
     /// Include route to leader header in metadata
     #[serde(default)]
     pub route_to_leader: bool,
-    /// Number of times to retry a GRPC function
+    /// Number of retries after the initial gRPC data operation. Defaults to
+    /// two. Health checks always use the same default and cannot be
+    /// configured separately.
     #[serde(default = "retry_default")]
     pub retry_count: usize,
     /// Max lifetime (in seconds) for a router entry
@@ -175,6 +177,7 @@ mod tests {
             settings.database_pool_create_timeout,
             Some(std::time::Duration::from_secs(123))
         );
+        assert_eq!(settings.retry_count, 2);
         Ok(())
     }
     #[test]

--- a/autopush-common/src/db/bigtable/pool.rs
+++ b/autopush-common/src/db/bigtable/pool.rs
@@ -79,12 +79,8 @@ impl BigTablePool {
         debug!("🉑 connection string {}", &connection);
 
         // Construct a new manager and put them in a pool for handling future requests.
-        let manager = BigtableClientManager::new(
-            &bt_settings,
-            settings.dsn.clone(),
-            connection.clone(),
-            metrics.clone(),
-        )?;
+        let manager =
+            BigtableClientManager::new(&bt_settings, settings.dsn.clone(), connection.clone())?;
         let mut config = PoolConfig {
             // Prefer LIFO to allow the sweeper task to evict least frequently
             // used connections
@@ -138,7 +134,6 @@ pub struct BigtableClientManager {
     settings: BigTableDbSettings,
     dsn: Option<String>,
     connection: String,
-    metrics: Arc<StatsdClient>,
     /// Lazily initialized Application Default Credentials (ADC) token
     /// provider, shared across all pooled connections (it caches and
     /// refreshes tokens internally). `None` until first used; never
@@ -151,13 +146,11 @@ impl BigtableClientManager {
         settings: &BigTableDbSettings,
         dsn: Option<String>,
         connection: String,
-        metrics: Arc<StatsdClient>,
     ) -> Result<Self, BigTableError> {
         Ok(Self {
             settings: settings.clone(),
             dsn,
             connection,
-            metrics,
             auth_provider: OnceCell::new(),
         })
     }
@@ -204,7 +197,7 @@ impl Manager for BigtableClientManager {
     async fn create(&self) -> Result<BigtableDb, Self::Error> {
         debug!("🏊 Create a new pool entry.");
         let entry = BigtableDb::new(
-            self.get_channel().await?,
+            self.get_channel()?,
             self.token_provider().await?,
             &self.settings.health_metadata()?,
             &self.settings.table_name,
@@ -216,7 +209,7 @@ impl Manager for BigtableClientManager {
     /// Recycle if the connection has outlived it's lifespan.
     async fn recycle(
         &self,
-        client: &mut Self::Type,
+        _client: &mut Self::Type,
         metrics: &deadpool::managed::Metrics,
     ) -> deadpool::managed::RecycleResult<Self::Error> {
         if let Some(timeout) = self.settings.database_pool_connection_ttl
@@ -233,30 +226,31 @@ impl Manager for BigtableClientManager {
             return Err(RecycleError::message("Connection too idle"));
         }
 
-        if !client
-            .health_check(&self.metrics.clone(), &self.settings.app_profile_id)
-            .await
-            .inspect_err(|e| debug!("🏊 Recycle requested (health). {:?}", e))?
-        {
-            debug!("🏊 Health check failed");
-            return Err(RecycleError::message("Health check failed"));
-        }
-
+        // A tonic Channel reconnects its transport as needed. Do not issue a
+        // Bigtable ReadRows RPC merely to check a pooled object back out: that
+        // doubles healthy traffic and can amplify an outage through retries.
+        // The application's explicit health endpoint still performs a real
+        // Bigtable health check.
         Ok(())
     }
 }
 
 impl BigtableClientManager {
     /// Get a new Channel, based on the application settings.
-    pub async fn get_channel(&self) -> Result<Channel, BigTableError> {
-        Self::create_channel(&self.connection, self.is_emulator()).await
+    pub fn get_channel(&self) -> Result<Channel, BigTableError> {
+        Self::create_channel(
+            &self.connection,
+            self.is_emulator(),
+            self.settings.database_pool_create_timeout,
+        )
     }
 
     /// Channels are the tonic transport constructs that contain the actual
     /// HTTP/2 connection. Channels are fairly light weight.
-    pub async fn create_channel(
+    pub fn create_channel(
         connection: &str,
         is_emulator: bool,
+        connect_timeout: Option<Duration>,
     ) -> Result<Channel, BigTableError> {
         debug!("🏊 Creating new channel...");
         // The emulator runs plain HTTP/2 without TLS or credentials.
@@ -268,6 +262,28 @@ impl BigtableClientManager {
                 .tls_config(ClientTlsConfig::new().with_native_roots())
                 .map_err(BigTableError::Connect)?;
         }
-        endpoint.connect().await.map_err(BigTableError::Connect)
+        if let Some(connect_timeout) = connect_timeout {
+            endpoint = endpoint.connect_timeout(connect_timeout);
+        }
+        Ok(endpoint.connect_lazy())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[actix_rt::test]
+    async fn channel_creation_is_lazy() {
+        // Port 9 is intentionally not expected to host a Bigtable emulator.
+        // Constructing the channel must still succeed without touching the
+        // network; the first RPC is responsible for establishing a connection.
+        let channel = BigtableClientManager::create_channel(
+            "127.0.0.1:9",
+            true,
+            Some(Duration::from_millis(10)),
+        );
+
+        assert!(channel.is_ok());
     }
 }

--- a/docs/src/datastore.md
+++ b/docs/src/datastore.md
@@ -28,9 +28,12 @@ It offers reasonable cost for the sort of scale that we see, and the performance
 The Bigtable DSN begins with the prefix `grpc` and points to the host and port of the Bigtable database (e.g. to point to a local emulator you would specify `grpc://localhost:8086`)
 
 Bigtable's database configuration options are stored in the `db_settings` as a serialized JSON string. The settings include:
+
 * `message_family` the Bigtable cell family that refers to the **message** data collections
 * `router_family` the Bigtable cell family that refers to the **router** data collections
 * `table_name` the Bigtable internal path URI to the table. You construct this by using the following template `projects/{YOUR PROJECT}/instances/{INSTANCE NAME}/tables/{TABLE NAME}`. For example, if I had created a GCP project named "test-prod", that has an instance ID of "test-prod-us" which contained a table named "auto-test", the `table_name` would be `projects/test-prod/instances/test-prod-us/tables/auto-test`.
+* `retry_count` the number of retries after the initial Bigtable data operation. It defaults to 2 (reduced from 5 to limit retry storms). Health checks also use 2 retries, but their retry count is not separately configurable.
+
 The `scripts/setup_bt.sh` file contains a collection of commands that can be used to configure Bigtable storage, or at least aid in setting up the table.
 
 ### Redis/Valkey


### PR DESCRIPTION
The `grpcio` to `tonic` migration replaced `grpcio`'s lazily-connected channel with tonic's eager `connect().await`, which moved connection establishment into `pool.get()` so that connection failures returned before reaching the circuit breaker's `record_failure()` accounting in read_rows/mutate_row. As a result, a BigTable connectivity event produced connection failures the breaker never observed, so it never opened, and normal churn amplified into an unbounded reconnect storm. 

This switches channel creation to `connect_lazy()` so dialing happens on the first RPC inside the breaker-guarded paths (matching the old grpcio behavior), and drops the now-unnecessary `async` from the channel constructors since `connect_lazy()` performs no I/O.