### PR TITLE
fix(ci): fix service account for coverage and test upload

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -78,7 +78,7 @@ jobs:
     with:
       destination: gs://ecosystem-test-eng-metrics/autopush-rs/junit
       extension: xml
-      service_account: ${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-autopush-prod.iam.gserviceaccount.com
+      service_account: ${{ vars.GCS_ARTIFACT_UPLOAD_SERVICE_ACCOUNT }}
 
   upload-coverage:
     needs: check-and-test
@@ -90,4 +90,4 @@ jobs:
     with:
       destination: gs://ecosystem-test-eng-metrics/autopush-rs/coverage
       extension: json
-      service_account: ${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-autopush-prod.iam.gserviceaccount.com
+      service_account: ${{ vars.GCS_ARTIFACT_UPLOAD_SERVICE_ACCOUNT }}

--- a/.github/workflows/reuse-upload-test-artifacts-to-gcs.yaml
+++ b/.github/workflows/reuse-upload-test-artifacts-to-gcs.yaml
@@ -5,9 +5,8 @@ on:
     inputs:
       service_account:
         description: "Service account to use for authentication"
-        required: false
+        required: true
         type: string
-        default: "artifact-writer@moz-fx-autopush-prod.iam.gserviceaccount.com"
       source:
         description: "Source directory containing test artifacts"
         required: false


### PR DESCRIPTION
Reuse the same service account CircleCI was for uploading test and coverage artifacts to GCS (added to repository variables under `GCS_ARTIFACT_UPLOAD_SERVICE_ACCOUNT`)