### PR TITLE
fix(config)!: require user-set AUTOEND__AUTH_KEYS

### DIFF
--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -119,7 +119,7 @@ impl Default for Settings {
             // presume base64 encoding, so we can bump things up to 5630 bytes max.
             max_data_bytes: 5630,
             crypto_keys: format!("[{}]", Fernet::generate_key()),
-            auth_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]"#.to_string(),
+            auth_keys: r#"[]"#.to_string(),
             tracking_keys: r#"[]"#.to_string(),
             human_logs: false,
             connection_timeout_millis: 1000,
@@ -182,7 +182,9 @@ impl Settings {
                 }
             }
         })?;
-
+        // Reject empty or missing auth_keys; may pass deserialization
+        // so have to check here
+        built.validate_auth_keys()?;
         Ok(built)
     }
 
@@ -218,6 +220,15 @@ impl Settings {
         Self::read_list_from_str(keys, "Invalid AUTOEND_AUTH_KEYS")
             .map(|v| v.to_owned())
             .collect()
+    }
+    /// Validate at least one usable (non-empty) auth key is configured.
+    fn validate_auth_keys(&self) -> Result<(), ConfigError> {
+        if self.auth_keys().iter().all(|key| key.is_empty()) {
+            return Err(ConfigError::Message(
+                "AUTOEND__AUTH_KEYS must contain at least one non-empty key".to_owned(),
+            ));
+        }
+        Ok(())
     }
 
     /// Get the list of tracking public keys converted to raw, x962 format byte arrays.
@@ -322,6 +333,30 @@ mod tests {
         };
         let result = settings.auth_keys();
         assert_eq!(result, success);
+        Ok(())
+    }
+    #[test]
+    fn test_auth_keys_rejects() -> ApiResult<()> {
+        // Unset *(rejects default)
+        assert!(Settings::default().validate_auth_keys().is_err());
+        // Empty array
+        let settings = Settings {
+            auth_keys: r#"[]"#.to_owned(),
+            ..Default::default()
+        };
+        assert!(settings.validate_auth_keys().is_err());
+        // Only empty strings
+        let settings = Settings {
+            auth_keys: r#"["", ""]"#.to_owned(),
+            ..Default::default()
+        };
+        assert!(settings.validate_auth_keys().is_err());
+        // A non-empty key passes
+        let settings = Settings {
+            auth_keys: r#"["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]"#.to_owned(),
+            ..Default::default()
+        };
+        assert!(settings.validate_auth_keys().is_ok());
         Ok(())
     }
 

--- a/configs/autoendpoint.toml.sample
+++ b/configs/autoendpoint.toml.sample
@@ -31,6 +31,8 @@
 
 # The HMAC SHA256 keys to use, for authenticating registration update requests.
 # Multiple are allowed when separated by a comma.
+# Should be replaced with a real key when deployed
+# Defaults to an empty array which will cause startup to fail
 #auth_keys = "["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]"
 
 # If human-readable logging should be used

--- a/docs/src/config_options.md
+++ b/docs/src/config_options.md
@@ -51,36 +51,37 @@ The following configuration options can be specified either in the configuration
 
 | **option** | **env var** | **type** | **default value** | **description** |
 |---|---|---|---|---|
-| <span id="AUTOENDPOINT__SCHEME" />scheme | AUTOENDPOINT__SCHEME | string | "http" | The URL scheme (http/https) for the endpoint URL |
-| <span id="AUTOENDPOINT__HOST" />host | AUTOENDPOINT__HOST | string | "127.0.0.1" | The machine host for the endpoint URL (e.g. `localhost`) |
-| <span id="AUTOENDPOINT__PORT" />port | AUTOENDPOINT__PORT | num | 8000 | The application port override for the endpoint URL |
-| <span id="AUTOENDPOINT__ENDPOINT_URL" />endpoint_url | AUTOENDPOINT__ENDPOINT_URL | string | _None_ | The full URL for the endpoint (overrides `scheme`, `host`, and `port` if set) |
-| <span id="AUTOENDPOINT__DB_DSN" />db_dsn | AUTOENDPOINT__DB_DSN | string | _None_ | Data Source Name for the back end database |
-| <span id="AUTOENDPOINT__DB_SETTINGS" />db_settings | AUTOENDPOINT__DB_SETTINGS | string | _None_ | Serialized JSON structure of Database settings (see each data store for details) |
-| <span id="AUTOENDPOINT__ROUTER_TABLE_NAME" />router_table_name | AUTOENDPOINT__ROUTER_TABLE_NAME | string | "router" | The name of the database table to use for the router (Note, this is legacy and will be removed in a future release) |
-| <span id="AUTOENDPOINT__MESSAGE_TABLE_NAME" />message_table_name | AUTOENDPOINT__MESSAGE_TABLE_NAME | string | "message" | The name of the database table to use for messages (Note, this is legacy and will be removed in a future release) |
-| <span id="AUTOENDPOINT__TRACKING_KEYS" />tracking_keys | AUTOENDPOINT__TRACKING_KEYS | string | _None_ | Comma separated list of VAPID public keys to track for reliability (if `--features=reliable_report` enabled) |
-| <span id="AUTOENDPOINT__MAX_DATA_BYTES" />max_data_bytes | AUTOENDPOINT__MAX_DATA_BYTES | num | 4096 | Maximum number of bytes to accept in the `data` field of a message |
-| <span id="AUTOENDPOINT__CRYPTO_KEYS" />crypto_keys | AUTOENDPOINT__CRYPTO_KEYS | string | _internally generated value_ | Comma separated list of cryptographic keys to use for endpoint encryption (the first key will be used for encrypting new messages) |
-| <span id="AUTOENDPOINT__AUTH_KEYS" />auth_keys | AUTOENDPOINT__AUTH_KEYS | string | _None_ | Comma separated list of authentication keys to use for client endpoint authentication (the first key will be used for authenticating new messages) |
-| <span id="AUTOENDPOINT__HUMAN_LOGS" />human_logs | AUTOENDPOINT__HUMAN_LOGS | bool | false | Whether to use human readable log formatting (e.g. timestamps, log levels) |
-| <span id="AUTOENDPOINT__CONNECTION_TIMEOUT_MILLIS" />connection_timeout_millis | AUTOENDPOINT__CONNECTION_TIMEOUT_MILLIS | num | 1000 | Number of milliseconds to wait for a bridge connection before timing out |
-| <span id="AUTOENDPOINT__REQUEST_TIMEOUT_MILLIS" />request_timeout_millis | AUTOENDPOINT__REQUEST_TIMEOUT_MILLIS | num | 3000 | Number of milliseconds to wait for a bridge request before timing out |
-| <span id="AUTOENDPOINT__STATSD_HOST" />statsd_host | AUTOENDPOINT__STATSD_HOST | string | "localhost" | Name of the statsd collector host |
-| <span id="AUTOENDPOINT__STATSD_PORT" />statsd_port | AUTOENDPOINT__STATSD_PORT | port | 8125 |
-| <span id="AUTOENDPOINT__STATSD_LABEL" />statsd_label | AUTOENDPOINT__STATSD_LABEL | string | "autoendpoint" | Label to use for statsd metrics |
-| <span id="AUTOENDPOINT__RELIABILITY_DSN" />reliability_dsn | AUTOENDPOINT__RELIABILITY_DSN | string | _None_ | Data Source Name for the reliability data store, if `--features=reliable_report` enabled |
-| <span id="AUTOENDPOINT__RELIABILITY_RETRY_COUNT" />reliability_retry_count | AUTOENDPOINT__RELIABILITY_RETRY_COUNT | num | 10 | Number of times to retry a Redis transaction write for reliability, if `--features=reliable_report` enabled |
-| <span id="AUTOENDPOINT__MAX_NOTIFICATION_TTL" />max_notification_ttl | AUTOENDPOINT__MAX_NOTIFICATION_TTL | num | 2592000 (30 days) | Maximum allowed TTL (in seconds) for a notification message |
+| <span id="AUTOEND__SCHEME" />scheme | AUTOEND__SCHEME | string | "http" | The URL scheme (http/https) for the endpoint URL |
+| <span id="AUTOEND__HOST" />host | AUTOEND__HOST | string | "127.0.0.1" | The machine host for the endpoint URL (e.g. `localhost`) |
+| <span id="AUTOEND__PORT" />port | AUTOEND__PORT | num | 8000 | The application port override for the endpoint URL |
+| <span id="AUTOEND__ENDPOINT_URL" />endpoint_url | AUTOEND__ENDPOINT_URL | string | _None_ | The full URL for the endpoint (overrides `scheme`, `host`, and `port` if set) |
+| <span id="AUTOEND__DB_DSN" />db_dsn | AUTOEND__DB_DSN | string | _None_ | Data Source Name for the back end database |
+| <span id="AUTOEND__DB_SETTINGS" />db_settings | AUTOEND__DB_SETTINGS | string | _None_ | Serialized JSON structure of Database settings (see each data store for details) |
+| <span id="AUTOEND__ROUTER_TABLE_NAME" />router_table_name | AUTOEND__ROUTER_TABLE_NAME | string | "router" | The name of the database table to use for the router (Note, this is legacy and will be removed in a future release) |
+| <span id="AUTOEND__MESSAGE_TABLE_NAME" />message_table_name | AUTOEND__MESSAGE_TABLE_NAME | string | "message" | The name of the database table to use for messages (Note, this is legacy and will be removed in a future release) |
+| <span id="AUTOEND__TRACKING_KEYS" />tracking_keys | AUTOEND__TRACKING_KEYS | string | _None_ | Comma separated list of VAPID public keys to track for reliability (if `--features=reliable_report` enabled) |
+| <span id="AUTOEND__MAX_DATA_BYTES" />max_data_bytes | AUTOEND__MAX_DATA_BYTES | num | 4096 | Maximum number of bytes to accept in the `data` field of a message |
+| <span id="AUTOEND__CRYPTO_KEYS" />crypto_keys | AUTOEND__CRYPTO_KEYS | string | _internally generated value_ | Comma separated list of cryptographic keys to use for endpoint encryption (the first key will be used for encrypting new messages) |
+| <span id="AUTOEND__AUTH_KEYS" />auth_keys | AUTOEND__AUTH_KEYS | string | "[]" | Comma separated list of authentication keys to use for client endpoint authentication (the first key will be used for authenticating new messages). Must contain at least one valid non-empty string. |
+| <span id="AUTOEND__HUMAN_LOGS" />human_logs | AUTOEND__HUMAN_LOGS | bool | false | Whether to use human readable log formatting (e.g. timestamps, log levels) |
+| <span id="AUTOEND__CONNECTION_TIMEOUT_MILLIS" />connection_timeout_millis | AUTOEND__CONNECTION_TIMEOUT_MILLIS | num | 1000 | Number of milliseconds to wait for a bridge connection before timing out |
+| <span id="AUTOEND__REQUEST_TIMEOUT_MILLIS" />request_timeout_millis | AUTOEND__REQUEST_TIMEOUT_MILLIS | num | 3000 | Number of milliseconds to wait for a bridge request before timing out |
+| <span id="AUTOEND__STATSD_HOST" />statsd_host | AUTOEND__STATSD_HOST | string | "localhost" | Name of the statsd collector host |
+| <span id="AUTOEND__STATSD_PORT" />statsd_port | AUTOEND__STATSD_PORT | port | 8125 |
+| <span id="AUTOEND__STATSD_LABEL" />statsd_label | AUTOEND__STATSD_LABEL | string | "autoendpoint" | Label to use for statsd metrics |
+| <span id="AUTOEND__RELIABILITY_DSN" />reliability_dsn | AUTOEND__RELIABILITY_DSN | string | _None_ | Data Source Name for the reliability data store, if `--features=reliable_report` enabled |
+| <span id="AUTOEND__RELIABILITY_RETRY_COUNT" />reliability_retry_count | AUTOEND__RELIABILITY_RETRY_COUNT | num | 10 | Number of times to retry a Redis transaction write for reliability, if `--features=reliable_report` enabled |
+| <span id="AUTOEND__MAX_NOTIFICATION_TTL" />max_notification_ttl | AUTOEND__MAX_NOTIFICATION_TTL | num | 2592000 (30 days) | Maximum allowed TTL (in seconds) for a notification message |
 
 ### FCM Settings
+
 | **option** | **env var** | **type** | **default value** | **description** |
 |---|---|---|---|---|
-| <span id="AUTOENDPOINT__FCM__SERVER_CREDENTIALS" />fcm.server_credentials | AUTOENDPOINT__FCM__SERVER_CREDENTIALS | string | _None_ | Serialized JSON structure of FCM server credentials (see below) |
-| <span id="AUTOENDPOINT__FCM__MAX_DATA" />fcm.max_data | AUTOENDPOINT__FCM__MAX_DATA | num | 4096 | Maximum number of bytes to accept in the `data` field of a message for FCM messages |
-| <span id="AUTOENDPOINT__FCM__BASE_URL" />fcm.base_url | AUTOENDPOINT__FCM__BASE_URL | string | "https://fcm.googleapis.com/fcm/send" | The base URL for FCM API requests |
-| <span id="AUTOENDPOINT__FCM__TIMEOUT" />fcm.timeout | AUTOENDPOINT__FCM__TIMEOUT | num | 3 | Number of seconds to wait for an FCM API request before timing out |
-| <span id="AUTOENDPOINT__FCM__MAX_TTL" />fcm.max_ttl | AUTOENDPOINT__FCM__MAX_TTL | num | 2419200 (28 days) | Maximum allowed TTL (in seconds) for an FCM message |
+| <span id="AUTOEND__FCM__SERVER_CREDENTIALS" />fcm.server_credentials | AUTOEND__FCM__SERVER_CREDENTIALS | string | _None_ | Serialized JSON structure of FCM server credentials (see below) |
+| <span id="AUTOEND__FCM__MAX_DATA" />fcm.max_data | AUTOEND__FCM__MAX_DATA | num | 4096 | Maximum number of bytes to accept in the `data` field of a message for FCM messages |
+| <span id="AUTOEND__FCM__BASE_URL" />fcm.base_url | AUTOEND__FCM__BASE_URL | string | "<https://fcm.googleapis.com/fcm/send>" | The base URL for FCM API requests |
+| <span id="AUTOEND__FCM__TIMEOUT" />fcm.timeout | AUTOEND__FCM__TIMEOUT | num | 3 | Number of seconds to wait for an FCM API request before timing out |
+| <span id="AUTOEND__FCM__MAX_TTL" />fcm.max_ttl | AUTOEND__FCM__MAX_TTL | num | 2419200 (28 days) | Maximum allowed TTL (in seconds) for an FCM message |
 
 `fcm.server_credentials` should be a serialized JSON dictionary. Each key should be the `app_id` of the FCM channel as identified by the client. This `app_id` would appear in the registration request URL (e.g. the "foo" channel would appear in the registration as `/v1/fcm/foo/registration/...`) with the following structure:
 
@@ -93,14 +94,15 @@ The following configuration options can be specified either in the configuration
     }
 }
 ```
+
 ### APNS Settings
 
 | **option** | **env var** | **type** | **default value** | **description** |
 |---|---|---|---|---|
-| <span id="AUTOENDPOINT__APNS__CHANNELS" />apns.channels | AUTOENDPOINT__APNS__CHANNELS | string | _None_ | JSON structure of APNS channel definitions (see below) |
-| <span id="AUTOENDPOINT__APNS__MAX_DATA" />apns.max_data | AUTOENDPOINT__APNS__MAX_DATA | num | 4096 | Maximum number of bytes to accept in the `data` field of a message for APNS messages |
-| <span id="AUTOENDPOINT__APNS__REQUEST_TIMEOUT_SECS" />apns.request_timeout_secs | AUTOENDPOINT__APNS__REQUEST_TIMEOUT_SECS | num | 3 | Number of seconds to wait for an APNS API request before timing out |
-| <span id="AUTOENDPOINT__APNS__POOL_IDLE_TIMEOUT_SECS" />apns.pool_idle_timeout_secs | AUTOENDPOINT__APNS__POOL_IDLE_TIMEOUT_SECS | num | 60 | Number of seconds to keep idle connections in the APNS connection pool before closing them |
+| <span id="AUTOEND__APNS__CHANNELS" />apns.channels | AUTOEND__APNS__CHANNELS | string | _None_ | JSON structure of APNS channel definitions (see below) |
+| <span id="AUTOEND__APNS__MAX_DATA" />apns.max_data | AUTOEND__APNS__MAX_DATA | num | 4096 | Maximum number of bytes to accept in the `data` field of a message for APNS messages |
+| <span id="AUTOEND__APNS__REQUEST_TIMEOUT_SECS" />apns.request_timeout_secs | AUTOEND__APNS__REQUEST_TIMEOUT_SECS | num | 3 | Number of seconds to wait for an APNS API request before timing out |
+| <span id="AUTOEND__APNS__POOL_IDLE_TIMEOUT_SECS" />apns.pool_idle_timeout_secs | AUTOEND__APNS__POOL_IDLE_TIMEOUT_SECS | num | 60 | Number of seconds to keep idle connections in the APNS connection pool before closing them |
 
 `apns.channels` should be a serialized JSON structure containing a dictionary. Each key should be the `app_id` of the APNS channel as identified by the client. This `app_id` would appear in the registration request URL (e.g. the "foo" channel would appear in the registration as `/v1/apns/foo/registration/...`) with the following structure:
 
@@ -115,4 +117,3 @@ The following configuration options can be specified either in the configuration
     }
 }
 ```
-

--- a/scripts/smoketests/autoendpoint.sh
+++ b/scripts/smoketests/autoendpoint.sh
@@ -33,6 +33,7 @@ CONTAINER_ID=$(docker run --detach --quiet \
   -e AUTOEND__HOST=0.0.0.0 \
   -e AUTOEND__DB_DSN=grpc://localhost:8086 \
   -e AUTOEND__DB_SETTINGS='{"table_name":"projects/test/instances/test/tables/autopush"}' \
+  -e AUTOEND__AUTH_KEYS='["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]' \
   -p "$PORT:$PORT" \
   "$IMAGE_NAME")
 

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -190,6 +190,7 @@ ENDPOINT_CONFIG = dict(
     crypto_keys=f"[{CRYPTO_KEY}]",
     # convert to x692 format
     tracking_keys=f"""[{encoded}]""",
+    auth_keys='["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB="]',
 )
 
 # Note: These are only used by the `reliable_report` feature, however, specifying them


### PR DESCRIPTION
Guard against booting the server with default (insecure) keys. Startup now fails unless auth_keys contains at least one non-empty key. Default no longer provides a static key.

BREAKING CHANGE: servers depending on the default auth_keys will no longer start until a real key is set.

[PUSH-748]

Note - this does not affect any Mozilla deployments (the value was always set).

I also updated the table in the docs to use the correct prefix (`AUTOEND__` not `AUTOENDPOINT__`)

[PUSH-748]: https://mozilla-hub.atlassian.net/browse/PUSH-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ