### PR TITLE
chore: tag 1.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="1.83.0"></a>
+## 1.83.0 (2026-07-28)
+
+### Bug Fixes
+
+- *(config)* [**breaking**] Require user-set AUTOEND__AUTH_KEYS (#1203) ([1080af8b](https://github.com/mozilla-services/autopush-rs/commit/1080af8b8dda8e1251cbf24431ed7dfe15bbf678))
+- *(bigtable)* Tonic connection and retry management (#1209) ([7de5c3ea](https://github.com/mozilla-services/autopush-rs/commit/7de5c3ea083266d0d6e06e04ca2d3c3ef39df59f))
+- *(docs)* Fix publish docs missing step (#1216) ([83b0638b](https://github.com/mozilla-services/autopush-rs/commit/83b0638bebcc978590bad0c4890819888894b8cd))
+
+### Chore
+
+- *(ci:docs)* Fix actions/checkout step (#1206) ([7dea068a](https://github.com/mozilla-services/autopush-rs/commit/7dea068aba113d983679af39e5c9e89da2ac9d12))
+
 <a name="1.82.3"></a>
 ## 1.82.3 (2026-07-21)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autoconnect"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "a2",
  "actix-cors",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.82.3"
+version = "1.83.0"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
## 1.83.0 (2026-07-28)

### Bug Fixes

- *(config)* [**breaking**] Require user-set AUTOEND__AUTH_KEYS (#1203) ([1080af8b](https://github.com/mozilla-services/autopush-rs/commit/1080af8b8dda8e1251cbf24431ed7dfe15bbf678))
- *(bigtable)* Tonic connection and retry management (#1209) ([7de5c3ea](https://github.com/mozilla-services/autopush-rs/commit/7de5c3ea083266d0d6e06e04ca2d3c3ef39df59f))
- *(docs)* Fix publish docs missing step (#1216) ([83b0638b](https://github.com/mozilla-services/autopush-rs/commit/83b0638bebcc978590bad0c4890819888894b8cd))

### Chore

- *(ci:docs)* Fix actions/checkout step (#1206) ([7dea068a](https://github.com/mozilla-services/autopush-rs/commit/7dea068aba113d983679af39e5c9e89da2ac9d12))
