### PR TITLE
fix(logging): stop ERROR-level log flood from slog-async channel overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "hyper 1.11.0",
  "hyper-util",
  "lazy_static",
+ "log",
  "mockall",
  "mockito 0.31.1",
  "num_cpus",

--- a/autoconnect/autoconnect-settings/src/lib.rs
+++ b/autoconnect/autoconnect-settings/src/lib.rs
@@ -100,6 +100,11 @@ pub struct Settings {
     pub megaphone_poll_interval: Duration,
     /// Use human readable (simplified, non-JSON)
     pub human_logs: bool,
+    /// Number of log records to buffer before dropping them. Records are dropped
+    /// when the buffer is full, and each drop emits an ERROR level overflow
+    /// report, so this should comfortably exceed the peak logging rate. 0 uses
+    /// the default.
+    pub log_chan_size: usize,
     /// Maximum allowed number of backlogged messages. Exceeding this number will
     /// trigger a user reset because the user may have been offline way too long.
     pub msg_limit: u32,
@@ -156,6 +161,7 @@ impl Default for Settings {
             megaphone_api_token: None,
             megaphone_poll_interval: Duration::from_secs(30),
             human_logs: false,
+            log_chan_size: autopush_common::logging::DEFAULT_LOG_CHAN_SIZE,
             msg_limit: 150,
             client_channel_capacity: 128,
             actix_max_connections: None,

--- a/autoconnect/src/main.rs
+++ b/autoconnect/src/main.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<()> {
         Settings::with_env_and_config_files(&filenames).map_err(ApcErrorKind::ConfigError)?;
     logging::init_logging(
         !settings.human_logs,
+        settings.log_chan_size,
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
     )

--- a/autoendpoint/docs/operation_notes.md
+++ b/autoendpoint/docs/operation_notes.md
@@ -1,5 +1,27 @@
 # Operation Notes / Runbook (WIP)
-- Logging level can be controlled via the `RUST_LOG` env variable on a per-module
-  basis: https://docs.rs/slog-envlogger/2.2.0/slog_envlogger/
-- Nested settings (ex. `FcmSettings`) can be set with environment variables. For
-  example, to set `settings.fcm.ttl`, use `AUTOEND_FCM.TTL=60`
+
+## Logging
+
+Logging level can be controlled via the `RUST_LOG` env variable on a per-module basis: <https://docs.rs/slog-envlogger/2.2.0/slog_envlogger/>.
+
+Note that there is a compile-time ceiling (`STATIC_MAX_LEVEL`), which is fixed at build time by Cargo features on the log crate. No runtime setting, including `RUST_LOG`, can re-enable them.
+
+Our own logging is unaffected by the compile-time ceiling, since application code logs through `slog`/`slog_scope` which reaches the logger directly. Any level our code emits (including `debug!`/`trace!`) is governed only by `RUST_LOG` at runtime.
+
+**Dependency** logging is capped in release by `STATIC_MAX_LEVEL`. This prevents tracing events from `hyper`, `h2`, `tonic`, and `tower` from falling through to the log crate (if no tracing subscriber is installed).
+
+If you need debug/trace from a log/tracing-emitting dependency (e.g. to debug an h2/tonic connection issue), a release binary won't produce it. You must either:
+
+- run a debug build (ceiling is Debug; trace still compiled out), or
+- build with a higher release ceiling by adjusting the log feature in the root Cargo.toml, e.g. `release_max_level_debug` or `release_max_level_trace` — then set `RUST_LOG` to the desired per-module level.
+
+### Overflow buffer (`log_chan_size`)
+
+Records are buffered to a background writer thread. When that buffer fills, records are dropped and each drop emits an ERROR-level "logger dropped messages due to channel overflow" report. If you see those reports, the process is logging faster than it can write — raise `AUTOEND__LOG_CHAN_SIZE` / `AUTOCONNECT__LOG_CHAN_SIZE` (default 20000; 0 means "use the default"), or reduce log verbosity.
+
+## Settings
+
+Nested settings (ex. `FcmSettings`) can be set with environment variables. For
+example, to set `settings.fcm.ttl`, use `AUTOEND_FCM.TTL=60`
+ent variables. For
+example, to set `settings.fcm.ttl`, use `AUTOEND_FCM.TTL=60`

--- a/autoendpoint/src/main.rs
+++ b/autoendpoint/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let host_port = format!("{}:{}", &settings.host, &settings.port);
     logging::init_logging(
         !settings.human_logs,
+        settings.log_chan_size,
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
     )

--- a/autoendpoint/src/settings.rs
+++ b/autoendpoint/src/settings.rs
@@ -58,6 +58,11 @@ pub struct Settings {
     pub auth_keys: String,
     /// Whether to include human readable logs in the output.
     pub human_logs: bool,
+    /// Number of log records to buffer before dropping them. Records are dropped
+    /// when the buffer is full, and each drop emits an ERROR level overflow
+    /// report, so this should comfortably exceed the peak logging rate. 0 uses
+    /// the default.
+    pub log_chan_size: usize,
 
     /// Bridge connection timeout in milliseconds.
     pub connection_timeout_millis: u64,
@@ -122,6 +127,7 @@ impl Default for Settings {
             auth_keys: r#"[]"#.to_string(),
             tracking_keys: r#"[]"#.to_string(),
             human_logs: false,
+            log_chan_size: autopush_common::logging::DEFAULT_LOG_CHAN_SIZE,
             connection_timeout_millis: 1000,
             request_timeout_millis: 3000,
             pool_max_idle_per_host: 10,

--- a/autopush-common/Cargo.toml
+++ b/autopush-common/Cargo.toml
@@ -21,6 +21,10 @@ fernet.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 lazy_static.workspace = true
+# Depended on directly so the workspace's `release_max_level_info` feature is
+# actually applied: it compiles out `log`-crate debug/trace at the callsite,
+# which is where our dependencies' `tracing` output lands (see logging.rs).
+log.workspace = true
 mockall.workspace = true
 openssl.workspace = true
 rand.workspace = true

--- a/autopush-common/src/logging.rs
+++ b/autopush-common/src/logging.rs
@@ -6,8 +6,33 @@ use slog_mozlog_json::MozLogJson;
 
 use crate::errors::Result;
 
-pub fn init_logging(json: bool, name: &str, version: &str) -> Result<()> {
-    let logger = if json {
+/// Default number of records slog-async buffers before it begins dropping them.
+///
+/// slog-async's own default of 128 is trivially overrun: the consumer only needs
+/// to stall briefly (scheduling, a slow write) for the buffer to fill, and each
+/// dropped record then produces an ERROR level "channel overflow" report of its
+/// own, converting filtered-out records into unfilterable noise. Sized instead
+/// for seconds of headroom at a high logging rate; ~110 bytes per slot is
+/// allocated up front, so this costs roughly 2MB resident.
+pub const DEFAULT_LOG_CHAN_SIZE: usize = 20_000;
+
+/// Initialize logging.
+///
+/// `chan_size` is the slog-async buffer depth; see [`DEFAULT_LOG_CHAN_SIZE`]. A
+/// value of 0 is treated as the default: crossbeam would otherwise give us a
+/// rendezvous channel, blocking every logging call until the consumer picks the
+/// record up.
+pub fn init_logging(json: bool, chan_size: usize, name: &str, version: &str) -> Result<()> {
+    let chan_size = if chan_size == 0 {
+        DEFAULT_LOG_CHAN_SIZE
+    } else {
+        chan_size
+    };
+    // NOTE: `slog_envlogger` (the RUST_LOG filter) must be the *outermost*
+    // drain, wrapping `slog_async`. Nested inside it instead, every record is
+    // queued to the async channel before anyone checks its level, so RUST_LOG
+    // can't relieve channel pressure and filtered records still cause overflow.
+    let (logger, filter_level) = if json {
         let hostname = gethostname().to_string_lossy().to_string();
 
         let drain = MozLogJson::new(io::stdout())
@@ -16,23 +41,60 @@ pub fn init_logging(json: bool, name: &str, version: &str) -> Result<()> {
             .hostname(hostname)
             .build()
             .fuse();
+        let drain = slog_async::Async::new(drain)
+            .chan_size(chan_size)
+            .build()
+            .fuse();
         let drain = slog_envlogger::new(drain);
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(drain, slog_o!())
+        let filter_level = slog_envlogger::EnvLogger::filter(&drain);
+        (slog::Logger::root(drain, slog_o!()), filter_level)
     } else {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain)
+            .chan_size(chan_size)
+            .build()
+            .fuse();
         let drain = slog_envlogger::new(drain);
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(drain, slog_o!())
+        let filter_level = slog_envlogger::EnvLogger::filter(&drain);
+        (slog::Logger::root(drain, slog_o!()), filter_level)
     };
     // XXX: cancel slog_scope's NoGlobalLoggerSet for now, it's difficult to
     // prevent it from potentially panicing during tests. reset_logging resets
     // the global logger during shutdown anyway:
     // https://github.com/slog-rs/slog/issues/169
     slog_scope::set_global_logger(logger).cancel_reset();
-    slog_stdlog::init().ok();
+    // Register the `log` -> `slog` bridge, then set `log`'s ceiling separately:
+    // `init_with_level` takes a `log::Level`, which can't express "off".
+    slog_stdlog::init_with_level(log::Level::Error).ok();
+    log::set_max_level(log_max_level(filter_level));
     Ok(())
+}
+
+/// Translate the `RUST_LOG` filter's maximum level into a ceiling for the `log`
+/// crate.
+///
+/// Our own `slog` macros reach the logger directly, so this governs only records
+/// arriving via `log` -- that is, our dependencies. hyper/h2/tonic/tower emit
+/// `tracing` events and, with no `tracing` subscriber installed, those fall
+/// through to `log`; h2 in particular traces per HTTP/2 frame.
+///
+/// `slog_stdlog::init` would set the ceiling to TRACE, admitting all of it.
+/// Deriving the ceiling from the filter's own maximum instead means a record no
+/// directive could ever accept is rejected by `log::max_level()` before it is
+/// built, rather than being constructed and then dropped by the filter. Records
+/// between this ceiling and a narrower per-module directive still reach the
+/// filter, which remains the authority on what is actually logged.
+fn log_max_level(filter: slog::FilterLevel) -> log::LevelFilter {
+    match filter {
+        slog::FilterLevel::Off => log::LevelFilter::Off,
+        // `log` has no Critical; Error is the nearest ceiling that admits it.
+        slog::FilterLevel::Critical | slog::FilterLevel::Error => log::LevelFilter::Error,
+        slog::FilterLevel::Warning => log::LevelFilter::Warn,
+        slog::FilterLevel::Info => log::LevelFilter::Info,
+        slog::FilterLevel::Debug => log::LevelFilter::Debug,
+        slog::FilterLevel::Trace => log::LevelFilter::Trace,
+    }
 }
 
 pub fn reset_logging() {

--- a/docs/src/config_options.md
+++ b/docs/src/config_options.md
@@ -29,6 +29,7 @@ using their environment variable form.
 | <span id="AUTOCONNECT__ENDPOINT_SCHEME" />endpoint_scheme | AUTOCONNECT__ENDPOINT_SCHEME | string | "http" | The URL scheme (http/https) for the endpoint URL |
 | <span id="AUTOCONNECT__HOSTNAME" />hostname | AUTOCONNECT__HOSTNAME | string | _None_ | The machine host name (e.g. `localhost`) |
 | <span id="AUTOCONNECT__HUMAN_LOGS" />human_logs | AUTOCONNECT__HUMAN_LOGS | bool | false | Whether to use human readable log formatting (e.g. timestamps, log levels) |
+| <span id="AUTOCONNECT__LOG_CHAN_SIZE" />log_chan_size | AUTOCONNECT__LOG_CHAN_SIZE | num | 20000 | Number of log records to buffer before dropping them. Each dropped record emits an ERROR level overflow report, so this should comfortably exceed the peak logging rate. Costs roughly 110 bytes per slot, allocated at startup. 0 uses the default |
 | <span id="AUTOCONNECT__MEGAPHONE_API_TOKEN" />megaphone_api_token | AUTOCONNECT__MEGAPHONE_API_TOKEN | string | _None_ | Deprecated: Access token for the Remote Settings "Megaphone" API server, kept for compatibility |
 | <span id="AUTOCONNECT__MEGAPHONE_API_URL" />megaphone_api_url | AUTOCONNECT__MEGAPHONE_API_URL | string | _None_ | URL to the Remote Settings "Megaphone" API server |
 | <span id="AUTOCONNECT__MEGAPHONE_POLL_INTERVAL" />megaphone_poll_interval | AUTOCONNECT__MEGAPHONE_POLL_INTERVAL | string | _None_ | Period in seconds to poll the Remote Settings "Megaphone" server |
@@ -64,6 +65,7 @@ The following configuration options can be specified either in the configuration
 | <span id="AUTOEND__CRYPTO_KEYS" />crypto_keys | AUTOEND__CRYPTO_KEYS | string | _internally generated value_ | Comma separated list of cryptographic keys to use for endpoint encryption (the first key will be used for encrypting new messages) |
 | <span id="AUTOEND__AUTH_KEYS" />auth_keys | AUTOEND__AUTH_KEYS | string | "[]" | Comma separated list of authentication keys to use for client endpoint authentication (the first key will be used for authenticating new messages). Must contain at least one valid non-empty string. |
 | <span id="AUTOEND__HUMAN_LOGS" />human_logs | AUTOEND__HUMAN_LOGS | bool | false | Whether to use human readable log formatting (e.g. timestamps, log levels) |
+| <span id="AUTOEND__LOG_CHAN_SIZE" />log_chan_size | AUTOEND__LOG_CHAN_SIZE | num | 20000 | Number of log records to buffer before dropping them. Each dropped record emits an ERROR level overflow report, so this should comfortably exceed the peak logging rate. Costs roughly 110 bytes per slot, allocated at startup. 0 uses the default |
 | <span id="AUTOEND__CONNECTION_TIMEOUT_MILLIS" />connection_timeout_millis | AUTOEND__CONNECTION_TIMEOUT_MILLIS | num | 1000 | Number of milliseconds to wait for a bridge connection before timing out |
 | <span id="AUTOEND__REQUEST_TIMEOUT_MILLIS" />request_timeout_millis | AUTOEND__REQUEST_TIMEOUT_MILLIS | num | 3000 | Number of milliseconds to wait for a bridge request before timing out |
 | <span id="AUTOEND__STATSD_HOST" />statsd_host | AUTOEND__STATSD_HOST | string | "localhost" | Name of the statsd collector host |


### PR DESCRIPTION
Since 1.83.0 autoendpoint emitted ~156M log lines/day, of which ~154.8M were slog-async's own "logger dropped messages due to channel overflow" report at ERROR level. Caused by:

slog_async was the outermost drain, so the RUST_LOG filter ran on the consumer thread after records were already queued, filling up the 128-slot default buffer with records that were about to be discarded. Once full dropped messages errors were logged.

The tonic migration introduced tracing  that fell through to logs without a tracing subscriber, and the log crate's ceiling was at TRACE. slog_stdlog::init() sets it to TRACE, and the workspace's release_max_level_info feature was inert (no member depended on `log`).

Changes:
- Depend on `log` from autopush-common so release_max_level_info applies, compiling out log-crate debug/trace in release builds.
- Reorder slog_envlogger to wrap slog_async, so RUST_LOG filters before a record is queued.
- Derive log's runtime ceiling from EnvLogger::filter() instead of TRACE.
- Make the buffer configurable (log_chan_size, default 20_000; 0 coerced to default, since crossbeam treats 0 as a rendezvous channel).

[PUSH-757]

[PUSH-757]: https://mozilla-hub.atlassian.net/browse/PUSH-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ