### PR TITLE
fix(autoendpoint): update FCM error mappings to HTTP status codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "mockall",
  "mockito 1.7.2",
  "openssl",
+ "rand 0.10.2",
  "regex",
  "reqwest 0.13.4",
  "sentry",

--- a/autoendpoint/Cargo.toml
+++ b/autoendpoint/Cargo.toml
@@ -25,6 +25,7 @@ jsonwebtoken = {version="10.3.0", features=["rust_crypto"]}
 lazy_static.workspace = true
 mimalloc.workspace = true
 openssl.workspace = true
+rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 sentry.workspace = true

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -134,6 +134,15 @@ pub enum ApiErrorKind {
 }
 
 impl ApiErrorKind {
+    /// The `Retry-After` to advertise, in seconds, when an upstream supplied
+    /// one. Falls back to [`RETRY_AFTER_PERIOD`] otherwise.
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            ApiErrorKind::Router(e) => e.retry_after(),
+            _ => None,
+        }
+    }
+
     /// Get the associated HTTP status code
     pub fn status(&self) -> StatusCode {
         match self {
@@ -325,8 +334,13 @@ impl ResponseError for ApiError {
             StatusCode::GONE => {
                 builder.insert_header(CacheControl(vec![CacheDirective::MaxAge(86400)]));
             }
-            StatusCode::SERVICE_UNAVAILABLE => {
-                builder.insert_header((header::RETRY_AFTER, RETRY_AFTER_PERIOD));
+            StatusCode::TOO_MANY_REQUESTS | StatusCode::SERVICE_UNAVAILABLE => {
+                let retry_after = self
+                    .kind
+                    .retry_after()
+                    .map(|secs| secs.to_string())
+                    .unwrap_or_else(|| RETRY_AFTER_PERIOD.to_owned());
+                builder.insert_header((header::RETRY_AFTER, retry_after));
             }
             _ => {}
         }

--- a/autoendpoint/src/error.rs
+++ b/autoendpoint/src/error.rs
@@ -13,6 +13,7 @@ use actix_web::{
 // Sentry uses the backtrace crate, not std::backtrace.
 use actix_http::header;
 use backtrace::Backtrace;
+use rand::RngExt;
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 use std::error::Error;
@@ -27,7 +28,23 @@ pub type ApiResult<T> = Result<T, ApiError>;
 
 /// A link for more info on the returned error
 const ERROR_URL: &str = "http://autopush.readthedocs.io/en/latest/http.html#error-codes";
-const RETRY_AFTER_PERIOD: &str = "120"; // retry after 2 minutes;
+/// The base `Retry-After` period, in seconds, when no upstream supplied one.
+const RETRY_AFTER_PERIOD: u64 = 120; // retry after 2 minutes;
+/// How far either side of [`RETRY_AFTER_PERIOD`] a generated `Retry-After` may
+/// land. See [`jittered_retry_after`].
+const RETRY_AFTER_JITTER: u64 = 30;
+
+/// A `Retry-After`, in seconds, for when no upstream supplied one.
+///
+/// Jittered around [`RETRY_AFTER_PERIOD`] so that senders throttled in the same
+/// moment don't all retry in the same later moment, rebuilding the spike that
+/// throttled them. The jitter is symmetric, leaving the mean at the base
+/// period: spreading retries costs no additional delivery latency on average.
+fn jittered_retry_after() -> u64 {
+    rand::rng().random_range(
+        RETRY_AFTER_PERIOD - RETRY_AFTER_JITTER..=RETRY_AFTER_PERIOD + RETRY_AFTER_JITTER,
+    )
+}
 
 /// The main error type.
 #[derive(Debug)]
@@ -134,8 +151,10 @@ pub enum ApiErrorKind {
 }
 
 impl ApiErrorKind {
-    /// The `Retry-After` to advertise, in seconds, when an upstream supplied
-    /// one. Falls back to [`RETRY_AFTER_PERIOD`] otherwise.
+    /// The upstream-supplied `Retry-After`, in seconds, when a bridge sent one.
+    ///
+    /// `None` leaves the caller to its own default; see
+    /// [`jittered_retry_after`].
     pub fn retry_after(&self) -> Option<u64> {
         match self {
             ApiErrorKind::Router(e) => e.retry_after(),
@@ -335,12 +354,8 @@ impl ResponseError for ApiError {
                 builder.insert_header(CacheControl(vec![CacheDirective::MaxAge(86400)]));
             }
             StatusCode::TOO_MANY_REQUESTS | StatusCode::SERVICE_UNAVAILABLE => {
-                let retry_after = self
-                    .kind
-                    .retry_after()
-                    .map(|secs| secs.to_string())
-                    .unwrap_or_else(|| RETRY_AFTER_PERIOD.to_owned());
-                builder.insert_header((header::RETRY_AFTER, retry_after));
+                let retry_after = self.kind.retry_after().unwrap_or_else(jittered_retry_after);
+                builder.insert_header((header::RETRY_AFTER, retry_after.to_string()));
             }
             _ => {}
         }
@@ -429,11 +444,17 @@ fn errno_from_validation_errors(e: &ValidationErrors) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use actix_web::ResponseError;
     use autopush_common::{db::error::DbError, sentry::event_from_error};
+    use std::collections::HashSet;
 
     use crate::routers::RouterError;
+    use crate::routers::fcm::error::FcmError;
 
-    use super::{ApiError, ApiErrorKind};
+    use super::{
+        ApiError, ApiErrorKind, RETRY_AFTER_JITTER, RETRY_AFTER_PERIOD, header,
+        jittered_retry_after,
+    };
     use crate::error::ReportableError;
 
     #[test]
@@ -445,6 +466,69 @@ mod tests {
         assert_eq!(event.exception[0].ty, "Integrity");
         assert_eq!(event.exception[1].ty, "ApiError");
         assert_eq!(event.extra.get("row"), Some(&"bar".into()));
+    }
+
+    /// A generated `Retry-After` stays inside the jitter band, and varies
+    /// across calls so throttled senders don't retry in lockstep.
+    #[test]
+    fn jittered_retry_after_spreads_within_band() {
+        let band =
+            (RETRY_AFTER_PERIOD - RETRY_AFTER_JITTER)..=(RETRY_AFTER_PERIOD + RETRY_AFTER_JITTER);
+        let values: HashSet<u64> = (0..200).map(|_| jittered_retry_after()).collect();
+
+        for value in &values {
+            assert!(band.contains(value), "{value} outside {band:?}");
+        }
+        // 200 draws from a 61-wide band collide into one value with
+        // probability 61 * (1/61)^200, so this cannot flake in practice.
+        assert!(values.len() > 1, "no jitter applied");
+    }
+
+    /// An upstream-supplied `Retry-After` is forwarded verbatim, unjittered:
+    /// the bridge's instruction wins over our own guess.
+    #[test]
+    fn retry_after_header_prefers_upstream() {
+        let e: ApiError = ApiErrorKind::Router(RouterError::Fcm(FcmError::Upstream {
+            error_code: "RESOURCE_EXHAUSTED".to_owned(),
+            message: "quota".to_owned(),
+            retry_after: Some(45),
+        }))
+        .into();
+        let response = e.error_response();
+
+        assert_eq!(response.status().as_u16(), 429);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER).unwrap(),
+            "45",
+            "upstream Retry-After should not be jittered"
+        );
+    }
+
+    /// Without an upstream value, the header falls back to a jittered default.
+    #[test]
+    fn retry_after_header_falls_back_to_jitter() {
+        let e: ApiError = ApiErrorKind::Router(RouterError::Fcm(FcmError::Upstream {
+            error_code: "UNAVAILABLE".to_owned(),
+            message: "try later".to_owned(),
+            retry_after: None,
+        }))
+        .into();
+        let response = e.error_response();
+
+        assert_eq!(response.status().as_u16(), 503);
+        let secs: u64 = response
+            .headers()
+            .get(header::RETRY_AFTER)
+            .expect("a Retry-After header")
+            .to_str()
+            .unwrap()
+            .parse()
+            .expect("delta-seconds");
+        assert!(
+            ((RETRY_AFTER_PERIOD - RETRY_AFTER_JITTER)..=(RETRY_AFTER_PERIOD + RETRY_AFTER_JITTER))
+                .contains(&secs),
+            "secs = {secs}"
+        );
     }
 
     /// Ensure that Pool error metric labels are specified and that they return a 503 status code.

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -2,16 +2,46 @@ use crate::routers::RouterError;
 use crate::routers::common::message_size_check;
 use crate::routers::fcm::error::FcmError;
 use crate::routers::fcm::settings::{FcmServerCredential, FcmSettings};
+use actix_web::http::header::HttpDate;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use url::Url;
 use yup_oauth2::authenticator::DefaultAuthenticator;
 use yup_oauth2::{ServiceAccountAuthenticator, ServiceAccountKey};
 
 const OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/firebase.messaging"];
+
+// Firebase docs recommend a minimum 10 second wait for any retry.
+const MIN_RETRY_AFTER_SECS: u64 = 10;
+const MAX_RETRY_AFTER_SECS: u64 = 3600;
+
+/// Parse an upstream `Retry-After` into delta-seconds. Accepts delta-seconds
+/// or an HTTP-date.
+///
+/// A date already in the past means "retry now" and is floored
+/// to the minimum rather than discarded. Anything unparseable yields `None`,
+/// leaving the caller to its own default.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    let raw = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim();
+
+    let secs = match raw.parse::<u64>() {
+        Ok(secs) => secs,
+        Err(_) => {
+            let when: SystemTime = raw.parse::<HttpDate>().ok()?.into();
+            when.duration_since(SystemTime::now())
+                .map_or(0, |delay| delay.as_secs())
+        }
+    };
+
+    Some(secs.clamp(MIN_RETRY_AFTER_SECS, MAX_RETRY_AFTER_SECS))
+}
 
 /// Holds application-specific Firebase data and authentication. This client
 /// handles sending notifications to Firebase.
@@ -133,6 +163,7 @@ impl FcmClient {
         // Handle error
         let status = response.status();
         if status.is_client_error() || status.is_server_error() {
+            let retry_after = parse_retry_after(response.headers());
             let raw_data = response
                 .bytes()
                 .await
@@ -156,6 +187,7 @@ impl FcmClient {
                     FcmError::Upstream {
                         error_code: error.status, // Note: this is the FCM error status enum value
                         message: error.message,
+                        retry_after,
                     }
                     .into()
                 }
@@ -172,6 +204,7 @@ impl FcmClient {
                     FcmError::Upstream {
                         error_code: "UNKNOWN".to_string(),
                         message: format!("Unknown reason: {:?}", status.to_string()),
+                        retry_after,
                     }
                 }
                 .into(),
@@ -198,10 +231,12 @@ struct FcmErrorResponse {
 #[cfg(test)]
 pub mod tests {
     use crate::routers::RouterError;
-    use crate::routers::fcm::client::FcmClient;
+    use crate::routers::fcm::client::{FcmClient, MIN_RETRY_AFTER_SECS};
     use crate::routers::fcm::error::FcmError;
     use crate::routers::fcm::settings::{FcmServerCredential, FcmSettings};
+    use actix_web::http::header::HttpDate;
     use std::collections::HashMap;
+    use std::time::{Duration, SystemTime};
     use url::Url;
 
     pub const PROJECT_ID: &str = "yup-test-243420";
@@ -356,6 +391,135 @@ pub mod tests {
         );
     }
 
+    /// A throttled send reports 429 and forwards FCM's `Retry-After` value
+    #[tokio::test]
+    async fn resource_exhausted_is_throttled() {
+        let mut server = mockito::Server::new_async().await;
+
+        let client = make_client(
+            &server,
+            FcmServerCredential {
+                project_id: PROJECT_ID.to_owned(),
+                is_gcm: Some(false),
+                server_access_token: make_service_key(&server),
+            },
+        )
+        .await;
+        let _token_mock = mock_token_endpoint(&mut server).await;
+        let _fcm_mock = mock_fcm_endpoint_builder(&mut server, PROJECT_ID)
+            .with_status(429)
+            .with_header("Retry-After", "30")
+            .with_body(r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota"}}"#)
+            .create_async()
+            .await;
+
+        let result = client
+            .send(HashMap::new(), "test-token".to_string(), 42)
+            .await;
+        let err = result.unwrap_err();
+
+        assert_eq!(err.status().as_u16(), 429);
+        assert_eq!(err.errno(), Some(201));
+        assert_eq!(err.retry_after(), Some(30));
+    }
+
+    /// An HTTP-date `Retry-After` is accepted and converted to a delay
+    #[tokio::test]
+    async fn retry_after_accepts_http_date() {
+        let mut server = mockito::Server::new_async().await;
+
+        let client = make_client(
+            &server,
+            FcmServerCredential {
+                project_id: PROJECT_ID.to_owned(),
+                is_gcm: Some(false),
+                server_access_token: make_service_key(&server),
+            },
+        )
+        .await;
+        let _token_mock = mock_token_endpoint(&mut server).await;
+        // Generated rather than hardcoded so the test doesn't expire.
+        let when = HttpDate::from(SystemTime::now() + Duration::from_secs(120)).to_string();
+        let _fcm_mock = mock_fcm_endpoint_builder(&mut server, PROJECT_ID)
+            .with_status(429)
+            .with_header("Retry-After", &when)
+            .with_body(r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota"}}"#)
+            .create_async()
+            .await;
+
+        let result = client
+            .send(HashMap::new(), "test-token".to_string(), 42)
+            .await;
+        let retry_after = result.unwrap_err().retry_after().expect("a delay");
+        // Ranged: the header has second granularity and time passes during the
+        // request.
+        assert!(
+            (110..=120).contains(&retry_after),
+            "retry_after = {retry_after}"
+        );
+    }
+
+    /// An unparseable `Retry-After` leaves the caller to its own default
+    #[tokio::test]
+    async fn retry_after_ignores_unparseable() {
+        let mut server = mockito::Server::new_async().await;
+
+        let client = make_client(
+            &server,
+            FcmServerCredential {
+                project_id: PROJECT_ID.to_owned(),
+                is_gcm: Some(false),
+                server_access_token: make_service_key(&server),
+            },
+        )
+        .await;
+        let _token_mock = mock_token_endpoint(&mut server).await;
+        let _fcm_mock = mock_fcm_endpoint_builder(&mut server, PROJECT_ID)
+            .with_status(429)
+            .with_header("Retry-After", "soon")
+            .with_body(r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota"}}"#)
+            .create_async()
+            .await;
+
+        let result = client
+            .send(HashMap::new(), "test-token".to_string(), 42)
+            .await;
+        assert_eq!(result.unwrap_err().retry_after(), None);
+    }
+
+    /// An HTTP-date already in the past floors to the minimum, rather than
+    /// falling back to the caller's default
+    #[tokio::test]
+    async fn retry_after_floors_past_http_date() {
+        let mut server = mockito::Server::new_async().await;
+
+        let client = make_client(
+            &server,
+            FcmServerCredential {
+                project_id: PROJECT_ID.to_owned(),
+                is_gcm: Some(false),
+                server_access_token: make_service_key(&server),
+            },
+        )
+        .await;
+        let _token_mock = mock_token_endpoint(&mut server).await;
+        let when = HttpDate::from(SystemTime::now() - Duration::from_secs(60)).to_string();
+        let _fcm_mock = mock_fcm_endpoint_builder(&mut server, PROJECT_ID)
+            .with_status(429)
+            .with_header("Retry-After", &when)
+            .with_body(r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota"}}"#)
+            .create_async()
+            .await;
+
+        let result = client
+            .send(HashMap::new(), "test-token".to_string(), 42)
+            .await;
+        assert_eq!(
+            result.unwrap_err().retry_after(),
+            Some(MIN_RETRY_AFTER_SECS)
+        );
+    }
+
     /// Unhandled errors (where an error object is returned) are wrapped and returned
     #[tokio::test]
     async fn other_fcm_error() {
@@ -384,7 +548,7 @@ pub mod tests {
         assert!(
             matches!(
                 result.as_ref().unwrap_err(),
-                RouterError::Fcm(FcmError::Upstream{ error_code, message })
+                RouterError::Fcm(FcmError::Upstream{ error_code, message, .. })
                     if error_code == "TEST_ERROR" && message == "test-message"
             ),
             "result = {result:?}"
@@ -419,7 +583,7 @@ pub mod tests {
         assert!(
             matches!(
                 result.as_ref().unwrap_err(),
-                RouterError::Fcm(FcmError::Upstream { error_code, message })
+                RouterError::Fcm(FcmError::Upstream { error_code, message, .. })
                     if error_code == "UNKNOWN" && message.starts_with("Unknown reason")
             ),
             "result = {result:?}"

--- a/autoendpoint/src/routers/fcm/client.rs
+++ b/autoendpoint/src/routers/fcm/client.rs
@@ -16,6 +16,7 @@ const OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/firebase.messag
 
 // Firebase docs recommend a minimum 10 second wait for any retry.
 const MIN_RETRY_AFTER_SECS: u64 = 10;
+// Adding a maximum value to avoid scheduling far into the future; value chosen by convention
 const MAX_RETRY_AFTER_SECS: u64 = 3600;
 
 /// Parse an upstream `Retry-After` into delta-seconds. Accepts delta-seconds

--- a/autoendpoint/src/routers/fcm/error.rs
+++ b/autoendpoint/src/routers/fcm/error.rs
@@ -38,7 +38,12 @@ pub enum FcmError {
     InvalidAppId(String),
 
     #[error("Upstream error, {error_code}: {message}")]
-    Upstream { error_code: String, message: String },
+    Upstream {
+        error_code: String,
+        message: String,
+        /// Sourced from upstream `Retry-After` if provided (otherise default)
+        retry_after: Option<u64>,
+    },
 }
 
 impl FcmError {
@@ -54,6 +59,15 @@ impl FcmError {
             | FcmError::OAuthToken(_)
             | FcmError::NoOAuthToken => StatusCode::INTERNAL_SERVER_ERROR,
 
+            // FCM is rate-limiting us
+            FcmError::Upstream { error_code, .. } if error_code == "RESOURCE_EXHAUSTED" => {
+                StatusCode::TOO_MANY_REQUESTS
+            }
+            // FCM is transiently unable to accept the message
+            FcmError::Upstream { error_code, .. } if error_code == "UNAVAILABLE" => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+
             FcmError::DeserializeResponse(_)
             | FcmError::EmptyResponse(_)
             | FcmError::InvalidResponse(_, _, _)
@@ -68,6 +82,20 @@ impl FcmError {
                 Some(106)
             }
 
+            FcmError::Upstream { error_code, .. }
+                if error_code == "RESOURCE_EXHAUSTED" || error_code == "UNAVAILABLE" =>
+            {
+                Some(201)
+            }
+
+            _ => None,
+        }
+    }
+
+    /// The upstream-supplied `Retry-After`, in seconds, when the bridge sent one.
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            FcmError::Upstream { retry_after, .. } => *retry_after,
             _ => None,
         }
     }

--- a/autoendpoint/src/routers/mod.rs
+++ b/autoendpoint/src/routers/mod.rs
@@ -133,6 +133,14 @@ impl RouterError {
         }
     }
 
+    /// The upstream-supplied `Retry-After`, in seconds, when the bridge sent one.
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            RouterError::Fcm(e) => e.retry_after(),
+            _ => None,
+        }
+    }
+
     /// Get the associated error number
     pub fn errno(&self) -> Option<usize> {
         match self {

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -89,7 +89,9 @@ statuses:
 * 429 - **Too many requests** - An upstream Bridge service is rate-limiting
     message delivery. The response carries a `Retry-After` header indicating
     how long to wait before retrying; the Bridge's own value is used when it
-    supplies one.
+    supplies one, otherwise a jittered default near 120 seconds. The jitter is
+    deliberate; senders should honor the value they were given rather than
+    rounding it, so that retries stay spread out.
 
     -   errno 201 - Use exponential back-off for retries
 

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -86,6 +86,13 @@ statuses:
 
     -   errno 104 - Data payload too large
 
+* 429 - **Too many requests** - An upstream Bridge service is rate-limiting
+    message delivery. The response carries a `Retry-After` header indicating
+    how long to wait before retrying; the Bridge's own value is used when it
+    supplies one.
+
+    -   errno 201 - Use exponential back-off for retries
+
 * 500 - **Unknown server error** - An internal error occurred within
     the Push Server.
 


### PR DESCRIPTION
Report RESOURCE_EXHAUSTED as 429 instead of 502, with errno 201 to hint exponential backoff. Forward the Retry-After header from FCM if provided, clamped between 10 and 3600s, otherwise use the original default of 120s.

Report transient UNAVAILABLE error as 503 instead of 502, which hints exponential backoff as well.

The original 502 status codes do not carry backoff hints, and retries plausibly worsen throttling or traffic congestion for FCM.

Note that this does have implications for 5xx tracking -- ~90% of autoendpoint's 5xx errors are currently due to FCM throttling, which will be moved to 429. This is intentional and desired, so that we can separate service degradation from being rate-limited and have appropriate retry hints.

[PUSH-759], [PUSH-760]

[PUSH-759]: https://mozilla-hub.atlassian.net/browse/PUSH-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PUSH-760]: https://mozilla-hub.atlassian.net/browse/PUSH-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ