### PR TITLE
chore: tag 1.84.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,4 +5,5 @@ ignore = [
     "RUSTSEC-2026-0098", # Bound by rustls 0.22.4, bound by tokio-rustls 0.25, hyper-rustls 0.26, and a2 0.10
     "RUSTSEC-2026-0099", # Bound by rustls 0.22.4, bound by tokio-rustls 0.25, hyper-rustls 0.26, and a2 0.10
     "RUSTSEC-2026-0104", # Bound by rustls 0.22.4, bound by tokio-rustls 0.25, hyper-rustls 0.26, a2 0.10
+    "RUSTSEC-2026-0258", # Bound by actix-http 3.13.3
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.84.0"></a>
+## 1.84.0 (2026-08-19)
+
+### Bug Fixes
+
+- *(autoendpoint)* Update FCM error mappings to HTTP status codes (#1223) ([ab6065cd](https://github.com/mozilla-services/autopush-rs/commit/ab6065cdd8682caa215319e48c705bf128e926a9))
+- *(bigtable)* Enforce router record expiry at read time (#1224) ([41d5b25e](https://github.com/mozilla-services/autopush-rs/commit/41d5b25e018080b5ddd1b3a8566a1e0b0a0f698a))
+
 <a name="1.83.1"></a>
 ## 1.83.1 (2026-07-31)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autoconnect"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "a2",
  "actix-cors",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.83.1"
+version = "1.84.0"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.83.1"
+version = "1.84.0"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
### Bug Fixes

- *(autoendpoint)* Update FCM error mappings to HTTP status codes (#1223) ([ab6065cd](https://github.com/mozilla-services/autopush-rs/commit/ab6065cdd8682caa215319e48c705bf128e926a9))
- *(bigtable)* Enforce router record expiry at read time (#1224) ([41d5b25e](https://github.com/mozilla-services/autopush-rs/commit/41d5b25e018080b5ddd1b3a8566a1e0b0a0f698a))