### PR TITLE
chore: tag 1.84.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="1.84.1"></a>
+## 1.84.1 (2026-08-20)
+
+### Bug Fixes
+
+- *(bigtable)* Remove expiration filter for delete operations (#1230) ([43bf2448](https://github.com/mozilla-services/autopush-rs/commit/43bf244836ffbdd5b9c04a10f10b066c0a159ead))
+- *(ci)* Run redis backend tests (#1229) ([6e452d1c](https://github.com/mozilla-services/autopush-rs/commit/6e452d1c03da23ca433423a130b4938a0e39dfcf))
+
+### Chore
+
+- *(autoconnect)* Add crypto_keys setting, deprecate crypto_key (#1226) ([2f9c8427](https://github.com/mozilla-services/autopush-rs/commit/2f9c84276ed59a650b5705c468b348442d1b6fa8))
+
 <a name="1.84.0"></a>
 ## 1.84.0 (2026-08-19)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autoconnect"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-http",
  "actix-server",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_common"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-web",
  "autopush_common",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_settings"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "autoconnect_common",
  "autopush_common",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_web"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "autoconnect_ws_sm"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "autoendpoint"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "a2",
  "actix-cors",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "autopush_common"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.84.0"
+version = "1.84.1"
 authors = [
     "Ben Bangert <ben@groovie.org>",
     "JR Conlin <jrconlin@mozilla.com>",


### PR DESCRIPTION
### Bug Fixes

- *(bigtable)* Remove expiration filter for delete operations (#1230) ([43bf2448](https://github.com/mozilla-services/autopush-rs/commit/43bf244836ffbdd5b9c04a10f10b066c0a159ead))
- *(ci)* Run redis backend tests (#1229) ([6e452d1c](https://github.com/mozilla-services/autopush-rs/commit/6e452d1c03da23ca433423a130b4938a0e39dfcf))

### Chore

- *(autoconnect)* Add crypto_keys setting, deprecate crypto_key (#1226) ([2f9c8427](https://github.com/mozilla-services/autopush-rs/commit/2f9c84276ed59a650b5705c468b348442d1b6fa8))
