### PR TITLE
fix(ci): run redis backend tests

### DIFF
--- a/.github/workflows/reuse-check-and-test.yml
+++ b/.github/workflows/reuse-check-and-test.yml
@@ -131,6 +131,59 @@ jobs:
           name: unit-test-results
           path: workspace/test-results
 
+  # Redis is a mutually exclusive build with Bigtable, so it gets its own job
+  # rather than another feature flag on `test-unit`.
+  test-unit-redis:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+      # The Redis-backed tests share one keyspace; run them serially.
+      RUST_TEST_THREADS: 1
+      REDIS_HOST: localhost
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Create test result workspace
+        run: mkdir -p workspace/test-results
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential clang cmake libssl-dev pkg-config
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Log in to Docker Hub
+        uses: ./.github/actions/dockerhub-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Started via `docker run` rather than a `services:` block so the Docker Hub
+      # login above applies: service containers are pulled before any step runs.
+      - name: Start Redis
+        run: |
+          docker run -d --name autopush-redis -p 6379:6379 redis:8 \
+            redis-server --save "" --appendonly no
+          for _ in $(seq 30); do
+            docker exec autopush-redis redis-cli ping && exit 0
+            sleep 1
+          done
+          echo "Redis did not become ready" >&2
+          exit 1
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+      - name: Echo Rust version
+        run: rustc --version
+      - name: Unit tests (Redis)
+        run: make unit-test-redis
+      - name: Store test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-redis-test-results
+          path: workspace/test-results
+
   test-integration:
     runs-on: ubuntu-latest
     needs:
@@ -158,4 +211,35 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-results
+          path: workspace/test-results
+
+  # Same suite as `test-integration`, but the services are built against Redis
+  # instead of the Bigtable emulator.
+  test-integration-redis:
+    runs-on: ubuntu-latest
+    needs:
+      - python-checks
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Create test result workspace
+        run: mkdir -p workspace/test-results
+      - name: Log in to Docker Hub
+        uses: ./.github/actions/dockerhub-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Integration tests (Redis)
+        run: |
+          docker compose -f tests/integration/docker-compose-redis.yml run -i --name integration-tests-redis tests; exit_code=$?
+          docker cp integration-tests-redis:/code/integration__results.xml workspace/test-results/integration-redis__results.xml
+          exit $exit_code
+      - name: Store test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-redis-test-results
           path: workspace/test-results

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ EPOCH_TIME := $(shell date +"%s")
 TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
 UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
 UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
+UNIT_REDIS_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit-redis__results.xml
 INTEGRATION_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml
+INTEGRATION_REDIS_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration-redis__results.xml
 INTEGRATION_JUNIT_XML_LEGACY := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__legacy-results.xml
 
 # NOTE: Do not be clever.
@@ -23,6 +25,8 @@ INTEGRATION_JUNIT_XML_LEGACY := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integrati
 PYTEST_ARGS := ${PYTEST_ARGS}
 INTEGRATION_TEST_DIR := $(TESTS_DIR)/integration
 INTEGRATION_TEST_FILE := $(INTEGRATION_TEST_DIR)/test_integration_all_rust.py
+INTEGRATION_COMPOSE := $(INTEGRATION_TEST_DIR)/docker-compose.yml
+INTEGRATION_REDIS_COMPOSE := $(INTEGRATION_TEST_DIR)/docker-compose-redis.yml
 NOTIFICATION_TEST_DIR := $(TESTS_DIR)/notification
 LOAD_TEST_DIR := $(TESTS_DIR)/load
 POETRY := poetry --directory $(TESTS_DIR)
@@ -68,18 +72,40 @@ unit-test: ## Run the Rust test suite (requires a running Bigtable emulator) and
 	mv target/nextest/ci/junit.xml $(UNIT_JUNIT_XML)
 	exit $$exit_code
 
+# Redis and Bigtable are mutually exclusive builds, so this is a separate
+# invocation rather than another feature on `unit-test`. Only autopush_common
+# carries Redis-backed tests; the other crates are storage agnostic.
+.ONESHELL:
+unit-test-redis: ## Run the Redis-backed Rust tests (requires a Redis server on $$REDIS_HOST, default localhost)
+	cargo nextest run -p autopush_common --no-default-features --features=redis --profile=ci; exit_code=$$?
+	mv target/nextest/ci/junit.xml $(UNIT_REDIS_JUNIT_XML)
+	exit $$exit_code
+
 build-integration-test:
-	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml build
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_COMPOSE) build
 
 .ONESHELL:
 integration-test:
-	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml run -it --name integration-tests tests; exit_code=$$?
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_COMPOSE) run -it --name integration-tests tests; exit_code=$$?
 	docker cp integration-tests:/code/integration__results.xml $(INTEGRATION_JUNIT_XML)
 	exit $$exit_code
 
 integration-test-clean:
-	$(DOCKER_COMPOSE) -f $(INTEGRATION_TEST_DIR)/docker-compose.yml down
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_COMPOSE) down
 	docker rm integration-tests
+
+build-integration-test-redis:
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_REDIS_COMPOSE) build
+
+.ONESHELL:
+integration-test-redis: ## Run the integration suite against a Redis backend instead of Bigtable
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_REDIS_COMPOSE) run -it --name integration-tests-redis tests; exit_code=$$?
+	docker cp integration-tests-redis:/code/integration__results.xml $(INTEGRATION_REDIS_JUNIT_XML)
+	exit $$exit_code
+
+integration-test-redis-clean:
+	$(DOCKER_COMPOSE) -f $(INTEGRATION_REDIS_COMPOSE) down
+	docker rm integration-tests-redis
 
 integration-test-legacy: ## pytest markers are stored in `tests/pytest.ini`
 	$(POETRY) -V

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -48,6 +48,20 @@ Run Rust unit tests with the `cargo test` command from the root of the directory
 
 To run a specific test, provide the function name to `cargo test`. Ex. `cargo test test_function_name`.
 
+#### Redis-backed unit tests
+
+The storage backends are mutually exclusive builds, so `cargo test` only covers whichever
+one the enabled features select — by default Bigtable. The Redis client's tests live behind
+`--features=redis` and talk to a real server, so they need one running:
+
+```bash
+docker run -d --name autopush-redis -p 6379:6379 redis:8
+make unit-test-redis
+```
+
+Point them at a different server with `REDIS_HOST` (which accepts a `host:port` pair, not
+just a hostname). CI runs this as the `test-unit-redis` job.
+
 ## Integration Tests
 The autopush-rs tests are written in Python and located in the [integration test directory][integration_tests]. 
 
@@ -104,6 +118,18 @@ Integration tests in CI will be triggered automatically whenever a commit is pus
 
 #### Using Docker to run the Integration Tests.
 If you aren't needing to run specific tests you can use the containerized version of the integration tests with the following make command: `make integration-test`. This will build a docker image and set up the Big Table emulator as well as execute a default set of tests with the `not stub` marker.
+
+#### Running the Integration Tests against Redis
+
+`make integration-test-redis` runs the same suite against a Redis backend instead: it builds
+the services with `--no-default-features --features=redis` and stands up a throwaway Redis
+container in place of the Bigtable emulator. CI runs this as the `test-integration-redis` job,
+alongside the Bigtable one.
+
+The backends are not yet at parity. Cases that pass on Bigtable but hit a known defect in the
+Redis client are marked with `xfail_on_redis` in the test module, which is inert on every
+other backend. Once a defect is fixed its test starts reporting XPASS on Redis -- that is the
+cue to drop the mark.
 
 ### Debugging
 In some instances after making test changes, the test client can potentially hang in a dangling process. This can result in inaccurate results or tests not running correctly. You can run the following commands to determine the PID's of the offending processes and terminate them:

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -23,6 +23,10 @@ RUN cargo chef prepare --recipe-path recipe.json
 # build process change.
 FROM chef AS cacher
 COPY --from=planner /app/recipe.json recipe.json
+# Must match the `builder` stage's flags below: cook a different feature set and
+# every fingerprint changes, so `builder` rebuilds the whole dependency tree
+# instead of reusing what was cooked here. Keep the two ARGs in lockstep.
+ARG CARGO_BUILD_ARGS="--features=emulator"
 
 RUN \
   apt-get -qq update && \
@@ -34,30 +38,22 @@ RUN \
   pkg-config \
   build-essential
 
-RUN cargo chef cook --recipe-path recipe.json
+RUN cargo chef cook --recipe-path recipe.json ${CARGO_BUILD_ARGS}
 
 # =============================================================================
 # Now build the project, taking advantage of the cached dependencies from above.
-FROM chef AS builder
-ARG APT_CACHE_BUST
+FROM cacher AS builder
+# Must match the cacher's ARG above. Storage backends are mutually exclusive
+# builds, so which one the integration suite exercises is decided here; defaults
+# to Bigtable-against-the-emulator and `docker-compose-redis.yml` overrides it.
+ARG CARGO_BUILD_ARGS="--features=emulator"
 
 RUN mkdir -m 755 bin
-RUN apt-get -qq update && \
-  apt-get -qq upgrade && apt-get -qq install --no-install-recommends -y \
-  cmake \
-  clang \
-  libssl-dev \
-  ca-certificates \
-  libstdc++6 \
-  libstdc++-12-dev
-
 RUN cargo --version && \
   rustc --version
 COPY . .
-COPY --from=cacher /app/target target
-COPY --from=cacher $CARGO_HOME $CARGO_HOME
 
-RUN cargo build --features=emulator
+RUN cargo build ${CARGO_BUILD_ARGS}
 
 FROM python:3.12-slim-bookworm AS integration-tests
 
@@ -94,10 +90,14 @@ RUN python -m pip install --no-cache-dir --quiet poetry
 COPY ./tests/pyproject.toml ./tests/poetry.lock ./
 RUN poetry install --only=integration --no-root --no-interaction --no-ansi
 
-# Setup cloud big table
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN apt-get update -y && apt install google-cloud-cli-cbt -y
+# Setup cloud big table. `cbt` is only used by `scripts/setup_bt.sh`; backends
+# that don't need it (e.g. redis) can turn it off to save some build time
+ARG INSTALL_CBT=1
+RUN if [ "${INSTALL_CBT}" = "1" ]; then \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  apt-get update -y && apt install google-cloud-cli-cbt -y; \
+  fi
 
 COPY . /code
 

--- a/tests/integration/docker-compose-redis.yml
+++ b/tests/integration/docker-compose-redis.yml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Runs the python integration suite against a Redis backend rather than the
+# Bigtable emulator (see `docker-compose.yml`). Redis and Bigtable are mutually
+# exclusive builds, so this builds its own `--features=redis` binaries via the
+# `CARGO_BUILD_ARGS` build arg, and skips the Bigtable table bootstrap that the
+# Dockerfile's default CMD performs.
+#
+# A distinct project name keeps this from clobbering the Bigtable images and
+# containers of the same service name.
+name: autopush-integration-redis
+
+services:
+  redis:
+    image: redis:8
+    network_mode: host
+    # Storage is per-run and throwaway; skip RDB/AOF persistence entirely.
+    command: redis-server --save "" --appendonly no
+  tests:
+    environment:
+      - DB_DSN=redis://localhost:6379
+      # Default settings
+      - DB_SETTINGS={}
+    build:
+      context: ../..
+      dockerfile: tests/integration/Dockerfile
+      args:
+        CARGO_BUILD_ARGS: "--no-default-features --features=redis"
+        # Not using bigtable so don't install `cbt`
+        INSTALL_CBT: "0"
+    depends_on:
+      - redis
+    network_mode: host
+    command:
+      - sh
+      - -c
+      - poetry run pytest tests/integration/test_integration_all_rust.py --junit-xml=integration__results.xml -v

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -202,6 +202,35 @@ if os.environ.get("RELIABLE_REPORT") is not None:
     CONNECTION_CONFIG["reliability_dsn"] = "redis://localhost:6379"
     ENDPOINT_CONFIG["reliability_dsn"] = "redis://localhost:6379"
 
+"""The suite runs against whichever backend `DB_DSN` names, and the backends are
+not yet at parity. A handful of cases below pass on Bigtable but hit known
+defects in the Redis client, so they are xfailed for Redis only.
+"""
+RUNNING_ON_REDIS: bool = str(CONNECTION_CONFIG.get("db_dsn") or "").startswith("redis")
+
+
+def xfail_on_redis(reason: str) -> pytest.MarkDecorator:
+    """Expect a test to fail when the suite runs against the Redis backend.
+
+    Inert on every other backend. Deliberately non-strict: these cases are
+    timing sensitive and one occasionally squeaks through, which under `strict`
+    would fail the run.
+    """
+    return pytest.mark.xfail(RUNNING_ON_REDIS, reason=reason, strict=False)
+
+
+# `RedisClientImpl::fetch_timestamp_messages` scans `autopush/msgs/{uaid}` with an
+# inclusive lower bound, while Bigtable's equivalent range is exclusive. After an
+# ack, `increment_storage` records that same score as the new floor, so the
+# message the client just acknowledged is handed back on the next fetch.
+REDIS_ACK_REDELIVERY = "Redis: acked stored messages are redelivered (inclusive fetch bound)"
+
+# `RedisClientImpl::fetch_timestamp_messages` returns `timestamp: None` when every
+# key in the fetched window has already expired out of Redis, so the caller never
+# advances past that window and never reaches the live message behind it. Bigtable
+# returns the expired rows and filters them later, which keeps its cursor moving.
+REDIS_EXPIRED_BATCH = "Redis: a full window of expired messages stalls the storage cursor"
+
 
 def _get_vapid(
     key: ecdsa.SigningKey | None = None,
@@ -1042,6 +1071,7 @@ async def test_topic_expired(registered_test_client: AsyncPushTestClient) -> Non
     assert result["data"] == base64url_encode(uuid_data)
 
 
+@xfail_on_redis(REDIS_ACK_REDELIVERY)
 @pytest.mark.parametrize("fixture_max_conn_logs", [4], indirect=True)
 async def test_multiple_delivery_with_single_ack(
     registered_test_client: AsyncPushTestClient,
@@ -1092,6 +1122,7 @@ async def test_multiple_delivery_with_single_ack(
     assert result is None
 
 
+@xfail_on_redis(REDIS_ACK_REDELIVERY)
 async def test_multiple_delivery_with_multiple_ack(
     registered_test_client: AsyncPushTestClient,
 ) -> None:
@@ -1189,6 +1220,7 @@ async def test_ttl_expired(registered_test_client: AsyncPushTestClient) -> None:
     assert result is None
 
 
+@xfail_on_redis(REDIS_EXPIRED_BATCH)
 @pytest.mark.parametrize("fixture_max_endpoint_logs", [28], indirect=True)
 async def test_ttl_batch_expired_and_good_one(registered_test_client: AsyncPushTestClient) -> None:
     """Test that if a batch of messages are received while the recipient is offline,
@@ -1219,6 +1251,7 @@ async def test_ttl_batch_expired_and_good_one(registered_test_client: AsyncPushT
     assert result is None
 
 
+@xfail_on_redis(REDIS_EXPIRED_BATCH)
 @pytest.mark.parametrize("fixture_max_endpoint_logs", [28], indirect=True)
 async def test_ttl_batch_partly_expired_and_good_one(
     registered_test_client: AsyncPushTestClient,


### PR DESCRIPTION
Run redis tests on CI. The redis unit tests are more like integration tests since they require an active redis instance, but I didn't refactor them.

Documented failing integration tests with the redis backend (real bugs) using xfail. e.g. see https://github.com/mozilla-services/autopush-rs/issues/1228

[PUSH-737]

[PUSH-737]: https://mozilla-hub.atlassian.net/browse/PUSH-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ