### PR TITLE
delete acked notifications in increment_storage to stop redelivery

### DIFF
--- a/autopush-common/src/db/redis/mod.rs
+++ b/autopush-common/src/db/redis/mod.rs
@@ -6,7 +6,7 @@
 /// `autopush/co/{uaid}` u64 to store the last time the user has interacted with the server
 /// `autopush/timestamp/{uaid}` u64 to store the last storage timestamp incremented by the server, once messages are delivered
 /// `autopush/channels/{uaid}` List to store the list of the channels of the user
-/// `autopush/msgs/{uaid}` SortedSet to store the list of the pending message ids for the user
+/// `autopush/msgs/{uaid}` SortedSet to store the list of the pending message ids for the user, scored by the message's millisecond `sortkey_timestamp` (matching the ordering of Bigtable's message row keys)
 /// `autopush/msgs_exp/{uaid}` SortedSet to store the list of the pending message ids, ordered by expiry date, this is because SortedSet elements can't have independent expiry date
 /// `autopush/msg/{uaid}/{chidmessageid}`, with `{chidmessageid} == {chid}:{version}` String to store
 /// the content of the messages

--- a/autopush-common/src/db/redis/redis_client/mod.rs
+++ b/autopush-common/src/db/redis/redis_client/mod.rs
@@ -379,7 +379,7 @@ impl DbClient for RedisClientImpl {
             // The function [fetch_timestamp_messages] takes a timestamp in input,
             // here we use the timestamp of the record
             .zadd(&exp_list_key, msg_id, expiry)
-            .zadd(&msg_list_key, msg_id, sec_since_epoch());
+            .zadd(&msg_list_key, msg_id, storable.timestamp);
 
         let _: () = pipe.exec_async(&mut con).await?;
         self.metrics
@@ -410,12 +410,14 @@ impl DbClient for RedisClientImpl {
         let exp_list_key = self.message_exp_list_key(&uaid);
         let storage_timestamp_key = self.storage_timestamp_key(&uaid);
         let mut con = self.connection().await?;
-        trace!("🐇 SEARCH: increment: {:?} - {}", &exp_list_key, timestamp);
-        let exp_id_list: Vec<String> = con.zrangebyscore(&exp_list_key, 0, timestamp).await?;
-        if !exp_id_list.is_empty() {
+        // Search msg_list_key for messages with timestamp <= the given timestamp.
+        // msg_list_key is sorted by message timestamp (after fix to save_message).
+        trace!("🐇 SEARCH: increment: {:?} - {}", &msg_list_key, timestamp);
+        let msg_id_list: Vec<String> = con.zrangebyscore(&msg_list_key, 0, timestamp).await?;
+        if !msg_id_list.is_empty() {
             // Remember, we store just the message_ids in the exp and msg lists, but need to convert back to
             // the full message keys for deletion.
-            let delete_msg_keys: Vec<String> = exp_id_list
+            let delete_msg_keys: Vec<String> = msg_id_list
                 .clone()
                 .into_iter()
                 .map(|msg_id| self.message_key(&uaid, &msg_id))
@@ -425,12 +427,12 @@ impl DbClient for RedisClientImpl {
                 "🐰🔥:rem: Deleting {} : [{:?}]",
                 msg_list_key, &delete_msg_keys
             );
-            trace!("🐰🔥:rem: Deleting {} : [{:?}]", exp_list_key, &exp_id_list);
+            trace!("🐰🔥:rem: Deleting {} : [{:?}]", exp_list_key, &msg_id_list);
             pipe()
                 .set_options::<_, _>(&storage_timestamp_key, timestamp, self.router_opts.clone())
                 .del(&delete_msg_keys)
-                .zrem(&msg_list_key, &exp_id_list)
-                .zrem(&exp_list_key, &exp_id_list)
+                .zrem(&msg_list_key, &msg_id_list)
+                .zrem(&exp_list_key, &msg_id_list)
                 .exec_async(&mut con)
                 .await?;
         } else {
@@ -509,7 +511,7 @@ impl DbClient for RedisClientImpl {
         let mut con = self.connection().await?;
         let msg_list_key = self.message_list_key(&uaid);
         let timestamp = if let Some(timestamp) = timestamp {
-            timestamp
+            timestamp.saturating_add(1)  // Make exclusive to avoid re-fetching ACK'd messages
         } else {
             let storage_timestamp_key = self.storage_timestamp_key(&uaid);
             con.get(&storage_timestamp_key).await.unwrap_or(0)
@@ -709,6 +711,48 @@ mod tests {
         client.increment_storage(&uaid, timestamp + 1).await?;
         let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
         assert_eq!(msgs.messages.len(), 0);
+        assert!(client.remove_user(&uaid).await.is_ok());
+        Ok(())
+    }
+
+    /// Test that [increment_storage] removes acked messages so a reconnecting
+    /// client doesn't get them delivered again.
+    ///
+    /// The message timestamp is pinned in the past (rather than `now_secs()`)
+    /// to keep this deterministic: increment_storage must find the message via
+    /// its msg_list_key score (the message timestamp), not the wall clock.
+    #[actix_rt::test]
+    async fn increment_storage_removes_acked() -> DbResult<()> {
+        init_test_logging();
+        let client = new_client()?;
+
+        let uaid = Uuid::parse_str(&gen_test_user()).unwrap();
+        let chid = Uuid::parse_str(TEST_CHID).unwrap();
+        let timestamp = now_secs() - 60;
+
+        // purge the user record if it exists.
+        let _ = client.remove_user(&uaid).await;
+
+        let test_notification = crate::db::Notification {
+            channel_id: chid,
+            version: "test".to_owned(),
+            ttl: 300,
+            timestamp,
+            data: Some("Encrypted".into()),
+            sortkey_timestamp: Some(timestamp),
+            ..Default::default()
+        };
+        let msg_id = test_notification.chidmessageid();
+        client.save_message(&uaid, test_notification).await?;
+
+        // Simulate the client ack'ing everything up to the message's timestamp
+        client.increment_storage(&uaid, timestamp + 1).await?;
+
+        let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
+        assert_eq!(msgs.messages.len(), 0);
+        // The message record itself should be gone too
+        assert_eq!(client.fetch_message(&uaid, &msg_id).await?, None);
+        // clean up after the test.
         assert!(client.remove_user(&uaid).await.is_ok());
         Ok(())
     }

--- a/autopush-common/src/db/redis/redis_client/mod.rs
+++ b/autopush-common/src/db/redis/redis_client/mod.rs
@@ -372,14 +372,24 @@ impl DbClient for RedisClientImpl {
             .clone()
             .with_expiration(SetExpiry::EXAT(expiry));
 
+        // Score the message list with the message's millisecond
+        // `sortkey_timestamp`, matching the ordering of Bigtable's
+        // `{uaid}#02:{sortkey_timestamp}:{chid}` message row keys. This keeps
+        // the ACK pointer ([increment_storage]) and fetch floor
+        // ([fetch_timestamp_messages]) operating on the same values for both
+        // backends. Topic and legacy messages carry no sortkey: like
+        // [Notification::chidmessageid], score them at the current time in ms.
+        let score = match storable.sortkey_timestamp {
+            Some(0) | None => ms_since_epoch(),
+            Some(sortkey) => sortkey,
+        };
+
         // Store notification record in autopush/msg/{uaid}/{chidmessageid}
         // And store {chidmessageid} in autopush/msgs/{uaid}
         debug!("🐰 Saving to {}", &msg_key);
         pipe.set_options(msg_key, serde_json::to_string(&storable)?, notif_opts)
-            // The function [fetch_timestamp_messages] takes a timestamp in input,
-            // here we use the timestamp of the record
             .zadd(&exp_list_key, msg_id, expiry)
-            .zadd(&msg_list_key, msg_id, storable.timestamp);
+            .zadd(&msg_list_key, msg_id, score);
 
         let _: () = pipe.exec_async(&mut con).await?;
         self.metrics
@@ -402,47 +412,25 @@ impl DbClient for RedisClientImpl {
         Ok(())
     }
 
-    /// Delete expired messages
+    /// Set the pointer of the last timestamp Message delivered to the user.
+    ///
+    /// Called when the Client has ACK'd all the timestamp Messages sent to it,
+    /// to move the timestamp Messages' "pointer".
+    ///
+    /// Like Bigtable's `current_timestamp`, ACK'd timestamp messages
+    /// deliberately persist in storage to be eventually cleaned up by their
+    /// TTL: delivery is managed by this pointer, as
+    /// [fetch_timestamp_messages] only returns messages scored after it.
+    /// Deleting by score range is not an option here: the pointer's resolution
+    /// is only as fine as the message scores (ms), so a range delete could
+    /// take out undelivered messages.
     async fn increment_storage(&self, uaid: &Uuid, timestamp: u64) -> DbResult<()> {
         let uaid = Uaid(uaid);
         debug!("🐰🔥 Incrementing storage to {}", timestamp);
-        let msg_list_key = self.message_list_key(&uaid);
-        let exp_list_key = self.message_exp_list_key(&uaid);
         let storage_timestamp_key = self.storage_timestamp_key(&uaid);
         let mut con = self.connection().await?;
-        // Search msg_list_key for messages with timestamp <= the given timestamp.
-        // msg_list_key is sorted by message timestamp (after fix to save_message).
-        trace!("🐇 SEARCH: increment: {:?} - {}", &msg_list_key, timestamp);
-        let msg_id_list: Vec<String> = con.zrangebyscore(&msg_list_key, 0, timestamp).await?;
-        if !msg_id_list.is_empty() {
-            // Remember, we store just the message_ids in the exp and msg lists, but need to convert back to
-            // the full message keys for deletion.
-            let delete_msg_keys: Vec<String> = msg_id_list
-                .clone()
-                .into_iter()
-                .map(|msg_id| self.message_key(&uaid, &msg_id))
-                .collect();
-
-            trace!(
-                "🐰🔥:rem: Deleting {} : [{:?}]",
-                msg_list_key, &delete_msg_keys
-            );
-            trace!("🐰🔥:rem: Deleting {} : [{:?}]", exp_list_key, &msg_id_list);
-            pipe()
-                .set_options::<_, _>(&storage_timestamp_key, timestamp, self.router_opts.clone())
-                .del(&delete_msg_keys)
-                .zrem(&msg_list_key, &msg_id_list)
-                .zrem(&exp_list_key, &msg_id_list)
-                .exec_async(&mut con)
-                .await?;
-        } else {
-            con.set_options::<_, _, ()>(
-                &storage_timestamp_key,
-                timestamp,
-                self.router_opts.clone(),
-            )
+        con.set_options::<_, _, ()>(&storage_timestamp_key, timestamp, self.router_opts.clone())
             .await?;
-        }
         Ok(())
     }
 
@@ -494,10 +482,13 @@ impl DbClient for RedisClientImpl {
         })
     }
 
-    /// Return [`limit`] messages pending for a [`uaid`] that have a record timestamp
-    /// after [`timestamp`] (secs).
+    /// Return [`limit`] messages pending for a [`uaid`] that have a record
+    /// `sortkey_timestamp` after [`timestamp`] (ms). `limit=0` for all messages.
     ///
-    /// If [`limit`] = 0, we fetch all messages after [`timestamp`].
+    /// If [`timestamp`] is None, the pointer written by [increment_storage]
+    /// is used as the floor. Either way the bound is exclusive, matching
+    /// Bigtable's `StartKeyOpen`: the pointer names the last message handed
+    /// to the Client, so an inclusive floor would re-deliver it.
     ///
     /// This can return expired messages, following bigtables behavior
     async fn fetch_timestamp_messages(
@@ -511,20 +502,23 @@ impl DbClient for RedisClientImpl {
         let mut con = self.connection().await?;
         let msg_list_key = self.message_list_key(&uaid);
         let timestamp = if let Some(timestamp) = timestamp {
-            timestamp.saturating_add(1)  // Make exclusive to avoid re-fetching ACK'd messages
+            timestamp
         } else {
             let storage_timestamp_key = self.storage_timestamp_key(&uaid);
             con.get(&storage_timestamp_key).await.unwrap_or(0)
         };
+        // Exclusive lower bound (the "(" prefix), like Bigtable's
+        // StartKeyOpen: only fetch messages strictly after the pointer.
         // ZRANGE Key (x) +inf LIMIT 0 limit
+        let min = format!("({}", timestamp);
         trace!(
             "🐇 SEARCH: zrangebyscore {:?} {} +inf withscores limit 0 {:?}",
-            &msg_list_key, timestamp, limit,
+            &msg_list_key, min, limit,
         );
         let results = con
             .zrangebyscore_limit_withscores::<&str, &str, &str, Vec<(String, u64)>>(
                 &msg_list_key,
-                &timestamp.to_string(),
+                &min,
                 "+inf",
                 0,
                 limit as isize,
@@ -632,6 +626,7 @@ mod tests {
     use crate::{logging::init_test_logging, util::ms_since_epoch};
     use rand::prelude::*;
     use std::env;
+    use std::time::Duration;
 
     use super::*;
     const TEST_CHID: &str = "DECAFBAD-0000-0000-0000-0123456789AB";
@@ -666,69 +661,22 @@ mod tests {
         assert!(result.unwrap());
     }
 
-    /// Test if [increment_storage] correctly wipe expired messages
-    #[actix_rt::test]
-    async fn wipe_expired() -> DbResult<()> {
-        init_test_logging();
-        let client = new_client()?;
-
-        let connected_at = ms_since_epoch();
-
-        let uaid = Uuid::parse_str(&gen_test_user()).unwrap();
-        let chid = Uuid::parse_str(TEST_CHID).unwrap();
-
-        let node_id = "test_node".to_owned();
-
-        // purge the user record if it exists.
-        let _ = client.remove_user(&uaid).await;
-
-        let test_user = User {
-            uaid,
-            router_type: "webpush".to_owned(),
-            connected_at,
-            router_data: None,
-            node_id: Some(node_id.clone()),
-            ..Default::default()
-        };
-
-        // purge the old user (if present)
-        // in case a prior test failed for whatever reason.
-        let _ = client.remove_user(&uaid).await;
-
-        // can we add the user?
-        let timestamp = now_secs();
-        client.add_user(&test_user).await?;
-        let test_notification = crate::db::Notification {
-            channel_id: chid,
-            version: "test".to_owned(),
-            ttl: 1,
-            timestamp,
-            data: Some("Encrypted".into()),
-            sortkey_timestamp: Some(timestamp),
-            ..Default::default()
-        };
-        client.save_message(&uaid, test_notification).await?;
-        client.increment_storage(&uaid, timestamp + 1).await?;
-        let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
-        assert_eq!(msgs.messages.len(), 0);
-        assert!(client.remove_user(&uaid).await.is_ok());
-        Ok(())
-    }
-
-    /// Test that [increment_storage] removes acked messages so a reconnecting
-    /// client doesn't get them delivered again.
+    /// Test that a reconnecting client is not delivered ACK'd messages again
+    /// (autopush-rs#1228), while newer, undelivered messages still are.
     ///
-    /// The message timestamp is pinned in the past (rather than `now_secs()`)
-    /// to keep this deterministic: increment_storage must find the message via
-    /// its msg_list_key score (the message timestamp), not the wall clock.
+    /// ACK'd timestamp messages persist until their TTL: [increment_storage]
+    /// only moves the pointer, and [fetch_timestamp_messages] fetches
+    /// strictly after it. Message sortkeys are pinned in the past (rather
+    /// than the current time) to keep this deterministic.
     #[actix_rt::test]
-    async fn increment_storage_removes_acked() -> DbResult<()> {
+    async fn increment_storage_blocks_redelivery() -> DbResult<()> {
         init_test_logging();
         let client = new_client()?;
 
         let uaid = Uuid::parse_str(&gen_test_user()).unwrap();
         let chid = Uuid::parse_str(TEST_CHID).unwrap();
-        let timestamp = now_secs() - 60;
+        // A minute ago, in ms: the resolution of the scores and pointer
+        let sortkey = ms_since_epoch() - 60_000;
 
         // purge the user record if it exists.
         let _ = client.remove_user(&uaid).await;
@@ -737,21 +685,36 @@ mod tests {
             channel_id: chid,
             version: "test".to_owned(),
             ttl: 300,
-            timestamp,
+            timestamp: sortkey / 1000,
             data: Some("Encrypted".into()),
-            sortkey_timestamp: Some(timestamp),
+            sortkey_timestamp: Some(sortkey),
             ..Default::default()
         };
         let msg_id = test_notification.chidmessageid();
-        client.save_message(&uaid, test_notification).await?;
+        client
+            .save_message(&uaid, test_notification.clone())
+            .await?;
 
-        // Simulate the client ack'ing everything up to the message's timestamp
-        client.increment_storage(&uaid, timestamp + 1).await?;
+        // Simulate the Client ACK'ing the message: increment_storage moves
+        // the pointer past it.
+        client.increment_storage(&uaid, sortkey).await?;
 
         let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
         assert_eq!(msgs.messages.len(), 0);
-        // The message record itself should be gone too
-        assert_eq!(client.fetch_message(&uaid, &msg_id).await?, None);
+        // The message record itself deliberately persists until its TTL
+        assert!(client.fetch_message(&uaid, &msg_id).await?.is_some());
+
+        // Newer messages that were never delivered must not be lost
+        let undelivered = crate::db::Notification {
+            version: "undelivered".to_owned(),
+            timestamp: (sortkey + 1_000) / 1000,
+            sortkey_timestamp: Some(sortkey + 1_000),
+            ..test_notification
+        };
+        client.save_message(&uaid, undelivered).await?;
+        let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
+        assert_eq!(msgs.messages.len(), 1);
+        assert_eq!(msgs.messages[0].version, "undelivered");
         // clean up after the test.
         assert!(client.remove_user(&uaid).await.is_ok());
         Ok(())
@@ -864,8 +827,10 @@ mod tests {
 
         let test_data = "An_encrypted_pile_of_crap".to_owned();
         let timestamp = now_secs();
-        let sort_key = now_secs();
-        let fetch_timestamp = timestamp;
+        // The message score (and the pointer [increment_storage] writes) is
+        // the millisecond `sortkey_timestamp`
+        let sort_key = ms_since_epoch();
+        let fetch_timestamp = sort_key;
         // Can we store a message?
         let test_notification = crate::db::Notification {
             channel_id: chid,
@@ -887,13 +852,13 @@ mod tests {
 
         // Grab all 1 of the messages that were submitted within the past 10 seconds.
         let fetched = client
-            .fetch_timestamp_messages(&uaid, Some(fetch_timestamp - 10), 999)
+            .fetch_timestamp_messages(&uaid, Some(fetch_timestamp - 10_000), 999)
             .await?;
         assert_ne!(fetched.messages.len(), 0);
 
         // Try grabbing a message for 10 seconds from now.
         let fetched = client
-            .fetch_timestamp_messages(&uaid, Some(fetch_timestamp + 10), 999)
+            .fetch_timestamp_messages(&uaid, Some(fetch_timestamp + 10_000), 999)
             .await?;
         assert_eq!(fetched.messages.len(), 0);
 
@@ -919,7 +884,7 @@ mod tests {
         client.add_channel(&uaid, &topic_chid).await?;
         let test_data = "An_encrypted_pile_of_crap_with_a_topic".to_owned();
         let timestamp = now_secs();
-        let sort_key = now_secs();
+        let sort_key = ms_since_epoch();
 
         // We store 2 messages, with a single topic
         let test_notification_0 = crate::db::Notification {
@@ -1005,6 +970,7 @@ mod tests {
         let uaid = Uuid::parse_str(&gen_test_user()).unwrap();
         let chid = Uuid::parse_str(TEST_CHID).unwrap();
         let now = now_secs();
+        let now_ms = ms_since_epoch();
 
         let test_notification = crate::db::Notification {
             channel_id: chid,
@@ -1012,7 +978,7 @@ mod tests {
             ttl: 2,
             timestamp: now,
             data: Some("SomeData".into()),
-            sortkey_timestamp: Some(now),
+            sortkey_timestamp: Some(now_ms),
             ..Default::default()
         };
         debug!("Writing test notif");
@@ -1024,8 +990,24 @@ mod tests {
             .fetch_message(&uaid, &test_notification.chidmessageid())
             .await?;
         assert!(!msg.unwrap().is_empty());
+
+        // ACK'd (incremented past) messages persist until their TTL: delivery
+        // is managed by the [increment_storage] pointer, so the record is
+        // still here...
+        client.increment_storage(&uaid, ms_since_epoch()).await?;
+        assert!(
+            client
+                .fetch_message(&uaid, &test_notification.chidmessageid())
+                .await?
+                .is_some()
+        );
+        // ...but it's no longer delivered
+        let msgs = client.fetch_timestamp_messages(&uaid, None, 999).await?;
+        assert_eq!(msgs.messages.len(), 0);
+
+        // Eventually Redis' per-record expiry purges it
         debug!("Purging...");
-        client.increment_storage(&uaid, now + 2).await?;
+        tokio::time::sleep(Duration::from_secs(3)).await;
         debug!("Checking {}...", &key);
         let cc = client
             .fetch_message(&uaid, &test_notification.chidmessageid())

--- a/tests/integration/test_integration_all_rust.py
+++ b/tests/integration/test_integration_all_rust.py
@@ -219,12 +219,6 @@ def xfail_on_redis(reason: str) -> pytest.MarkDecorator:
     return pytest.mark.xfail(RUNNING_ON_REDIS, reason=reason, strict=False)
 
 
-# `RedisClientImpl::fetch_timestamp_messages` scans `autopush/msgs/{uaid}` with an
-# inclusive lower bound, while Bigtable's equivalent range is exclusive. After an
-# ack, `increment_storage` records that same score as the new floor, so the
-# message the client just acknowledged is handed back on the next fetch.
-REDIS_ACK_REDELIVERY = "Redis: acked stored messages are redelivered (inclusive fetch bound)"
-
 # `RedisClientImpl::fetch_timestamp_messages` returns `timestamp: None` when every
 # key in the fetched window has already expired out of Redis, so the caller never
 # advances past that window and never reaches the live message behind it. Bigtable
@@ -1071,7 +1065,6 @@ async def test_topic_expired(registered_test_client: AsyncPushTestClient) -> Non
     assert result["data"] == base64url_encode(uuid_data)
 
 
-@xfail_on_redis(REDIS_ACK_REDELIVERY)
 @pytest.mark.parametrize("fixture_max_conn_logs", [4], indirect=True)
 async def test_multiple_delivery_with_single_ack(
     registered_test_client: AsyncPushTestClient,
@@ -1122,7 +1115,6 @@ async def test_multiple_delivery_with_single_ack(
     assert result is None
 
 
-@xfail_on_redis(REDIS_ACK_REDELIVERY)
 async def test_multiple_delivery_with_multiple_ack(
     registered_test_client: AsyncPushTestClient,
 ) -> None:


### PR DESCRIPTION
  Fixes https://github.com/mozilla-services/autopush-rs/issues/1228

  ACKed notifications were never removed from Redis storage, so clients
  received them again on reconnect:

  - `increment_storage` queried `exp_list_key` (scored by expiry time) with a
    message timestamp, so the range was always empty and nothing was deleted.
    It now queries `msg_list_key`, which is scored by message timestamp.
  - `save_message` scored `msg_list_key` with the wall clock instead of
    `storable.timestamp`.
  - `fetch_timestamp_messages` used an inclusive lower bound, re-fetching the
    message at the resume point; now exclusive (+1), matching Bigtable's
    `StartKeyOpen`.

  The `unacked_stored_highest` clearing mentioned in the issue was dropped as
  unnecessary (see issue discussion).

  Adds `increment_storage_removes_acked`, a deterministic regression test
  (the existing `test_expiry`/`wipe_expired` only fail on the old code when
  the wall clock ticks a second mid-test). Redis tests need a live
  `REDIS_HOST` — CI coverage is coming via #1229.